### PR TITLE
Opt-in directory auth for token-less relay CLI callers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,12 @@ Auth flow: `AuthenticateProject(plaintext)` → find project by token hash → d
 permissions from `allowed_mcp_ids` + registered MCPs → return a `StoredToken`
 view with permissions + disabled_tools + context.
 
+`allow_cwd_auth` (default false, per project) opts into a token-less fallback:
+a caller with no token whose working directory is inside the project path
+authenticates as that project via `AuthenticateProjectByPath`, with identical
+scope. A present-but-invalid token never falls back. See
+[`docs/tokens.md`](docs/tokens.md#directory-auth-allow_cwd_auth).
+
 ## Service manifest (enhanced services)
 
 Every spawned service gets `RELAY_BRIDGE_SOCKET` + `RELAY_SERVICE_ID`. Services

--- a/bridge/client.go
+++ b/bridge/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"time"
 )
 
@@ -11,14 +12,25 @@ import (
 type Client struct {
 	sockPath string
 	token    string
+	cwd      string // sent only when token is empty; see BridgeRequest.Cwd
 }
 
 // NewClient creates a Client that will authenticate with the given token.
+//
+// With no token, the client falls back to directory auth: it sends its working
+// directory, which relay resolves against projects that opted in via
+// AllowCwdAuth. The cwd is captured once at construction (the process doesn't
+// chdir between calls) and is never sent alongside a token, so an authenticated
+// call can't be re-scoped by the directory it happens to run from.
 func NewClient(token string) *Client {
-	return &Client{
+	c := &Client{
 		sockPath: SocketPath(),
 		token:    token,
 	}
+	if token == "" {
+		c.cwd, _ = os.Getwd()
+	}
+	return c
 }
 
 // checkError returns an error if the bridge response is an error response.
@@ -34,6 +46,7 @@ func (c *Client) ListTools() (json.RawMessage, error) {
 	resp, err := c.send(BridgeRequest{
 		Type:  ReqListTools,
 		Token: c.token,
+		Cwd:   c.cwd,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tools: %w", err)
@@ -59,6 +72,7 @@ func (c *Client) CallToolStreaming(name string, args json.RawMessage, onProgress
 		Name:      name,
 		Arguments: args,
 		Token:     c.token,
+		Cwd:       c.cwd,
 	}, onProgress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool %q: %w", name, err)

--- a/bridge/contract_test.go
+++ b/bridge/contract_test.go
@@ -30,6 +30,7 @@ type stubRouter struct {
 	mu sync.Mutex
 
 	listToolsTokens   []string
+	listToolsCwds     []string // caller-asserted cwd, as seen through the request context
 	listToolsResponse json.RawMessage
 	listToolsErr      error
 
@@ -76,10 +77,11 @@ type stubRouter struct {
 	registerErr  error
 }
 
-func (s *stubRouter) ListTools(_ context.Context, token string) (json.RawMessage, error) {
+func (s *stubRouter) ListTools(ctx context.Context, token string) (json.RawMessage, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.listToolsTokens = append(s.listToolsTokens, token)
+	s.listToolsCwds = append(s.listToolsCwds, CallerCwdFromContext(ctx))
 	return s.listToolsResponse, s.listToolsErr
 }
 
@@ -231,6 +233,51 @@ func TestContract_ListTools(t *testing.T) {
 	}
 	if len(router.listToolsTokens) != 1 || router.listToolsTokens[0] != "proj-token" {
 		t.Fatalf("token not forwarded; got %v", router.listToolsTokens)
+	}
+}
+
+// A tokenless client asserts its working directory so relay can fall back to
+// directory auth; the server hands it to the router through the request context.
+func TestContract_TokenlessSendsCwd(t *testing.T) {
+	router := &stubRouter{listToolsResponse: json.RawMessage(`[]`)}
+	sock := startTestBridge(t, router)
+	c := &Client{sockPath: sock, cwd: "/Users/you/projects/acme/sub"}
+
+	if _, err := c.ListTools(); err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if got := router.listToolsCwds[0]; got != "/Users/you/projects/acme/sub" {
+		t.Fatalf("cwd not delivered to router; got %q", got)
+	}
+	if got := router.listToolsTokens[0]; got != "" {
+		t.Fatalf("expected an empty token, got %q", got)
+	}
+}
+
+// With a token, no cwd reaches the router even if the wire carries one — the
+// directory must never be able to re-scope an authenticated call.
+func TestContract_TokenSuppressesCwd(t *testing.T) {
+	router := &stubRouter{listToolsResponse: json.RawMessage(`[]`)}
+	sock := startTestBridge(t, router)
+
+	// NewClient wouldn't populate cwd alongside a token; set both by hand so
+	// this asserts the SERVER-side rule, not just the client's restraint.
+	c := &Client{sockPath: sock, token: "proj-token", cwd: "/Users/you/projects/acme"}
+	if _, err := c.ListTools(); err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if got := router.listToolsCwds[0]; got != "" {
+		t.Fatalf("cwd leaked into an authenticated call: %q", got)
+	}
+}
+
+// NewClient captures a cwd only when it has no token to present.
+func TestNewClient_CwdOnlyWhenTokenless(t *testing.T) {
+	if c := NewClient(""); c.cwd == "" {
+		t.Error("tokenless client should capture its working directory")
+	}
+	if c := NewClient("some-token"); c.cwd != "" {
+		t.Errorf("tokened client should not capture a working directory, got %q", c.cwd)
 	}
 }
 

--- a/bridge/server.go
+++ b/bridge/server.go
@@ -205,6 +205,13 @@ func (s *BridgeServer) handleRequest(ctx context.Context, line string) BridgeRes
 		}
 	}
 
+	// Carry the caller-asserted cwd so the router can fall back to directory
+	// auth when no token was supplied. Ignored by every handler that doesn't
+	// authenticate a project.
+	if req.Token == "" {
+		ctx = WithCallerCwd(ctx, req.Cwd)
+	}
+
 	return h.handle(ctx, &req, s.router)
 }
 

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -142,6 +142,15 @@ type BridgeRequest struct {
 	Arguments json.RawMessage `json:"arguments,omitempty"`  // tool arguments for CallTool
 	Token     string          `json:"token,omitempty"`      // auth token
 	ProjectID string          `json:"project_id,omitempty"` // for GetProject
+
+	// Cwd is the caller's working directory, sent ONLY when no token is set. It
+	// selects a project that has opted into directory auth (Project.AllowCwdAuth);
+	// relay ignores it whenever a token is present, so it can never widen the
+	// scope of an authenticated call. Advisory, not attested: the client asserts
+	// its own cwd. That is deliberate — anything able to lie here can already
+	// read every token out of the 0600 settings.json, so requiring kernel
+	// attestation would buy nothing.
+	Cwd string `json:"cwd,omitempty"`
 }
 
 // BridgeResponse is the wire format for responses sent over the Unix socket.
@@ -187,6 +196,26 @@ func WithProgress(ctx context.Context, fn ProgressFunc) context.Context {
 func ProgressFromContext(ctx context.Context) ProgressFunc {
 	fn, _ := ctx.Value(progressCtxKey{}).(ProgressFunc)
 	return fn
+}
+
+type callerCwdCtxKey struct{}
+
+// WithCallerCwd returns ctx carrying the working directory a tokenless caller
+// asserted (BridgeRequest.Cwd). Carried in the context rather than added to
+// every ToolRouter method so the router interface — which cross-repo services
+// implement — stays unchanged. An empty dir returns ctx unchanged.
+func WithCallerCwd(ctx context.Context, dir string) context.Context {
+	if dir == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, callerCwdCtxKey{}, dir)
+}
+
+// CallerCwdFromContext returns the caller-asserted working directory set by
+// WithCallerCwd, or "".
+func CallerCwdFromContext(ctx context.Context) string {
+	dir, _ := ctx.Value(callerCwdCtxKey{}).(string)
+	return dir
 }
 
 // ToolRouter handles bridge requests. Implemented by the main app.

--- a/cmd/devui/main.go
+++ b/cmd/devui/main.go
@@ -102,7 +102,7 @@ const fixtureRunningIDs = `["relay-llm","relaytts-daemon","stt-daemon"]`
 
 const fixtureProjects = `[
   {"id":"proj-acme","name":"Acme Website","path":"/Users/you/projects/acme","allowed_mcp_ids":["*"],"allowed_models":["*"],"chat_templates":[{"id":"tpl-1","name":"Default","model":"claude-sonnet","system_prompt":"You are a helpful assistant.","append_claude_md":true,"use_relay_tools":true}],"permission_policy":{"default_mode":"acceptEdits","allowed_tools":["Read","Grep"],"denied_tools":["Bash(rm *)"]},"generate_skill":true,"token":"relay_proj_8f2a1c9d4e6b0a7f3c5d","disabled_tools":{}},
-  {"id":"proj-internal","name":"Internal Tools","path":"/Users/you/projects/internal","allowed_mcp_ids":["fsmcp"],"allowed_models":["claude-opus","claude-sonnet"],"chat_templates":[],"permission_policy":{"default_mode":""},"generate_skill":false,"token":"relay_proj_1a2b3c4d5e6f7a8b9c0d","disabled_tools":{"fsmcp":["write_file"]}}
+  {"id":"proj-internal","name":"Internal Tools","path":"/Users/you/projects/internal","allowed_mcp_ids":["fsmcp"],"allowed_models":["claude-opus","claude-sonnet"],"chat_templates":[],"permission_policy":{"default_mode":""},"generate_skill":false,"allow_cwd_auth":true,"token":"relay_proj_1a2b3c4d5e6f7a8b9c0d","disabled_tools":{"fsmcp":["write_file"]}}
 ]`
 
 const fixtureMcpToolCache = `{

--- a/cwd_auth_test.go
+++ b/cwd_auth_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"relaygo/bridge"
+	"relaygo/jsonrpc"
+)
+
+// Directory auth (Project.AllowCwdAuth): a tokenless bridge caller is resolved
+// to a project by its working directory, but only for projects that opted in.
+// Every failure mode must land on "no access" — the danger in this feature is a
+// mismatch that silently widens scope, so the tests below lean on that.
+
+// cwdProject builds a Settings with one opted-in project rooted at path.
+func cwdProject(t *testing.T, path string, allowCwd bool) *Settings {
+	t.Helper()
+	s := makeSettings(nil, nil, nil)
+	s.Projects[0].Path = path
+	s.Projects[0].AllowCwdAuth = allowCwd
+	return s
+}
+
+func TestAuthenticateProjectByPath_OptedIn(t *testing.T) {
+	dir := t.TempDir()
+	s := cwdProject(t, dir, true)
+
+	for _, cwd := range []string{dir, filepath.Join(dir, "sub", "deeper")} {
+		stored := s.AuthenticateProjectByPath(cwd)
+		if stored == nil {
+			t.Fatalf("cwd %q: expected a StoredToken", cwd)
+		}
+		if stored.ProjectID != "test-project" {
+			t.Errorf("cwd %q: project id = %q, want test-project", cwd, stored.ProjectID)
+		}
+	}
+}
+
+func TestAuthenticateProjectByPath_RequiresOptIn(t *testing.T) {
+	dir := t.TempDir()
+	s := cwdProject(t, dir, false)
+
+	if stored := s.AuthenticateProjectByPath(dir); stored != nil {
+		t.Fatalf("expected nil for a project that did not opt in, got %+v", stored)
+	}
+}
+
+func TestAuthenticateProjectByPath_NoMatch(t *testing.T) {
+	s := cwdProject(t, t.TempDir(), true)
+
+	cases := map[string]string{
+		"empty cwd":       "",
+		"unrelated dir":   t.TempDir(),
+		"parent of proj":  filepath.Dir(s.Projects[0].Path),
+		"sibling prefix":  s.Projects[0].Path + "-other",
+		"escaping suffix": filepath.Join(s.Projects[0].Path, "..", "elsewhere"),
+	}
+	for name, cwd := range cases {
+		if stored := s.AuthenticateProjectByPath(cwd); stored != nil {
+			t.Errorf("%s (%q): expected nil, got project %q", name, cwd, stored.ProjectID)
+		}
+	}
+}
+
+// A project nested inside another wins for its own subtree; the outer project
+// still owns everything above it.
+func TestAuthenticateProjectByPath_NestedLongestMatch(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "packages", "inner")
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	s := cwdProject(t, outer, true)
+	s.Projects = append(s.Projects, Project{
+		ID:            "inner-project",
+		Name:          "inner",
+		Path:          inner,
+		AllowedMcpIDs: []string{"*"},
+		AllowCwdAuth:  true,
+	})
+
+	if got := s.AuthenticateProjectByPath(inner); got == nil || got.ProjectID != "inner-project" {
+		t.Errorf("inner dir resolved to %v, want inner-project", got)
+	}
+	if got := s.AuthenticateProjectByPath(filepath.Join(outer, "docs")); got == nil || got.ProjectID != "test-project" {
+		t.Errorf("outer dir resolved to %v, want test-project", got)
+	}
+}
+
+// A nested project that did NOT opt in must not shadow an opted-in parent:
+// the longest match is only computed among participants, so the parent's grant
+// still applies inside the nested path.
+func TestAuthenticateProjectByPath_NestedOptOutDoesNotShadow(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "vendored")
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	s := cwdProject(t, outer, true)
+	s.Projects = append(s.Projects, Project{
+		ID:            "inner-project",
+		Name:          "inner",
+		Path:          inner,
+		AllowedMcpIDs: []string{"*"},
+		AllowCwdAuth:  false,
+	})
+
+	got := s.AuthenticateProjectByPath(inner)
+	if got == nil || got.ProjectID != "test-project" {
+		t.Fatalf("resolved to %v, want the opted-in parent test-project", got)
+	}
+}
+
+// Directory auth must grant exactly what the token grants — same permissions,
+// same disabled tools, same context. Only the identification differs.
+func TestAuthenticateProjectByPath_ScopeMatchesTokenAuth(t *testing.T) {
+	dir := t.TempDir()
+	s := makeSettings(
+		map[string]Permission{"fsmcp": PermOn, "macmcp": PermOff},
+		map[string][]string{"fsmcp": {"write_file"}},
+		map[string]json.RawMessage{"fsmcp": json.RawMessage(`{"allowed_dirs":["/x"]}`)},
+	)
+	s.Projects[0].Path = dir
+	s.Projects[0].AllowCwdAuth = true
+
+	byToken := s.AuthenticateProjectByHash(hashToken(testToken))
+	byPath := s.AuthenticateProjectByPath(filepath.Join(dir, "sub"))
+	if byToken == nil || byPath == nil {
+		t.Fatal("both auth paths must resolve")
+	}
+
+	wantJSON, _ := json.Marshal(byToken)
+	gotJSON, _ := json.Marshal(byPath)
+	if string(wantJSON) != string(gotJSON) {
+		t.Errorf("scope differs between auth paths:\n token: %s\n  path: %s", wantJSON, gotJSON)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Router integration
+// ---------------------------------------------------------------------------
+
+func TestResolveAuth_CwdFallback(t *testing.T) {
+	dir := t.TempDir()
+	r := newTestRouter(t, cwdProject(t, dir, true), NewExternalMcpManager(nil))
+
+	ctx := bridge.WithCallerCwd(context.Background(), filepath.Join(dir, "nested"))
+	stored, settings, err := r.resolveAuth(ctx, "")
+	if err != nil {
+		t.Fatalf("expected cwd auth to succeed, got %v", err)
+	}
+	if stored.ProjectID != "test-project" {
+		t.Errorf("project id = %q, want test-project", stored.ProjectID)
+	}
+	if settings == nil {
+		t.Fatal("expected non-nil Settings")
+	}
+}
+
+func TestResolveAuth_CwdFallbackDeniedWithoutOptIn(t *testing.T) {
+	dir := t.TempDir()
+	r := newTestRouter(t, cwdProject(t, dir, false), NewExternalMcpManager(nil))
+
+	ctx := bridge.WithCallerCwd(context.Background(), dir)
+	_, _, err := r.resolveAuth(ctx, "")
+	if err == nil {
+		t.Fatal("expected denial for a project without allow_cwd_auth")
+	}
+	var coded *jsonrpc.CodedError
+	if !errors.As(err, &coded) || coded.RPCCode != jsonrpc.CodeUnauthorized {
+		t.Errorf("expected CodeUnauthorized, got %v", err)
+	}
+}
+
+// A wrong token must fail even from a directory that would have authenticated:
+// the fallback covers the absence of a credential, never a bad one.
+func TestResolveAuth_BadTokenNotRescuedByCwd(t *testing.T) {
+	dir := t.TempDir()
+	r := newTestRouter(t, cwdProject(t, dir, true), NewExternalMcpManager(nil))
+
+	ctx := bridge.WithCallerCwd(context.Background(), dir)
+	if _, _, err := r.resolveAuth(ctx, "not-the-right-token"); err == nil {
+		t.Fatal("expected a bad token to fail regardless of cwd")
+	}
+}
+
+// Service-token operations must be unreachable through directory auth, which
+// only ever yields a project-scoped token.
+func TestResolveCwdAuth_CannotSatisfyServiceOps(t *testing.T) {
+	dir := t.TempDir()
+	r := newTestRouter(t, cwdProject(t, dir, true), NewExternalMcpManager(nil))
+
+	ctx := bridge.WithCallerCwd(context.Background(), dir)
+	if _, err := r.ResolvePtyEnv(ctx, bridge.PtyEnvRequest{ProjectID: "test-project"}, ""); err == nil {
+		t.Fatal("expected ResolvePtyEnv to reject a tokenless caller")
+	}
+	if _, err := r.ListProjects(""); err == nil {
+		t.Fatal("expected ListProjects to reject a tokenless caller")
+	}
+}
+
+// ListTools over the full router: the tool surface a tokenless caller sees from
+// inside the project must equal what the project's token sees.
+func TestListTools_CwdAuthMatchesTokenSurface(t *testing.T) {
+	dir := t.TempDir()
+	mock := newMockConn("fsmcp", simpleTools("read_file", "write_file"), nil)
+	r := setupRouter(t,
+		map[string]Permission{"fsmcp": PermOn},
+		map[string][]string{"fsmcp": {"write_file"}},
+		nil,
+		map[string]*mockMcpConn{"fsmcp": mock},
+	)
+	if err := r.store.With(func(s *Settings) {
+		s.Projects[0].Path = dir
+		s.Projects[0].AllowCwdAuth = true
+	}); err != nil {
+		t.Fatalf("settings mutation: %v", err)
+	}
+
+	byToken, err := r.ListTools(context.Background(), testToken)
+	if err != nil {
+		t.Fatalf("token ListTools: %v", err)
+	}
+	byCwd, err := r.ListTools(bridge.WithCallerCwd(context.Background(), dir), "")
+	if err != nil {
+		t.Fatalf("cwd ListTools: %v", err)
+	}
+	if string(byToken) != string(byCwd) {
+		t.Errorf("tool surface differs:\n token: %s\n   cwd: %s", byToken, byCwd)
+	}
+	// The disabled tool must be absent from both — a sanity check that the
+	// comparison above isn't comparing two empty lists.
+	tools := unmarshalTools(t, byCwd)
+	if len(tools) != 1 || tools[0].Name != "read_file" {
+		t.Errorf("expected only read_file, got %+v", tools)
+	}
+}

--- a/cwd_auth_test.go
+++ b/cwd_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"relaygo/bridge"
@@ -241,4 +242,68 @@ func TestListTools_CwdAuthMatchesTokenSurface(t *testing.T) {
 	if len(tools) != 1 || tools[0].Name != "read_file" {
 		t.Errorf("expected only read_file, got %+v", tools)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// dirWithinProject: filesystem identity
+// ---------------------------------------------------------------------------
+
+// A stored project path that differs only in case from the real directory must
+// still match on a case-insensitive volume — this is the common shape of a
+// hand-typed path ("/users/Jonathan/Eve/TBO" vs "/Users/jonathan/Eve/TBO").
+// Skipped on case-sensitive volumes, where the two really are different dirs.
+func TestDirWithinProject_CaseInsensitiveVolume(t *testing.T) {
+	// A named element, not t.TempDir()'s numeric leaf — digits have no case.
+	dir := filepath.Join(t.TempDir(), "ProjectDir")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	variant := caseVariant(dir)
+	if variant == "" {
+		t.Skip("case-sensitive volume: no case variant resolves to the same directory")
+	}
+
+	if !dirWithinProject(dir, variant) {
+		t.Errorf("dir %q not matched against case-variant project path %q", dir, variant)
+	}
+	if !dirWithinProject(filepath.Join(dir, "sub"), variant) {
+		t.Errorf("subdirectory of %q not matched against %q", dir, variant)
+	}
+}
+
+// The identity walk must not turn unrelated directories into matches.
+func TestDirWithinProject_IdentityRejectsOutsiders(t *testing.T) {
+	proj := t.TempDir()
+	other := t.TempDir()
+
+	if dirWithinProject(other, proj) {
+		t.Errorf("unrelated dir %q matched project %q", other, proj)
+	}
+	if dirWithinProject(filepath.Dir(proj), proj) {
+		t.Errorf("parent of %q matched the project itself", proj)
+	}
+	// A path that doesn't exist yet still resolves textually.
+	if !dirWithinProject(filepath.Join(proj, "not", "created", "yet"), proj) {
+		t.Errorf("non-existent nested path should still match textually")
+	}
+}
+
+// caseVariant returns a case-flipped form of dir's last element that stats to
+// the same directory, or "" when the volume is case-sensitive.
+func caseVariant(dir string) string {
+	base := filepath.Base(dir)
+	flipped := strings.ToUpper(base)
+	if flipped == base {
+		flipped = strings.ToLower(base)
+	}
+	if flipped == base {
+		return ""
+	}
+	candidate := filepath.Join(filepath.Dir(dir), flipped)
+	a, err1 := os.Stat(dir)
+	b, err2 := os.Stat(candidate)
+	if err1 != nil || err2 != nil || !os.SameFile(a, b) {
+		return ""
+	}
+	return candidate
 }

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -25,3 +25,37 @@ Notes:
 - Legacy env names `RELAY_TOKEN` / `RELAY_MCP_TOKEN` are accepted as transition
   fallbacks for one release, to be removed once relay + relayLLM have both shipped
   the rename.
+
+## Directory auth (`allow_cwd_auth`)
+
+A project may opt into token-less bridge auth: with `allow_cwd_auth: true`, a
+caller that presents **no** token but whose working directory is inside the
+project's path is authenticated as that project. Default is off, per project.
+
+- **Scope is unchanged.** The caller gets exactly the project's token scope —
+  same derived permissions, same `disabled_tools`, same `_meta` context, same
+  `project_id`. Directory auth changes how a caller is *identified*, never what
+  the project may reach.
+- **Only the absence of a token triggers it.** A token that is present but
+  invalid is still a hard failure; the fallback never rescues a bad credential.
+  Relay ignores an inbound `cwd` whenever a token is set, so a directory can't
+  re-scope an authenticated call.
+- **Service ops stay out of reach.** Directory auth yields a project-scoped
+  token, and `requireServiceToken` resolves against a bare context, so
+  `ResolvePtyEnv` / `RegisterManifest` / project reads can never be satisfied
+  this way.
+- **Nested projects** resolve to the most specific opted-in project containing
+  the directory. A nested project that has *not* opted in does not shadow an
+  opted-in parent.
+- **The cwd is asserted, not attested** — the client sends its own
+  `os.Getwd()`. That is deliberate: `settings.json` is 0600 and already holds
+  every project token in plaintext, so anything that could lie about its cwd can
+  already read the token it would be forging. This is not a boundary against
+  another user; it is a convenience for the local user.
+- **What it costs.** The deliberate hand-off. With a token, a process holds a
+  project's tools because something gave it the credential; with this flag, any
+  process running as the user gets them by standing in the directory. Grants are
+  logged (`cwd auth granted`) because that log is the only audit trail left.
+
+Enable per project in Settings → Projects → **Directory Auth**, or via
+`allow_cwd_auth` on the create/update project APIs (HTTP and IPC).

--- a/exec_cmd.go
+++ b/exec_cmd.go
@@ -29,23 +29,23 @@ func runMcpExec(args []string) {
 		// Transition: accept the legacy env name from an un-migrated spawner.
 		*token = os.Getenv(bridge.EnvProjectTokenLegacy)
 	}
-	if *token == "" {
-		fmt.Fprintln(os.Stderr, "error: RELAY_PROJECT_TOKEN not set (and --token not provided)")
-		fmt.Fprintln(os.Stderr, "  export RELAY_PROJECT_TOKEN=<project-token>  # find it in Settings UI → Projects")
-		fmt.Fprintln(os.Stderr, "Usage: relay mcp call [--list [--schema] | --tool <name> [--args '<json>']]")
-		os.Exit(1)
-	}
+	// No token is no longer fatal: the bridge falls back to directory auth,
+	// which succeeds when the cwd is inside a project that enabled it. Relay
+	// decides — the CLI can't know which projects opted in, so it asks and
+	// reports whatever the bridge says (tokenlessHint expands the denial).
 	if !*list && *tool == "" {
 		fmt.Fprintln(os.Stderr, "error: must specify --list or --tool")
 		os.Exit(1)
 	}
 
 	client := bridge.NewClient(*token)
+	tokenless := *token == ""
 
 	if *list {
 		raw, err := client.ListTools()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			tokenlessHint(tokenless)
 			os.Exit(1)
 		}
 
@@ -98,6 +98,7 @@ func runMcpExec(args []string) {
 	raw, err := client.CallTool(*tool, argsJSON)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		tokenlessHint(tokenless)
 		os.Exit(1)
 	}
 
@@ -116,6 +117,18 @@ func runMcpExec(args []string) {
 	if result.IsError {
 		os.Exit(1)
 	}
+}
+
+// tokenlessHint prints the two ways to get authenticated, but only after a
+// failure on a run that supplied no token at all — a bad-token failure is a
+// different problem and shouldn't be answered with directory-auth advice.
+func tokenlessHint(tokenless bool) {
+	if !tokenless {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "\nNo token was supplied. Either:")
+	fmt.Fprintln(os.Stderr, "  export RELAY_PROJECT_TOKEN=<project-token>   # Settings UI → Projects → Bearer Token")
+	fmt.Fprintln(os.Stderr, "  or enable Settings UI → Projects → Directory Auth for the project containing this directory")
 }
 
 // resolveToolArgs determines the tool-arguments JSON from the mutually-exclusive

--- a/ipc_projects_test.go
+++ b/ipc_projects_test.go
@@ -423,3 +423,52 @@ func TestProjectLifecycle_CreateWithSkill_Delete_CleansUpSkillFile(t *testing.T)
 func readFileExists(path string) ([]byte, error) {
 	return os.ReadFile(path)
 }
+
+// The allow_cwd_auth flag must survive create and be togglable both ways over
+// the shared apply path. Off is the security-relevant direction: a patch that
+// silently dropped `false` would leave directory auth impossible to revoke from
+// the UI.
+func TestIPCProject_AllowCwdAuthRoundTrips(t *testing.T) {
+	ipc, store, ui, _ := newProjectsIPC(t)
+	raw := mustRaw(t, map[string]interface{}{
+		"name":            "Alpha",
+		"path":            t.TempDir(),
+		"allowed_mcp_ids": []string{"fsmcp"},
+		"allow_cwd_auth":  true,
+	})
+
+	ipcCreateProject(ipc, raw)
+	args, ok := findEvent(ui, "onProjectAdded")
+	if !ok {
+		t.Fatalf("expected onProjectAdded; got events=%+v", ui.events)
+	}
+	var added Project
+	_ = json.Unmarshal(args[0].(json.RawMessage), &added)
+	if persisted, _ := store.Get().findProjectByID(added.ID); !persisted.AllowCwdAuth {
+		t.Fatalf("allow_cwd_auth not persisted on create")
+	}
+
+	off := false
+	ipcUpdateProject(ipc, mustRaw(t, ipcUpdateProjectMsg{
+		ID:                  added.ID,
+		projectUpdateFields: projectUpdateFields{AllowCwdAuth: &off},
+	}))
+	if persisted, _ := store.Get().findProjectByID(added.ID); persisted.AllowCwdAuth {
+		t.Errorf("allow_cwd_auth still set after patching it off")
+	}
+
+	// An unrelated patch leaves the flag alone (pointer semantics).
+	on := true
+	ipcUpdateProject(ipc, mustRaw(t, ipcUpdateProjectMsg{
+		ID:                  added.ID,
+		projectUpdateFields: projectUpdateFields{AllowCwdAuth: &on},
+	}))
+	newName := "Bravo"
+	ipcUpdateProject(ipc, mustRaw(t, ipcUpdateProjectMsg{
+		ID:                  added.ID,
+		projectUpdateFields: projectUpdateFields{Name: &newName},
+	}))
+	if persisted, _ := store.Get().findProjectByID(added.ID); !persisted.AllowCwdAuth {
+		t.Errorf("allow_cwd_auth cleared by an unrelated patch")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -112,6 +112,9 @@ func runMcpOrServer(args []string) {
 		// Transition: accept the legacy env name from an un-migrated spawner.
 		*token = os.Getenv(bridge.EnvProjectTokenLegacy)
 	}
+	// An empty token is not fatal: the bridge client falls back to directory
+	// auth, which relay honors only for projects that opted in (AllowCwdAuth).
+	// Failing here instead would deny that path before relay can decide.
 	if err := mcp.RunMCPServer(*token); err != nil {
 		exitError("mcp server error: %v", err)
 	}

--- a/project_apply.go
+++ b/project_apply.go
@@ -14,6 +14,7 @@ type projectCreateFields struct {
 	ShellTemplates   []ShellTemplate     `json:"shell_templates"`
 	PermissionPolicy *PermissionPolicy   `json:"permission_policy,omitempty"`
 	GenerateSkill    bool                `json:"generate_skill,omitempty"`
+	AllowCwdAuth     bool                `json:"allow_cwd_auth,omitempty"`
 	DisabledTools    map[string][]string `json:"disabled_tools,omitempty"`
 	SessionFolders   []string            `json:"session_folders,omitempty"`
 }
@@ -30,6 +31,7 @@ type projectUpdateFields struct {
 	ShellTemplates   *[]ShellTemplate     `json:"shell_templates,omitempty"`
 	PermissionPolicy *PermissionPolicy    `json:"permission_policy,omitempty"`
 	GenerateSkill    *bool                `json:"generate_skill,omitempty"`
+	AllowCwdAuth     *bool                `json:"allow_cwd_auth,omitempty"`
 	DisabledTools    *map[string][]string `json:"disabled_tools,omitempty"`
 	SessionFolders   *[]string            `json:"session_folders,omitempty"`
 }
@@ -55,6 +57,9 @@ func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]j
 	}
 	if f.GenerateSkill {
 		s.SetProjectGenerateSkill(created.ID, true)
+	}
+	if f.AllowCwdAuth {
+		s.SetProjectAllowCwdAuth(created.ID, true)
 	}
 	if len(f.SessionFolders) > 0 {
 		s.UpdateProjectSessionFolders(created.ID, f.SessionFolders)
@@ -113,6 +118,9 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 	}
 	if f.GenerateSkill != nil {
 		s.SetProjectGenerateSkill(id, *f.GenerateSkill)
+	}
+	if f.AllowCwdAuth != nil {
+		s.SetProjectAllowCwdAuth(id, *f.AllowCwdAuth)
 	}
 	if f.SessionFolders != nil {
 		s.UpdateProjectSessionFolders(id, *f.SessionFolders)

--- a/project_dto.go
+++ b/project_dto.go
@@ -32,6 +32,7 @@ type projectView struct {
 	Context          map[string]json.RawMessage `json:"context,omitempty"`
 	PermissionPolicy *PermissionPolicy          `json:"permission_policy,omitempty"`
 	GenerateSkill    bool                       `json:"generate_skill,omitempty"`
+	AllowCwdAuth     bool                       `json:"allow_cwd_auth,omitempty"`
 	SessionFolders   []string                   `json:"session_folders,omitempty"`
 }
 
@@ -49,6 +50,7 @@ func projectToView(p Project) projectView {
 		Context:          p.Context,
 		PermissionPolicy: p.PermissionPolicy,
 		GenerateSkill:    p.GenerateSkill,
+		AllowCwdAuth:     p.AllowCwdAuth,
 		SessionFolders:   p.SessionFolders,
 	}
 }

--- a/router.go
+++ b/router.go
@@ -128,9 +128,13 @@ var (
 // resolveAuth loads settings and authenticates the given token.
 // Checks in-memory service tokens first (full access, no per-MCP permissions),
 // then project tokens (inline permissions), then external tokens in settings.
-func (r *appRouter) resolveAuth(token string) (*StoredToken, *Settings, error) {
+//
+// With no token, falls back to directory auth (resolveCwdAuth) — opt-in per
+// project. A token that is present but wrong is always a hard failure: the
+// fallback must never rescue a bad credential, only the absence of one.
+func (r *appRouter) resolveAuth(ctx context.Context, token string) (*StoredToken, *Settings, error) {
 	if token == "" {
-		return nil, nil, jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, ErrNoToken)
+		return r.resolveCwdAuth(ctx)
 	}
 
 	s := r.store.Get()
@@ -149,8 +153,30 @@ func (r *appRouter) resolveAuth(token string) (*StoredToken, *Settings, error) {
 	return nil, nil, jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, ErrInvalidToken)
 }
 
-func (r *appRouter) ListTools(_ context.Context, token string) (json.RawMessage, error) {
-	stored, settings, err := r.resolveAuth(token)
+// resolveCwdAuth authenticates a tokenless caller by the working directory it
+// asserted over the bridge. Only projects with AllowCwdAuth participate, and the
+// resulting scope is exactly the project's token scope — this identifies a
+// caller, it does not widen one. Grants are logged: directory auth has no
+// deliberate hand-off to point at afterwards, so the log is the audit trail.
+func (r *appRouter) resolveCwdAuth(ctx context.Context) (*StoredToken, *Settings, error) {
+	cwd := bridge.CallerCwdFromContext(ctx)
+	if cwd == "" {
+		return nil, nil, jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, ErrNoToken)
+	}
+
+	s := r.store.Get()
+	stored := s.AuthenticateProjectByPath(cwd)
+	if stored == nil {
+		slog.Debug("cwd auth rejected", "cwd", cwd)
+		return nil, nil, jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized,
+			fmt.Errorf("no token supplied and working directory %q is not inside a project with directory auth enabled", cwd))
+	}
+	slog.Info("cwd auth granted", "cwd", cwd, "project", stored.ProjectID, "name", stored.Name)
+	return stored, s, nil
+}
+
+func (r *appRouter) ListTools(ctx context.Context, token string) (json.RawMessage, error) {
+	stored, settings, err := r.resolveAuth(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -182,8 +208,8 @@ func (r *appRouter) ListTools(_ context.Context, token string) (json.RawMessage,
 // fallback in toolCategory is intentionally NOT used for keys — it produces
 // noise like "Generate" from generate_image; uncategorized tools route by
 // their MCP instead). Buckets are returned in a deterministic order.
-func (r *appRouter) ListSkillBuckets(_ context.Context, token string) ([]SkillBucket, error) {
-	stored, settings, err := r.resolveAuth(token)
+func (r *appRouter) ListSkillBuckets(ctx context.Context, token string) ([]SkillBucket, error) {
+	stored, settings, err := r.resolveAuth(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +260,7 @@ func (r *appRouter) ListSkillBuckets(_ context.Context, token string) ([]SkillBu
 }
 
 func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMessage, token string) (json.RawMessage, error) {
-	stored, _, err := r.resolveAuth(token)
+	stored, _, err := r.resolveAuth(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -344,8 +370,12 @@ func (r *appRouter) ReloadService(id string) error {
 // requireServiceToken authenticates a token and rejects anything that isn't
 // a service token. Returns CodeUnauthorized on failure with op named in the
 // error for caller-friendly logging.
+//
+// Deliberately resolves against a bare context: service-token operations
+// (ResolvePtyEnv, RegisterManifest, project reads) must never be reachable by
+// directory auth, which only ever yields a project-scoped token.
 func (r *appRouter) requireServiceToken(token, op string) error {
-	stored, _, err := r.resolveAuth(token)
+	stored, _, err := r.resolveAuth(context.Background(), token)
 	if err != nil {
 		return err
 	}

--- a/router.go
+++ b/router.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -513,6 +514,16 @@ func dirWithinProject(dir, projectPath string) bool {
 	if projectPath == "" {
 		return false
 	}
+	// Prefer filesystem identity when both paths exist: os.SameFile compares
+	// device + inode, so it sees through case-insensitive volumes (a stored
+	// "/users/Jonathan/x" really is the on-disk "/Users/jonathan/x") and any
+	// aliasing that string comparison would reject. Only ever adds matches for
+	// directories that genuinely ARE the project directory. Falls through to the
+	// textual check when either side can't be stat'd — paths that don't exist
+	// yet are legitimate here.
+	if within, decided := dirWithinProjectByIdentity(dir, projectPath); decided {
+		return within
+	}
 	// Resolve symlinks on both sides so e.g. macOS /var vs /private/var (or
 	// /tmp) don't false-reject a directory that really is inside the project.
 	dir = realpathBestEffort(dir)
@@ -529,6 +540,37 @@ func dirWithinProject(dir, projectPath string) bool {
 		return false
 	}
 	return true
+}
+
+// dirWithinProjectByIdentity walks from dir up to the filesystem root looking
+// for the directory that IS projectPath, comparing by device+inode. Returns
+// (result, true) once it can answer from the filesystem, or (false, false) when
+// the project path can't be stat'd and the caller should fall back to comparing
+// text. The walk is bounded by path depth and each step is a single stat.
+func dirWithinProjectByIdentity(dir, projectPath string) (within, decided bool) {
+	projInfo, err := os.Stat(projectPath)
+	if err != nil || !projInfo.IsDir() {
+		return false, false
+	}
+	cur := filepath.Clean(dir)
+	for {
+		info, err := os.Stat(cur)
+		if err == nil {
+			if os.SameFile(info, projInfo) {
+				return true, true
+			}
+		} else if !os.IsNotExist(err) {
+			// Permission trouble or worse: don't claim an answer we can't back up.
+			return false, false
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root without meeting the project directory. The project
+			// exists and dir's whole chain was walkable, so this is a real "no".
+			return false, true
+		}
+		cur = parent
+	}
 }
 
 // realpathBestEffort cleans p and resolves symlinks. The path may not exist yet

--- a/router_test.go
+++ b/router_test.go
@@ -113,7 +113,7 @@ func TestResolveAuth_ValidToken(t *testing.T) {
 	s := makeSettings(nil, nil, nil)
 	r := newTestRouter(t, s, NewExternalMcpManager(nil))
 
-	stored, settings, err := r.resolveAuth(testToken)
+	stored, settings, err := r.resolveAuth(context.Background(), testToken)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -132,7 +132,7 @@ func TestResolveAuth_InvalidToken(t *testing.T) {
 	s := makeSettings(nil, nil, nil)
 	r := newTestRouter(t, s, NewExternalMcpManager(nil))
 
-	_, _, err := r.resolveAuth("completely-wrong-token")
+	_, _, err := r.resolveAuth(context.Background(), "completely-wrong-token")
 	if err == nil {
 		t.Fatal("expected error for invalid token")
 	}
@@ -142,7 +142,7 @@ func TestResolveAuth_EmptyToken(t *testing.T) {
 	s := makeSettings(nil, nil, nil)
 	r := newTestRouter(t, s, NewExternalMcpManager(nil))
 
-	_, _, err := r.resolveAuth("")
+	_, _, err := r.resolveAuth(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected error for empty token")
 	}
@@ -513,7 +513,7 @@ func TestResolveAuth_ServiceToken(t *testing.T) {
 	svcHash := hashToken(svcToken)
 	r.serviceTokens.Register(svcHash)
 
-	stored, _, err := r.resolveAuth(svcToken)
+	stored, _, err := r.resolveAuth(context.Background(), svcToken)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -523,7 +523,7 @@ func TestResolveAuth_ServiceToken(t *testing.T) {
 
 	// Cleanup.
 	r.serviceTokens.Remove(svcHash)
-	_, _, err = r.resolveAuth(svcToken)
+	_, _, err = r.resolveAuth(context.Background(), svcToken)
 	if err == nil {
 		t.Fatal("expected error after service token removal")
 	}

--- a/settings.go
+++ b/settings.go
@@ -374,6 +374,16 @@ func (s *Settings) SetProjectGenerateSkill(id string, gen bool) {
 	proj.GenerateSkill = gen
 }
 
+// SetProjectAllowCwdAuth toggles the AllowCwdAuth flag. Does not save; use
+// within store.With.
+func (s *Settings) SetProjectAllowCwdAuth(id string, allow bool) {
+	proj, _ := s.findProjectByID(id)
+	if proj == nil {
+		return
+	}
+	proj.AllowCwdAuth = allow
+}
+
 // SyncProjectToken updates the project's disabled tools and context to match
 // its current allowedMcpIDs and path. Permissions are derived at auth time
 // from AllowedMcpIDs, so they're not stored.
@@ -508,6 +518,52 @@ func (s *Settings) AuthenticateProjectByHash(hash string) *StoredToken {
 	if proj == nil {
 		return nil
 	}
+	return s.storedTokenForProject(proj, hash)
+}
+
+// AuthenticateProjectByPath resolves a caller's working directory to a project
+// that has opted into directory auth (AllowCwdAuth) and returns the same
+// synthetic StoredToken the token path would produce. Returns nil when dir is
+// empty, matches nothing, or matches only projects that have NOT opted in —
+// every failure mode is "no access", never "all access".
+//
+// The scope granted is identical to the project's token: opting in changes how
+// a caller is *identified*, never what the project is allowed to reach.
+//
+// Nested projects resolve to the most specific match (longest project path
+// containing dir), so a project nested inside another wins for its own subtree.
+func (s *Settings) AuthenticateProjectByPath(dir string) *StoredToken {
+	if dir == "" {
+		return nil
+	}
+	var best *Project
+	bestLen := -1
+	for i := range s.Projects {
+		p := &s.Projects[i]
+		// Check the opt-in first: a project that hasn't enabled directory auth
+		// must not even participate in the longest-match race, or it could
+		// shadow an opted-in parent and turn a valid grant into a denial.
+		if !p.AllowCwdAuth || p.Path == "" {
+			continue
+		}
+		if !dirWithinProject(dir, p.Path) {
+			continue
+		}
+		if n := len(realpathBestEffort(p.Path)); n > bestLen {
+			best, bestLen = p, n
+		}
+	}
+	if best == nil {
+		return nil
+	}
+	return s.storedTokenForProject(best, best.TokenHash)
+}
+
+// storedTokenForProject builds the synthetic StoredToken view of a project:
+// permissions derived from AllowedMcpIDs, plus the project's disabled tools and
+// per-MCP context. Shared by every authentication path so a project's scope
+// cannot drift depending on how the caller was identified.
+func (s *Settings) storedTokenForProject(proj *Project, hash string) *StoredToken {
 	// Wildcard: nil permissions map — checkToolAccess treats missing keys as allowed.
 	if isWildcard(proj.AllowedMcpIDs) {
 		return &StoredToken{

--- a/settings_bundle_test.go
+++ b/settings_bundle_test.go
@@ -267,6 +267,64 @@ func TestProjectFormTemplatesReadOnly(t *testing.T) {
 	}
 }
 
+// TestProjectFormDirectoryAuth covers the allow_cwd_auth toggle end to end in
+// the form: it reflects the stored value, defaults to off for a new project,
+// and — the part that matters — always rides along in the save payload, since
+// update_project reads an absent field as "leave unchanged" and the toggle
+// would then be impossible to turn back OFF from the UI.
+func TestProjectFormDirectoryAuth(t *testing.T) {
+	vm := newAppVM(t)
+
+	script := `(function(){
+		window.state.projects = [
+			{id:'p1', name:'On', path:'/tmp/on', allowed_mcp_ids:['*'], allowed_models:['*'],
+			 disabled_tools:{}, allow_cwd_auth:true},
+			{id:'p2', name:'Off', path:'/tmp/off', allowed_mcp_ids:['*'], allowed_models:['*'],
+			 disabled_tools:{}}
+		];
+		window.editProject('p1');
+		var onHtml = window.renderProjectForm();
+		var onPayload = window.harvestProjectForm();
+
+		window.editProject('p2');
+		var offHtml = window.renderProjectForm();
+		var offPayload = window.harvestProjectForm();
+
+		// Toggling off must survive into the payload as an explicit false.
+		window.editProject('p1');
+		window.state.projectForm.allow_cwd_auth = false;
+		var toggledOff = window.harvestProjectForm();
+
+		window.newProject();
+		var blank = window.state.projectForm;
+
+		var listHtml = (window.state.editingProjectId = null, window.renderProjects());
+
+		return JSON.stringify({
+			section: onHtml.indexOf('Directory Auth') >= 0,
+			warns: onHtml.indexOf('Any process running as you') >= 0,
+			onChecked: onHtml.indexOf('allow_cwd_auth = this.checked') >= 0 && /checked[^>]*onchange="state\.projectForm\.allow_cwd_auth/.test(onHtml),
+			offUnchecked: !/checked[^>]*onchange="state\.projectForm\.allow_cwd_auth/.test(offHtml),
+			onPayload: onPayload.allow_cwd_auth === true,
+			offPayload: offPayload.allow_cwd_auth === false,
+			toggledOff: toggledOff.allow_cwd_auth === false,
+			newDefaultsOff: blank.allow_cwd_auth === false,
+			listBadge: listHtml.indexOf('Dir auth') >= 0
+		});
+	})()`
+
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"section":true`, `"warns":true`, `"onChecked":true`, `"offUnchecked":true`,
+		`"onPayload":true`, `"offPayload":true`, `"toggledOff":true`,
+		`"newDefaultsOff":true`, `"listBadge":true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("directory auth toggle: missing %s in %s", want, got)
+		}
+	}
+}
+
 // TestStatusPollPreservesConfigRegion is the regression test for the focus-clobber
 // bug: a steady-state status poll (same set of services) must update ONLY a
 // service's #svc-status-<id> region and leave #svc-config-<id> — where an open

--- a/types.go
+++ b/types.go
@@ -207,6 +207,19 @@ type Project struct {
 	// path is controlled per-template, not per-project, so it runs independent
 	// of this flag.
 	GenerateSkill bool `json:"generate_skill,omitempty"`
+
+	// AllowCwdAuth opts this project into token-less bridge auth for callers
+	// whose working directory is inside Path (see AuthenticateProjectByPath).
+	// Default false: without it, a tokenless caller gets nothing.
+	//
+	// This trades an explicit grant for convenience. With a token, a process
+	// holds this project's tool surface because something deliberately handed
+	// it the credential; with this flag, ANY process running as the user gets
+	// that surface by standing in the directory — a stray agent in a
+	// subdirectory included. It is not a privilege escalation across users
+	// (settings.json is 0600 and already holds every token in plaintext), but
+	// it does erase the deliberate hand-off, so it stays opt-in per project.
+	AllowCwdAuth bool `json:"allow_cwd_auth,omitempty"`
 }
 
 // Validate checks that required fields are present.

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -1240,6 +1240,7 @@ window.__RELAY_INIT__ = {
         html += "<span>Models: <strong>" + esc(modelsCount) + "</strong></span>";
         html += "<span>Policy: <strong>" + esc(policy) + "</strong></span>";
         html += "<span>Skill: <strong>" + esc(skillState) + "</strong></span>";
+        if (p.allow_cwd_auth) html += "<span>Dir auth: <strong>on</strong></span>";
         html += "</div>";
         if (regen) {
           const cls = regen.ok ? "proj-ok" : "proj-error";
@@ -1261,6 +1262,8 @@ window.__RELAY_INIT__ = {
       chat_templates: [],
       permission_policy: { default_mode: "", allowed_tools: [], denied_tools: [] },
       generate_skill: false,
+      allow_cwd_auth: false,
+      // token-less auth by working directory
       disabled_tools: {}
       // mcpID -> [toolName, ...]
     };
@@ -1280,6 +1283,7 @@ window.__RELAY_INIT__ = {
         denied_tools: (policy.denied_tools || []).slice()
       },
       generate_skill: !!p.generate_skill,
+      allow_cwd_auth: !!p.allow_cwd_auth,
       disabled_tools: JSON.parse(JSON.stringify(p.disabled_tools || {})),
       token: p.token || ""
     };
@@ -1508,6 +1512,14 @@ window.__RELAY_INIT__ = {
       }
     }
     html += "</div>";
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Directory Auth</div>';
+    html += `<p class="proj-section-help">Lets <code>relay mcp</code> / <code>relay mcp call</code> run with no token when the working directory is inside this project's path, granting exactly this project's tools. <strong>Any process running as you</strong> gets them by being in the directory \u2014 including agents you started for something else. Leave off unless you want that trade.</p>`;
+    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+    html += "<span>Allow token-less access from this project's directory</span>";
+    html += '<label class="switch"><input type="checkbox" ' + (f.allow_cwd_auth ? "checked" : "") + ' onchange="state.projectForm.allow_cwd_auth = this.checked" /><span class="slider"></span></label>';
+    html += "</div>";
+    html += "</div>";
     if (!isNew) {
       const visible = !!state.projectTokenVisible[f.id];
       const fresh = state.projectFreshToken[f.id];
@@ -1598,6 +1610,7 @@ window.__RELAY_INIT__ = {
       allowed_models: allowedModels,
       permission_policy: policy,
       generate_skill: f.generate_skill,
+      allow_cwd_auth: f.allow_cwd_auth,
       disabled_tools: f.disabled_tools
     };
   }

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -774,6 +774,9 @@ function renderProjects() {
             html += '<span>Models: <strong>' + esc(modelsCount) + '</strong></span>';
             html += '<span>Policy: <strong>' + esc(policy) + '</strong></span>';
             html += '<span>Skill: <strong>' + esc(skillState) + '</strong></span>';
+            // Only shown when on: directory auth is the exception, and a row of
+            // "off" labels would bury the projects where it's actually enabled.
+            if (p.allow_cwd_auth) html += '<span>Dir auth: <strong>on</strong></span>';
             html += '</div>';
             if (regen) {
                 const cls = regen.ok ? 'proj-ok' : 'proj-error';
@@ -796,6 +799,7 @@ function blankProjectForm() {
         chat_templates: [],
         permission_policy: { default_mode: '', allowed_tools: [], denied_tools: [] },
         generate_skill: false,
+        allow_cwd_auth: false,                   // token-less auth by working directory
         disabled_tools: {},                      // mcpID -> [toolName, ...]
     };
 }
@@ -816,6 +820,7 @@ function projectFormFromExisting(p) {
             denied_tools: (policy.denied_tools || []).slice(),
         },
         generate_skill: !!p.generate_skill,
+        allow_cwd_auth: !!p.allow_cwd_auth,
         disabled_tools: JSON.parse(JSON.stringify(p.disabled_tools || {})),
         token: p.token || '',
     };
@@ -1094,6 +1099,16 @@ function renderProjectForm() {
     }
     html += '</div>';
 
+    // ---- Directory auth ----
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Directory Auth</div>';
+    html += '<p class="proj-section-help">Lets <code>relay mcp</code> / <code>relay mcp call</code> run with no token when the working directory is inside this project\'s path, granting exactly this project\'s tools. <strong>Any process running as you</strong> gets them by being in the directory — including agents you started for something else. Leave off unless you want that trade.</p>';
+    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+    html += '<span>Allow token-less access from this project\'s directory</span>';
+    html += '<label class="switch"><input type="checkbox" ' + (f.allow_cwd_auth ? 'checked' : '') + ' onchange="state.projectForm.allow_cwd_auth = this.checked" /><span class="slider"></span></label>';
+    html += '</div>';
+    html += '</div>';
+
     // ---- Token (edit only) ----
     if (!isNew) {
         const visible = !!state.projectTokenVisible[f.id];
@@ -1196,6 +1211,7 @@ function harvestProjectForm() {
         allowed_models: allowedModels,
         permission_policy: policy,
         generate_skill: f.generate_skill,
+        allow_cwd_auth: f.allow_cwd_auth,
         disabled_tools: f.disabled_tools,
     };
 }


### PR DESCRIPTION
Adds `allow_cwd_auth` (per project, default false). With it on, a bridge caller that presents no token but whose working directory is inside the project path authenticates as that project.

## Behavior

- **Scope is identical to the project token** — same derived permissions, disabled tools, `_meta` context, `project_id`. This changes how a caller is identified, not what the project may reach.
- **Only the absence of a token triggers it.** A present-but-invalid token is still a hard failure, and relay ignores an inbound cwd whenever a token is set, so a directory can never re-scope an authenticated call.
- **Service ops stay unreachable.** Directory auth only ever yields a project-scoped token, and `requireServiceToken` resolves against a bare context.
- **Nested projects** resolve to the most specific opted-in project; a nested project that did not opt in does not shadow an opted-in parent.
- Grants log as `cwd auth granted` — with no deliberate hand-off to point at, that log is the audit trail.

## The trade

The cwd is asserted by the client, not attested by the kernel. That is deliberate: `settings.json` is 0600 and already holds every project token in plaintext, so a process able to lie about its cwd can already read the token it would be forging. What the flag actually gives up is the explicit hand-off: any process running as the user gets the project's tools by standing in the directory, including agents started for something else. Hence per project, default off, and a UI warning that says so.

## Also here

`dirWithinProject` now matches on filesystem identity (device+inode walk) before falling back to text. Real settings carry hand-typed paths like `/users/Jonathan/Eve/TBO` where the directory on disk is `/Users/jonathan/Eve/TBO`; on a case-insensitive volume `filepath.Rel` reads that as an escape and denies a caller standing in its own project. It only ever adds matches for directories that genuinely are the project directory, so `ResolvePtyEnv`'s confused-deputy check is not loosened.

## Verified live

Built and installed, flag enabled on the TBO project:

- `relay mcp call --list` and `--tool mail_list_accounts` from `~/Eve/TBO` with no token: 46 tools, accounts returned.
- Same from a nested subdirectory: works.
- From `/tmp`: denied.
- From `~/Eve/Assistant` (a project that did not opt in): denied.

## Tests

`go test ./...` and `go test -race ./...` green. New coverage: opt-in enforcement, nested longest-match and non-shadowing, scope equality with token auth, bad-token-not-rescued, service-op unreachability, bridge wire contract (cwd sent only when tokenless, suppressed server-side when a token is present), case-insensitive path matching, and the settings UI toggle under goja.

https://claude.ai/code/session_01AoCD9gRH2ncv3dP8u37aby