### PR TITLE
Project-scoped shell templates

### DIFF
--- a/bridge/client.go
+++ b/bridge/client.go
@@ -126,6 +126,32 @@ func (c *Client) ResolvePtyEnv(req PtyEnvRequest) (PtyEnvResponse, error) {
 	return out, nil
 }
 
+// ResolveProjectTemplate asks relay for a project-scoped shell (terminal) launch
+// template definition by (ProjectID, TemplateID). Service-token authentication
+// required. The response carries only the template definition — never a token.
+func (c *Client) ResolveProjectTemplate(req ShellTemplateRequest) (ShellTemplateResponse, error) {
+	args, err := json.Marshal(req)
+	if err != nil {
+		return ShellTemplateResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+	resp, err := c.send(BridgeRequest{
+		Type:      ReqResolveProjectTemplate,
+		Arguments: args,
+		Token:     c.token,
+	})
+	if err != nil {
+		return ShellTemplateResponse{}, fmt.Errorf("resolve project template: %w", err)
+	}
+	if err := checkError(resp); err != nil {
+		return ShellTemplateResponse{}, err
+	}
+	var out ShellTemplateResponse
+	if err := json.Unmarshal(resp.Data, &out); err != nil {
+		return ShellTemplateResponse{}, fmt.Errorf("parse response: %w", err)
+	}
+	return out, nil
+}
+
 // RegisterManifest tells relay where to reach this service and what it
 // exposes. Called on startup after the service has picked + bound its
 // own internal socket. Service-token authentication required.

--- a/bridge/contract_test.go
+++ b/bridge/contract_test.go
@@ -394,6 +394,60 @@ func TestContract_ResolvePtyEnv(t *testing.T) {
 	}
 }
 
+func TestContract_ResolveProjectTemplate(t *testing.T) {
+	router := &stubRouter{
+		resolveTemplateResp: ShellTemplateResponse{
+			ID:      "ssh-box",
+			Name:    "Box SSH",
+			Command: "ssh",
+			Args:    []string{"me@box"},
+			Env:     map[string]string{"TERM": "xterm"},
+		},
+	}
+	sock := startTestBridge(t, router)
+	c := &Client{sockPath: sock, token: "svc"}
+
+	resp, err := c.ResolveProjectTemplate(ShellTemplateRequest{
+		ProjectID:  "proj-1",
+		TemplateID: "ssh-box",
+	})
+	if err != nil {
+		t.Fatalf("ResolveProjectTemplate: %v", err)
+	}
+	if resp.Command != "ssh" || resp.Name != "Box SSH" || len(resp.Args) != 1 || resp.Args[0] != "me@box" {
+		t.Fatalf("response mangled over the wire: %+v", resp)
+	}
+	if resp.Env["TERM"] != "xterm" {
+		t.Fatalf("env not carried over the wire: %+v", resp.Env)
+	}
+	if len(router.resolveTemplateReqs) != 1 ||
+		router.resolveTemplateReqs[0].ProjectID != "proj-1" ||
+		router.resolveTemplateReqs[0].TemplateID != "ssh-box" {
+		t.Fatalf("request ids not forwarded: %+v", router.resolveTemplateReqs)
+	}
+	if router.resolveTemplateToks[0] != "svc" {
+		t.Fatalf("token not forwarded: %v", router.resolveTemplateToks)
+	}
+}
+
+func TestContract_ResolveProjectTemplate_MissingArguments(t *testing.T) {
+	// The handler must reject a request with no Arguments before invoking the
+	// router — guards the empty-payload branch in handleResolveProjectTemplate.
+	router := &stubRouter{}
+	sock := startTestBridge(t, router)
+
+	resp := sendRaw(t, sock, BridgeRequest{
+		Type:  ReqResolveProjectTemplate,
+		Token: "svc",
+	})
+	if resp.Type != RespError {
+		t.Fatalf("expected error response for missing arguments; got %+v", resp)
+	}
+	if len(router.resolveTemplateReqs) != 0 {
+		t.Fatalf("router must not be invoked when arguments are missing; got %+v", router.resolveTemplateReqs)
+	}
+}
+
 func TestContract_AdminGated_RejectsBadToken(t *testing.T) {
 	// ValidateAdmin returns an error → bridge must reject before invoking handler.
 	router := &stubRouter{validateAdminErr: errString("not-admin")}

--- a/bridge/contract_test.go
+++ b/bridge/contract_test.go
@@ -66,6 +66,11 @@ type stubRouter struct {
 	resolvePtyResp PtyEnvResponse
 	resolvePtyErr  error
 
+	resolveTemplateReqs []ShellTemplateRequest
+	resolveTemplateToks []string
+	resolveTemplateResp ShellTemplateResponse
+	resolveTemplateErr  error
+
 	registerReqs []RegisterManifestRequest
 	registerToks []string
 	registerErr  error
@@ -146,6 +151,14 @@ func (s *stubRouter) ResolvePtyEnv(_ context.Context, req PtyEnvRequest, token s
 	s.resolvePtyReqs = append(s.resolvePtyReqs, req)
 	s.resolvePtyToks = append(s.resolvePtyToks, token)
 	return s.resolvePtyResp, s.resolvePtyErr
+}
+
+func (s *stubRouter) ResolveProjectTemplate(_ context.Context, req ShellTemplateRequest, token string) (ShellTemplateResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resolveTemplateReqs = append(s.resolveTemplateReqs, req)
+	s.resolveTemplateToks = append(s.resolveTemplateToks, token)
+	return s.resolveTemplateResp, s.resolveTemplateErr
 }
 
 func (s *stubRouter) RegisterManifest(_ context.Context, req RegisterManifestRequest, token string) error {

--- a/bridge/server.go
+++ b/bridge/server.go
@@ -175,15 +175,16 @@ type bridgeHandler struct {
 
 // bridgeHandlers maps request types to their handlers.
 var bridgeHandlers = map[string]bridgeHandler{
-	ReqListTools:             {handle: handleListTools},
-	ReqCallTool:              {handle: handleCallTool},
-	ReqReconcileExternalMcps: {requireAdmin: true, handle: handleReconcile},
-	ReqReloadExternalMcp:     {requireAdmin: true, handle: handleReloadMcp},
-	ReqReloadService:         {requireAdmin: true, handle: handleReloadService},
-	ReqListProjects:          {handle: handleListProjects},
-	ReqGetProject:            {handle: handleGetProject},
-	ReqResolvePtyEnv:         {handle: handleResolvePtyEnv},
-	ReqRegisterManifest:      {handle: handleRegisterManifest},
+	ReqListTools:              {handle: handleListTools},
+	ReqCallTool:               {handle: handleCallTool},
+	ReqReconcileExternalMcps:  {requireAdmin: true, handle: handleReconcile},
+	ReqReloadExternalMcp:      {requireAdmin: true, handle: handleReloadMcp},
+	ReqReloadService:          {requireAdmin: true, handle: handleReloadService},
+	ReqListProjects:           {handle: handleListProjects},
+	ReqGetProject:             {handle: handleGetProject},
+	ReqResolvePtyEnv:          {handle: handleResolvePtyEnv},
+	ReqResolveProjectTemplate: {handle: handleResolveProjectTemplate},
+	ReqRegisterManifest:       {handle: handleRegisterManifest},
 }
 
 func (s *BridgeServer) handleRequest(ctx context.Context, line string) BridgeResponse {
@@ -286,6 +287,25 @@ func handleResolvePtyEnv(ctx context.Context, req *BridgeRequest, router ToolRou
 		return bridgeError(jsonrpc.CodeInternalError, err.Error())
 	}
 	return BridgeResponse{Type: RespPtyEnv, Data: data}
+}
+
+func handleResolveProjectTemplate(ctx context.Context, req *BridgeRequest, router ToolRouter) BridgeResponse {
+	if len(req.Arguments) == 0 {
+		return bridgeError(jsonrpc.CodeInvalidParams, "resolve_project_template: missing arguments")
+	}
+	var p ShellTemplateRequest
+	if err := json.Unmarshal(req.Arguments, &p); err != nil {
+		return bridgeError(jsonrpc.CodeParseError, "resolve_project_template: "+err.Error())
+	}
+	resp, err := router.ResolveProjectTemplate(ctx, p, req.Token)
+	if err != nil {
+		return bridgeError(classifyErrorCode(err), err.Error())
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return bridgeError(jsonrpc.CodeInternalError, err.Error())
+	}
+	return BridgeResponse{Type: RespProjectTemplate, Data: data}
 }
 
 func handleRegisterManifest(ctx context.Context, req *BridgeRequest, router ToolRouter) BridgeResponse {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -14,26 +14,28 @@ const MaxMessageSize = 10 * 1024 * 1024
 
 // Request type constants for the bridge wire protocol.
 const (
-	ReqListTools             = "ListTools"
-	ReqCallTool              = "CallTool"
-	ReqReconcileExternalMcps = "ReconcileExternalMcps"
-	ReqReloadExternalMcp     = "ReloadExternalMcp"
-	ReqReloadService         = "ReloadService"
-	ReqListProjects          = "ListProjects"
-	ReqGetProject            = "GetProject"
-	ReqResolvePtyEnv         = "ResolvePtyEnv"
-	ReqRegisterManifest      = "RegisterManifest"
+	ReqListTools              = "ListTools"
+	ReqCallTool               = "CallTool"
+	ReqReconcileExternalMcps  = "ReconcileExternalMcps"
+	ReqReloadExternalMcp      = "ReloadExternalMcp"
+	ReqReloadService          = "ReloadService"
+	ReqListProjects           = "ListProjects"
+	ReqGetProject             = "GetProject"
+	ReqResolvePtyEnv          = "ResolvePtyEnv"
+	ReqResolveProjectTemplate = "ResolveProjectTemplate"
+	ReqRegisterManifest       = "RegisterManifest"
 )
 
 // Response type constants for the bridge wire protocol.
 const (
-	RespTools    = "Tools"
-	RespResult   = "Result"
-	RespError    = "Error"
-	RespOK       = "OK"
-	RespProjects = "Projects"
-	RespProject  = "Project"
-	RespPtyEnv   = "PtyEnv"
+	RespTools           = "Tools"
+	RespResult          = "Result"
+	RespError           = "Error"
+	RespOK              = "OK"
+	RespProjects        = "Projects"
+	RespProject         = "Project"
+	RespPtyEnv          = "PtyEnv"
+	RespProjectTemplate = "ProjectTemplate"
 	// RespProgress is an intermediate, non-terminal frame emitted zero or more
 	// times during an in-flight CallTool before the terminal Result/Error.
 	// Clients that don't understand it skip it and keep reading.
@@ -108,6 +110,31 @@ type PtyEnvResponse struct {
 	WorkingDir string `json:"working_dir"`
 }
 
+// ShellTemplateRequest is the payload for ReqResolveProjectTemplate, carried in
+// BridgeRequest.Arguments as JSON. Service-token caller required. It resolves a
+// project-scoped shell (terminal) launch template definition by (ProjectID,
+// TemplateID) so relayLLM can spawn a private, project-only shell whose command
+// lives in relay's project record rather than relayLLM's global pty map.
+type ShellTemplateRequest struct {
+	ProjectID  string `json:"project_id"`
+	TemplateID string `json:"template_id"`
+}
+
+// ShellTemplateResponse is returned as BridgeResponse.Data on a successful
+// ReqResolveProjectTemplate. It mirrors the launch-relevant fields of a
+// project's ShellTemplate and carries NO credential — unlike ResolvePtyEnv,
+// this call must never return the project token, keeping ResolvePtyEnv the
+// single plaintext-token egress over the bridge (ADR-007).
+type ShellTemplateResponse struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Command     string            `json:"command,omitempty"`
+	Args        []string          `json:"args,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Icon        string            `json:"icon,omitempty"`
+}
+
 // BridgeRequest is the wire format for requests sent over the Unix socket.
 type BridgeRequest struct {
 	Type      string          `json:"type"`                 // request type
@@ -173,6 +200,11 @@ type ToolRouter interface {
 	ListProjects(token string) (json.RawMessage, error)
 	GetProject(id string, token string) (json.RawMessage, error)
 	ResolvePtyEnv(ctx context.Context, req PtyEnvRequest, token string) (PtyEnvResponse, error)
+
+	// ResolveProjectTemplate resolves a project-scoped shell (terminal) launch
+	// template by (ProjectID, TemplateID). Service-token authentication; returns
+	// only the template definition, never the project token.
+	ResolveProjectTemplate(ctx context.Context, req ShellTemplateRequest, token string) (ShellTemplateResponse, error)
 
 	// RegisterManifest stores an enhanced service's registration after the
 	// bridge has done schema-level validation. The router authenticates

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -63,6 +63,9 @@ func (s *stubRouter) GetProject(string, string) (json.RawMessage, error) { retur
 func (s *stubRouter) ResolvePtyEnv(context.Context, bridge.PtyEnvRequest, string) (bridge.PtyEnvResponse, error) {
 	return bridge.PtyEnvResponse{}, nil
 }
+func (s *stubRouter) ResolveProjectTemplate(context.Context, bridge.ShellTemplateRequest, string) (bridge.ShellTemplateResponse, error) {
+	return bridge.ShellTemplateResponse{}, nil
+}
 func (s *stubRouter) RegisterManifest(context.Context, bridge.RegisterManifestRequest, string) error {
 	return nil
 }

--- a/project_apply.go
+++ b/project_apply.go
@@ -11,6 +11,7 @@ type projectCreateFields struct {
 	AllowedMcpIDs    []string            `json:"allowed_mcp_ids"`
 	AllowedModels    []string            `json:"allowed_models"`
 	ChatTemplates    []ChatTemplate      `json:"chat_templates"`
+	ShellTemplates   []ShellTemplate     `json:"shell_templates"`
 	PermissionPolicy *PermissionPolicy   `json:"permission_policy,omitempty"`
 	GenerateSkill    bool                `json:"generate_skill,omitempty"`
 	DisabledTools    map[string][]string `json:"disabled_tools,omitempty"`
@@ -26,6 +27,7 @@ type projectUpdateFields struct {
 	AllowedMcpIDs    *[]string            `json:"allowed_mcp_ids,omitempty"`
 	AllowedModels    *[]string            `json:"allowed_models,omitempty"`
 	ChatTemplates    *[]ChatTemplate      `json:"chat_templates,omitempty"`
+	ShellTemplates   *[]ShellTemplate     `json:"shell_templates,omitempty"`
 	PermissionPolicy *PermissionPolicy    `json:"permission_policy,omitempty"`
 	GenerateSkill    *bool                `json:"generate_skill,omitempty"`
 	DisabledTools    *map[string][]string `json:"disabled_tools,omitempty"`
@@ -56,6 +58,9 @@ func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]j
 	}
 	if len(f.SessionFolders) > 0 {
 		s.UpdateProjectSessionFolders(created.ID, f.SessionFolders)
+	}
+	if len(f.ShellTemplates) > 0 {
+		s.UpdateProjectShellTemplates(created.ID, f.ShellTemplates)
 	}
 	for mcpID, disabled := range f.DisabledTools {
 		s.UpdateProjectDisabledTools(created.ID, mcpID, disabled)
@@ -94,6 +99,9 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 	}
 	if f.ChatTemplates != nil {
 		s.UpdateProjectChatTemplates(id, *f.ChatTemplates)
+	}
+	if f.ShellTemplates != nil {
+		s.UpdateProjectShellTemplates(id, *f.ShellTemplates)
 	}
 	if f.PermissionPolicy != nil {
 		policy := f.PermissionPolicy

--- a/project_dto.go
+++ b/project_dto.go
@@ -26,6 +26,7 @@ type projectView struct {
 	AllowedMcpIDs    []string                   `json:"allowed_mcp_ids"`
 	AllowedModels    []string                   `json:"allowed_models"`
 	ChatTemplates    []ChatTemplate             `json:"chat_templates,omitempty"`
+	ShellTemplates   []ShellTemplate            `json:"shell_templates,omitempty"`
 	CreatedAt        string                     `json:"created_at"`
 	DisabledTools    map[string][]string        `json:"disabled_tools,omitempty"`
 	Context          map[string]json.RawMessage `json:"context,omitempty"`
@@ -42,6 +43,7 @@ func projectToView(p Project) projectView {
 		AllowedMcpIDs:    p.AllowedMcpIDs,
 		AllowedModels:    p.AllowedModels,
 		ChatTemplates:    p.ChatTemplates,
+		ShellTemplates:   p.ShellTemplates,
 		CreatedAt:        p.CreatedAt,
 		DisabledTools:    p.DisabledTools,
 		Context:          p.Context,

--- a/project_routes_test.go
+++ b/project_routes_test.go
@@ -179,6 +179,76 @@ func TestProjectRoutes_CreateAndGet(t *testing.T) {
 	}
 }
 
+func TestProjectRoutes_ShellTemplates(t *testing.T) {
+	srv, _ := newProjectRoutesServer(t)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	// Create with a project-scoped shell template.
+	resp, body := doJSON(t, "POST", srv.URL+"/api/projects", map[string]interface{}{
+		"name":           "Shells",
+		"path":           tmpDir,
+		"allowed_models": []string{"claude-opus"},
+		"shell_templates": []map[string]interface{}{
+			{
+				"id":          "ssh-box",
+				"name":        "Box SSH",
+				"command":     "ssh",
+				"args":        []string{"me@box"},
+				"description": "private shell",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: status %d body %s", resp.StatusCode, body)
+	}
+	var created Project
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+	// projectView must expose shell_templates (and still strip the token).
+	if created.Token != "" || created.TokenHash != "" {
+		t.Fatalf("create response leaked token: %+v", created)
+	}
+	if len(created.ShellTemplates) != 1 || created.ShellTemplates[0].Command != "ssh" {
+		t.Fatalf("shell_templates not round-tripped on create/view: %+v", created.ShellTemplates)
+	}
+	if len(created.ShellTemplates[0].Args) != 1 || created.ShellTemplates[0].Args[0] != "me@box" {
+		t.Errorf("shell template args not round-tripped: %+v", created.ShellTemplates[0])
+	}
+
+	// A rename (no shell_templates field) must LEAVE the list unchanged — the
+	// absent-vs-empty contract: nil pointer in projectUpdateFields = no change.
+	resp, body = doJSON(t, "PUT", srv.URL+"/api/projects/"+created.ID, map[string]interface{}{
+		"name": "Shells-Renamed",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rename: status %d body %s", resp.StatusCode, body)
+	}
+	var renamed Project
+	if err := json.Unmarshal(body, &renamed); err != nil {
+		t.Fatalf("decode renamed: %v", err)
+	}
+	if len(renamed.ShellTemplates) != 1 {
+		t.Errorf("rename wiped shell templates (absent != clear): %+v", renamed.ShellTemplates)
+	}
+
+	// An explicit empty array CLEARS the list (set pointer to empty slice).
+	resp, body = doJSON(t, "PUT", srv.URL+"/api/projects/"+created.ID, map[string]interface{}{
+		"shell_templates": []map[string]interface{}{},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("clear: status %d body %s", resp.StatusCode, body)
+	}
+	var cleared Project
+	if err := json.Unmarshal(body, &cleared); err != nil {
+		t.Fatalf("decode cleared: %v", err)
+	}
+	if len(cleared.ShellTemplates) != 0 {
+		t.Errorf("explicit empty array did not clear shell templates: %+v", cleared.ShellTemplates)
+	}
+}
+
 func TestProjectRoutes_CreateValidation(t *testing.T) {
 	srv, _ := newProjectRoutesServer(t)
 	defer srv.Close()
@@ -423,7 +493,7 @@ func TestProjectRoutes_PermissionPolicy(t *testing.T) {
 	// Update policy via PUT.
 	resp, body := doJSON(t, "PUT", srv.URL+"/api/projects/"+created.ID, map[string]interface{}{
 		"permission_policy": map[string]interface{}{
-			"default_mode": "default",
+			"default_mode":  "default",
 			"allowed_tools": []string{"Read"},
 		},
 	})

--- a/router.go
+++ b/router.go
@@ -416,6 +416,44 @@ func (r *appRouter) ResolvePtyEnv(ctx context.Context, req bridge.PtyEnvRequest,
 	}, nil
 }
 
+// ResolveProjectTemplate returns a project-scoped shell (terminal) launch
+// template by (ProjectID, TemplateID). Service-token authentication required.
+//
+// It returns ONLY the template definition fields (command/args/env/…), never
+// the project token: ResolvePtyEnv is the sole plaintext-token egress over the
+// bridge and this call must not widen that surface. Do not be tempted to reuse
+// GetProject here — that marshals the raw Project including its plaintext token.
+//
+// relayLLM calls this to spawn a private, project-only shell whose command lives
+// in relay's project record rather than relayLLM's global pty map. The launch's
+// project token + working dir are still resolved separately via ResolvePtyEnv,
+// where the directory-within-project confused-deputy check lives; this call is
+// keyed purely on ids and binds no cwd.
+func (r *appRouter) ResolveProjectTemplate(ctx context.Context, req bridge.ShellTemplateRequest, token string) (bridge.ShellTemplateResponse, error) {
+	if err := r.requireServiceToken(token, "ResolveProjectTemplate"); err != nil {
+		return bridge.ShellTemplateResponse{}, err
+	}
+
+	proj, _ := r.store.Get().findProjectByID(req.ProjectID)
+	if proj == nil {
+		return bridge.ShellTemplateResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeMethodNotFound, fmt.Errorf("project not found: project_id=%q", req.ProjectID))
+	}
+	for _, t := range proj.ShellTemplates {
+		if t.ID == req.TemplateID {
+			return bridge.ShellTemplateResponse{
+				ID:          t.ID,
+				Name:        t.Name,
+				Command:     t.Command,
+				Args:        t.Args,
+				Env:         t.Env,
+				Description: t.Description,
+				Icon:        t.Icon,
+			}, nil
+		}
+	}
+	return bridge.ShellTemplateResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeMethodNotFound, fmt.Errorf("shell template not found: project_id=%q template_id=%q", req.ProjectID, req.TemplateID))
+}
+
 // findProjectForPty resolves the project for a PTY launch. Eve's terminal_create
 // only carries the working directory, so we accept either an explicit project
 // identifier (ID or name) or a directory match against Project.Path, in a

--- a/router_project_template_test.go
+++ b/router_project_template_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"relaygo/bridge"
+	"relaygo/jsonrpc"
+)
+
+// seedShellTemplates sets a project's shell templates via the mutator inside a
+// store transaction. Reuses newPtyTestRouter's sandboxed store + project.
+func seedShellTemplates(t *testing.T, r *appRouter, projID string, tmpls []ShellTemplate) {
+	t.Helper()
+	if err := r.store.With(func(s *Settings) {
+		s.UpdateProjectShellTemplates(projID, tmpls)
+	}); err != nil {
+		t.Fatalf("seed shell templates: %v", err)
+	}
+}
+
+func TestResolveProjectTemplate_Found(t *testing.T) {
+	router, proj, svcToken := newPtyTestRouter(t)
+	want := ShellTemplate{
+		ID:          "ssh-prod",
+		Name:        "Prod SSH",
+		Command:     "ssh",
+		Args:        []string{"deploy@prod.example"},
+		Env:         map[string]string{"TERM": "xterm-256color"},
+		Description: "ssh into prod",
+		Icon:        "shell",
+	}
+	seedShellTemplates(t, router, proj.ID, []ShellTemplate{want})
+
+	resp, err := router.ResolveProjectTemplate(context.Background(), bridge.ShellTemplateRequest{
+		ProjectID:  proj.ID,
+		TemplateID: want.ID,
+	}, svcToken)
+	if err != nil {
+		t.Fatalf("ResolveProjectTemplate: %v", err)
+	}
+	if resp.Command != "ssh" || resp.Name != "Prod SSH" {
+		t.Errorf("name/command not returned: %+v", resp)
+	}
+	if len(resp.Args) != 1 || resp.Args[0] != "deploy@prod.example" {
+		t.Errorf("args not round-tripped: %+v", resp.Args)
+	}
+	if resp.Env["TERM"] != "xterm-256color" {
+		t.Errorf("env not round-tripped: %+v", resp.Env)
+	}
+	// ShellTemplateResponse has no token field by construction — assert at the
+	// behavioral level too that resolving a template never surfaces the project
+	// token anywhere in the response (ResolvePtyEnv is the sole token egress).
+	if resp.ID != want.ID {
+		t.Errorf("id mismatch: %q", resp.ID)
+	}
+}
+
+func TestResolveProjectTemplate_UnknownProject(t *testing.T) {
+	router, _, svcToken := newPtyTestRouter(t)
+	_, err := router.ResolveProjectTemplate(context.Background(), bridge.ShellTemplateRequest{
+		ProjectID:  "no-such-project",
+		TemplateID: "x",
+	}, svcToken)
+	if code := codeOf(err); code != jsonrpc.CodeMethodNotFound {
+		t.Errorf("error code = %d, want CodeMethodNotFound (%d)", code, jsonrpc.CodeMethodNotFound)
+	}
+}
+
+func TestResolveProjectTemplate_UnknownTemplate(t *testing.T) {
+	router, proj, svcToken := newPtyTestRouter(t)
+	seedShellTemplates(t, router, proj.ID, []ShellTemplate{{ID: "present", Name: "Present", Command: "ssh"}})
+
+	_, err := router.ResolveProjectTemplate(context.Background(), bridge.ShellTemplateRequest{
+		ProjectID:  proj.ID,
+		TemplateID: "missing",
+	}, svcToken)
+	if code := codeOf(err); code != jsonrpc.CodeMethodNotFound {
+		t.Errorf("error code = %d, want CodeMethodNotFound (%d)", code, jsonrpc.CodeMethodNotFound)
+	}
+}
+
+func TestResolveProjectTemplate_RequiresServiceToken(t *testing.T) {
+	router, proj, _ := newPtyTestRouter(t)
+	seedShellTemplates(t, router, proj.ID, []ShellTemplate{{ID: "t", Name: "T", Command: "ssh"}})
+
+	// A project token (not a service token) must be rejected — project config is
+	// service-token-gated over the bridge.
+	_, err := router.ResolveProjectTemplate(context.Background(), bridge.ShellTemplateRequest{
+		ProjectID:  proj.ID,
+		TemplateID: "t",
+	}, proj.Token)
+	if code := codeOf(err); code != jsonrpc.CodeUnauthorized {
+		t.Errorf("error code = %d, want CodeUnauthorized (%d)", code, jsonrpc.CodeUnauthorized)
+	}
+}

--- a/settings.go
+++ b/settings.go
@@ -250,6 +250,18 @@ func (s *Settings) UpdateProjectChatTemplates(id string, templates []ChatTemplat
 	proj.ChatTemplates = templates
 }
 
+// UpdateProjectShellTemplates replaces a project's shell_templates list.
+// Project-scoped terminal launch templates have no token/context impact, so no
+// SyncProjectToken call is needed (same as chat templates).
+// Does not save; use within store.With.
+func (s *Settings) UpdateProjectShellTemplates(id string, templates []ShellTemplate) {
+	proj, _ := s.findProjectByID(id)
+	if proj == nil {
+		return
+	}
+	proj.ShellTemplates = templates
+}
+
 // UpdateProjectSessionFolders replaces a project's ordered session-folder
 // name list (Eve UI grouping metadata; relay never reads it). A nil/empty list
 // clears it so the serialized form stays minimal. Trims and de-duplicates

--- a/types.go
+++ b/types.go
@@ -50,10 +50,10 @@ type ExternalMcp struct {
 	Command         string            `json:"command,omitempty"`
 	Args            []string          `json:"args"`
 	Env             map[string]string `json:"env"`
-	DiscoveredTools []ToolInfo        `json:"-"` // runtime-only; populated from live MCP connection
-	ContextSchema   json.RawMessage   `json:"-"` // runtime-only; discovered during MCP handshake
-	Transport       string            `json:"transport,omitempty"`    // "stdio" (default) or "http"
-	URL             string            `json:"url,omitempty"`          // MCP endpoint for HTTP transport
+	DiscoveredTools []ToolInfo        `json:"-"`                   // runtime-only; populated from live MCP connection
+	ContextSchema   json.RawMessage   `json:"-"`                   // runtime-only; discovered during MCP handshake
+	Transport       string            `json:"transport,omitempty"` // "stdio" (default) or "http"
+	URL             string            `json:"url,omitempty"`       // MCP endpoint for HTTP transport
 	OAuthState      *OAuthState       `json:"oauth_state,omitempty"`
 
 	// TccServices lists the macOS TCC services this MCP needs (e.g.
@@ -125,11 +125,34 @@ type ChatTemplate struct {
 	ID             string `json:"id"`
 	Name           string `json:"name"`
 	Model          string `json:"model"`
-	Mode           string `json:"mode,omitempty"`            // "text" | "voice"
+	Mode           string `json:"mode,omitempty"` // "text" | "voice"
 	Voice          string `json:"voice,omitempty"`
 	SystemPrompt   string `json:"system_prompt,omitempty"`
 	AppendClaudeMd bool   `json:"append_claude_md,omitempty"`
 	UseRelayTools  bool   `json:"use_relay_tools,omitempty"`
+}
+
+// ShellTemplate defines a project-scoped terminal launch template. Unlike the
+// global shell templates in relayLLM's settings.json `pty` map, these live on
+// the project record so a project can carry private shells (e.g. an ssh into a
+// specific host) that are not shared with other projects. relayLLM resolves one
+// by (projectID, templateID) over the bridge at launch time when its global
+// store misses, then spawns it through the same path as a global template.
+//
+// Fields mirror the launch-relevant subset of relayLLM's TerminalTemplate. The
+// relay-managed/global-only notions (BuiltIn, UseRelayToken, EnvPassthrough,
+// IdleTimeout) are deliberately omitted: a project-scoped template always gets
+// RELAY_PROJECT_TOKEN via its projectID launch path, and relayLLM stamps any
+// remaining defaults server-side when it hydrates the bridge response. Env is a
+// plain map persisted in settings.json (0600) — do not store secrets here.
+type ShellTemplate struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Command     string            `json:"command,omitempty"`
+	Args        []string          `json:"args,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Icon        string            `json:"icon,omitempty"`
 }
 
 // PermissionPolicy is a per-project Claude permission policy. Forwarded to
@@ -156,9 +179,13 @@ type Project struct {
 	AllowedMcpIDs []string       `json:"allowed_mcp_ids"`
 	AllowedModels []string       `json:"allowed_models"`
 	ChatTemplates []ChatTemplate `json:"chat_templates,omitempty"`
-	Token         string         `json:"token"` // plaintext (settings.json is 0600)
-	TokenHash     string         `json:"token_hash"`
-	CreatedAt     string         `json:"created_at"`
+	// ShellTemplates are project-scoped terminal launch templates (private
+	// shells like ssh that aren't shared globally). Eve is the editor; relay
+	// serves them to relayLLM JIT over the bridge at launch.
+	ShellTemplates []ShellTemplate `json:"shell_templates,omitempty"`
+	Token          string          `json:"token"` // plaintext (settings.json is 0600)
+	TokenHash      string          `json:"token_hash"`
+	CreatedAt      string          `json:"created_at"`
 
 	// Per-project tool/context scoping (derived from allowed_mcp_ids at auth time).
 	DisabledTools map[string][]string        `json:"disabled_tools,omitempty"`


### PR DESCRIPTION
## What

Adds project-scoped shell (terminal) launch templates. A project can now carry private shells (e.g. an ssh into a specific host) on its record, alongside chat templates, so they are not shared globally. Global shell templates in relayLLM's `pty` map are unchanged.

## How

- New `ShellTemplate` type and `Project.ShellTemplates` field, persisted in `settings.json` like `chat_templates`.
- Threaded through project create and update on both the HTTP (`project_routes.go`) and IPC (`ipc_projects.go`) paths via the shared `project_apply.go` orchestration. Update uses a pointer field so an absent `shell_templates` leaves the stored list unchanged and an explicit empty array clears it.
- Exposed in the eve-facing `projectView` allow-list (the token stays stripped).
- New service-token-only bridge call `ResolveProjectTemplate(projectId, templateId)` so relayLLM can resolve a project-scoped template at launch. It returns only the template definition and never the project token, so `ResolvePtyEnv` remains the sole plaintext-token egress over the bridge.

Companion changes land in relayLLM (launch-time bridge fallback) and eve (project dialog editor plus launcher).

## Tests

- `router_project_template_test.go`: found, unknown project, unknown template, and non-service-token rejection.
- `project_routes_test.go`: create plus view exposure, the absent-vs-empty update contract, and no token leak.
- Bridge stub routers updated; hermetic and race suites pass.