### PR TITLE
Phase 1: tool-call audit log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ service management.
 - `relay mcp call --token TOKEN --list | --tool NAME [--args '<json>']` — one-shot list/invoke over the bridge (also spelled `relay mcpExec`). No long-lived session; handy for agents.
 - `relay mcp register|unregister|list` — external MCP management.
 - `relay service register|unregister|restart|list` — service self-registration. `restart` sends `ReloadService`; the tray does Stop → Start in place.
+- `relay audit [--tail N] [--project ID] [--outcome denied] [--grep TEXT] [--json]` — tail the tool-call audit log. Reads the file directly, so it works with the tray stopped.
 
 ## Architecture
 
@@ -38,6 +39,9 @@ project.go               Project + token creation
 project_routes.go        HTTP project routes; shares Settings mutators with ipc_projects.go
 project_dto.go           projectView DTO — strips the token from every response except rotate
 router.go                Bridge auth (service vs project tokens), tool filtering, _meta injection
+audit.go                 Tool-call audit log: event model, async writer, ring, redaction, query
+audit_call.go            Nil-safe per-call event builder used by the router instrumentation
+audit_cmd.go             `relay audit` CLI
 external_mcp.go          stdio/HTTP MCP clients + runtime schema storage (McpConnection iface)
 http_mcp.go, oauth.go    HTTP transport + OAuth 2.1 (PKCE, dynamic registration, refresh)
 mcp_cmd.go, exec_cmd.go, service_cmd.go   CLI subcommands
@@ -49,7 +53,7 @@ enhanced_services.go     In-memory registry of enhanced services; per-service re
 service_registry.go      Background process management + ephemeral service tokens
 service_pidfile.go       Pidfiles under run/; enables orphan reclaim after a force-quit
 service_status_client.go, service_status_poller.go   Generic per-service status polling + action dispatch
-ipc_*.go                 Settings-UI IPC handlers (projects, services, mcps, service action/config)
+ipc_*.go                 Settings-UI IPC handlers (projects, services, mcps, service action/config, audit)
 service_config_file.go   resolveConfigPath security gate for the manifest config editor
 settings_html.go         Settings WKWebView HTML/JS
 bridge/                  Unix-socket IPC (newline-delimited JSON); manifest.go holds Manifest/FieldDecl
@@ -101,6 +105,15 @@ brokering rationale: ADR-007):
 - **Frontend token** (`RELAY_FRONTEND_TOKEN`) — frontend consumers dial `RELAY_FRONTEND_SOCKET` (0600), bearer-checked on every HTTP + WS before dispatch; an empty configured token fails closed. Injected only into frontend consumers (`service register --no-frontend-creds` keeps it out of backends).
 - **Enhanced internal bearer** — each service picks its own internal socket + token and declares both via the manifest; relay strips inbound `Authorization` and injects the service-declared token when proxying.
 
+**Tool-call audit log** — every call, denial, and auth failure is recorded at
+`appRouter.CallTool`, the single chokepoint every transport funnels through.
+Attribution comes from relay's own auth resolution (project id) and the kernel
+(peer pid off the bridge socket), never from the caller. Arguments are redacted
+and capped; results are metadata-only unless explicitly opted in. The sink fails
+open and shows its drop count rather than stalling a tool call. Viewer:
+Settings → Tool Calls, or `relay audit`. Full reference:
+[`docs/audit-log.md`](docs/audit-log.md); rationale: ADR-008.
+
 **TCC permissions** — relay holds the personal-information entitlements
 (`Relay.entitlements`) and fires the prompts from its own process; MCPs declare
 what they need with `--tcc-services foo,bar` and inherit relay's grants via TCC's
@@ -110,7 +123,7 @@ service: ADR-005.
 ## Settings UI
 
 IPC: `ipc(json)` → `window.webkit.messageHandlers.ipc.postMessage`. Tabs:
-Services, MCP Servers, Projects, Service Inspector.
+Services, MCP Servers, Projects, Service Inspector, Tool Calls.
 
 The Projects tab is native and co-equal with Eve's project dialog — both hit the
 same `Settings.*Project*` mutators (relay via `ipc_projects.go`, Eve via

--- a/audit.go
+++ b/audit.go
@@ -1,0 +1,725 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Event model
+// ---------------------------------------------------------------------------
+
+// Audit event kinds. CallTool is the one that matters for security review;
+// the list kinds record what tool surface a credential was shown.
+const (
+	AuditEventCallTool   = "call_tool"
+	AuditEventListTools  = "list_tools"
+	AuditEventListSkills = "list_skills"
+)
+
+// Audit outcomes. Denied and Unauthorized are deliberately distinct: the first
+// means a known credential was refused a tool it may not use, the second means
+// the credential itself did not resolve. They call for different responses.
+const (
+	AuditOutcomeOK           = "ok"
+	AuditOutcomeError        = "error"
+	AuditOutcomeDenied       = "denied"
+	AuditOutcomeUnauthorized = "unauthorized"
+)
+
+// Actor kinds.
+const (
+	AuditActorProject = "project"
+	AuditActorService = "service"
+	AuditActorUnknown = "unknown"
+)
+
+// Auth methods, mirroring resolveAuth's branches.
+const (
+	AuditAuthToken   = "token"
+	AuditAuthCwd     = "cwd"
+	AuditAuthService = "service"
+	AuditAuthNone    = "none"
+)
+
+// AuditActor identifies who made a call. Every field is derived from relay's
+// own resolution (the authenticated StoredToken) or from the kernel (the peer
+// pid) — never from a value the caller supplied, with the single exception of
+// Cwd, which is caller-asserted and only present for directory auth.
+type AuditActor struct {
+	Kind        string `json:"kind"`
+	ProjectID   string `json:"project_id,omitempty"`
+	ProjectName string `json:"project_name,omitempty"`
+	Auth        string `json:"auth"`
+	Cwd         string `json:"cwd,omitempty"`
+	PID         int    `json:"pid,omitempty"`
+	Proc        string `json:"proc,omitempty"`
+	Parent      string `json:"parent,omitempty"`
+}
+
+// AuditEvent is one record in the tool-call log, serialized as a single JSONL
+// line. Field names are the on-disk contract: external tooling greps this file.
+type AuditEvent struct {
+	ID    string     `json:"id"`
+	TS    time.Time  `json:"ts"`
+	DurMs int64      `json:"dur_ms"`
+	Event string     `json:"event"`
+	Actor AuditActor `json:"actor"`
+
+	McpID string `json:"mcp_id,omitempty"`
+	Tool  string `json:"tool,omitempty"`
+
+	// Args is the redacted, size-capped call arguments. When ArgsTruncated is
+	// set it holds a JSON *string* containing the truncated prefix rather than
+	// the original object, so the line stays valid JSON either way.
+	Args          json.RawMessage `json:"args,omitempty"`
+	ArgsBytes     int             `json:"args_bytes,omitempty"`
+	ArgsTruncated bool            `json:"args_truncated,omitempty"`
+
+	Outcome string `json:"outcome"`
+	Error   string `json:"error,omitempty"`
+
+	ResultBytes   int    `json:"result_bytes,omitempty"`
+	ResultIsError bool   `json:"result_is_error,omitempty"`
+	ResultPreview string `json:"result_preview,omitempty"`
+
+	// ToolCount is set on list events: how many tools the credential could see.
+	ToolCount int `json:"tool_count,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// AuditConfig is the optional "audit" block in settings.json. Booleans are
+// pointers so an absent block, an absent field, and an explicit false are all
+// distinguishable — absent means "use the default", which for Enabled is true.
+// Zero-valued ints likewise mean "default"; call resolve() before use.
+type AuditConfig struct {
+	Enabled               *bool    `json:"enabled,omitempty"`
+	LogArgs               *bool    `json:"log_args,omitempty"`
+	LogLists              *bool    `json:"log_lists,omitempty"`
+	MaxArgBytes           int      `json:"max_arg_bytes,omitempty"`
+	MaxResultPreviewBytes int      `json:"max_result_preview_bytes,omitempty"`
+	RingSize              int      `json:"ring_size,omitempty"`
+	MaxFileBytes          int64    `json:"max_file_bytes,omitempty"`
+	Generations           int      `json:"generations,omitempty"`
+	RedactKeys            []string `json:"redact_keys,omitempty"`
+}
+
+// Audit defaults. Results are metadata-only by default (preview 0) because a
+// tool result carries file contents, mail bodies, and calendar entries — the
+// audit log should not quietly become the most sensitive file on the machine.
+// List events default off: skill regeneration lists the tool surface for every
+// project on every MCP reconcile, which would bury the calls that matter.
+const (
+	auditDefaultMaxArgBytes  = 4096
+	auditDefaultRingSize     = 1000
+	auditDefaultMaxFileBytes = 32 << 20
+	auditDefaultGenerations  = 5
+
+	// auditQueueSize bounds the handoff between tool calls and the writer
+	// goroutine. Past this, events are dropped and counted rather than made to
+	// wait: the audit sink must never be able to stall a tool call.
+	auditQueueSize = 512
+
+	// auditTailBudget caps how far back a disk-backed query reads. Bounded work
+	// per query regardless of how large the log has grown.
+	auditTailBudget = 8 << 20
+)
+
+// resolvedAuditConfig is AuditConfig with every default applied.
+type resolvedAuditConfig struct {
+	Enabled               bool
+	LogArgs               bool
+	LogLists              bool
+	MaxArgBytes           int
+	MaxResultPreviewBytes int
+	RingSize              int
+	MaxFileBytes          int64
+	Generations           int
+	RedactKeys            []string
+}
+
+func boolOr(p *bool, def bool) bool {
+	if p == nil {
+		return def
+	}
+	return *p
+}
+
+func intOr(v, def int) int {
+	if v <= 0 {
+		return def
+	}
+	return v
+}
+
+// resolve applies defaults. A nil receiver resolves to the full default set, so
+// settings.json written before this feature existed behaves as if auditing was
+// always on.
+func (c *AuditConfig) resolve() resolvedAuditConfig {
+	if c == nil {
+		c = &AuditConfig{}
+	}
+	maxFile := c.MaxFileBytes
+	if maxFile <= 0 {
+		maxFile = auditDefaultMaxFileBytes
+	}
+	return resolvedAuditConfig{
+		Enabled:               boolOr(c.Enabled, true),
+		LogArgs:               boolOr(c.LogArgs, true),
+		LogLists:              boolOr(c.LogLists, false),
+		MaxArgBytes:           intOr(c.MaxArgBytes, auditDefaultMaxArgBytes),
+		MaxResultPreviewBytes: c.MaxResultPreviewBytes, // 0 is meaningful: metadata only
+		RingSize:              intOr(c.RingSize, auditDefaultRingSize),
+		MaxFileBytes:          maxFile,
+		Generations:           intOr(c.Generations, auditDefaultGenerations),
+		RedactKeys:            c.RedactKeys,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+// auditRedactedValue replaces any value whose key looks like a credential.
+const auditRedactedValue = "[redacted]"
+
+// auditSensitiveKeys are matched as case-insensitive substrings of an argument
+// key. Substring rather than exact match so "mcp_token", "X-Api-Key", and
+// "userPassword" are all caught without enumerating every spelling. Bare
+// "session" is deliberately absent: session ids are routinely load-bearing for
+// debugging and are not secrets, while "session_token" is already covered by
+// "token".
+var auditSensitiveKeys = []string{
+	"token", "secret", "password", "passwd", "apikey", "api_key", "api-key",
+	"authorization", "credential", "privatekey", "private_key", "cookie",
+	"bearer", "passphrase",
+}
+
+// redactValue walks a decoded JSON value, replacing values under credential-like
+// keys. Recurses through nested objects and arrays; scalars pass through.
+// extra keys are appended to the built-in set (already lowercased by caller).
+func redactValue(v interface{}, extra []string) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, val := range t {
+			if isSensitiveKey(k, extra) {
+				out[k] = auditRedactedValue
+				continue
+			}
+			out[k] = redactValue(val, extra)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, val := range t {
+			out[i] = redactValue(val, extra)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func isSensitiveKey(key string, extra []string) bool {
+	lower := strings.ToLower(key)
+	for _, s := range auditSensitiveKeys {
+		if strings.Contains(lower, s) {
+			return true
+		}
+	}
+	for _, s := range extra {
+		if s != "" && strings.Contains(lower, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// redactArgs returns the arguments ready for storage: credential-like values
+// replaced, then capped at maxBytes. Over the cap, the result is a JSON string
+// holding the truncated prefix (truncated=true) rather than a malformed object,
+// so every line in the log parses.
+//
+// Arguments that aren't valid JSON are stored as a capped string too: the point
+// is a faithful record of what was attempted, including malformed attempts.
+func redactArgs(raw json.RawMessage, maxBytes int, extra []string) (out json.RawMessage, size int, truncated bool) {
+	if len(raw) == 0 {
+		return nil, 0, false
+	}
+	size = len(raw)
+
+	var decoded interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return capAsString(string(raw), maxBytes)
+	}
+	encoded, err := json.Marshal(redactValue(decoded, extra))
+	if err != nil {
+		return capAsString(string(raw), maxBytes)
+	}
+	if len(encoded) <= maxBytes {
+		return encoded, size, false
+	}
+	return capAsString(string(encoded), maxBytes)
+}
+
+// capAsString truncates s to maxBytes (on a rune boundary) and encodes it as a
+// JSON string.
+func capAsString(s string, maxBytes int) (json.RawMessage, int, bool) {
+	size := len(s)
+	if len(s) > maxBytes {
+		s = truncateRunes(s, maxBytes)
+	}
+	encoded, err := json.Marshal(s)
+	if err != nil {
+		return nil, size, true
+	}
+	return encoded, size, size > maxBytes
+}
+
+// truncateRunes cuts s to at most n bytes without splitting a multi-byte rune.
+func truncateRunes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8StartByte(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
+// utf8StartByte reports whether b begins a UTF-8 sequence (i.e. is not a
+// continuation byte).
+func utf8StartByte(b byte) bool { return b&0xC0 != 0x80 }
+
+// ---------------------------------------------------------------------------
+// Ring buffer
+// ---------------------------------------------------------------------------
+
+// auditRing is a fixed-size circular buffer of the most recent events. It backs
+// the settings UI's first paint and live tail without re-reading the log file.
+type auditRing struct {
+	mu   sync.RWMutex
+	buf  []AuditEvent
+	next int
+	full bool
+}
+
+func newAuditRing(size int) *auditRing {
+	return &auditRing{buf: make([]AuditEvent, size)}
+}
+
+func (r *auditRing) add(ev AuditEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buf[r.next] = ev
+	r.next = (r.next + 1) % len(r.buf)
+	if r.next == 0 {
+		r.full = true
+	}
+}
+
+// snapshot returns the buffered events newest-first.
+func (r *auditRing) snapshot() []AuditEvent {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	n := r.next
+	if r.full {
+		n = len(r.buf)
+	}
+	out := make([]AuditEvent, 0, n)
+	for i := 0; i < n; i++ {
+		// Walk backwards from the most recently written slot.
+		idx := (r.next - 1 - i + len(r.buf)*2) % len(r.buf)
+		out = append(out, r.buf[idx])
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Recorder
+// ---------------------------------------------------------------------------
+
+// AuditRecorder receives events from the router and persists them. Writes are
+// handed to a single goroutine over a bounded channel so a slow or full disk
+// can never delay a tool call; on overflow the event is dropped and counted.
+//
+// A nil *AuditRecorder is a valid no-op recorder: every method tolerates it, so
+// callers (and tests) never have to branch on whether auditing is configured.
+type AuditRecorder struct {
+	cfg  resolvedAuditConfig
+	path string
+
+	ch      chan AuditEvent
+	flushCh chan chan struct{}
+	ring    *auditRing
+	w       io.WriteCloser
+
+	dropped atomic.Uint64
+	wrote   atomic.Uint64
+
+	// sink receives each recorded event for live UI push. Guarded by sinkMu
+	// because the settings window can attach and detach at any time.
+	sinkMu sync.RWMutex
+	sink   func(AuditEvent)
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// NewAuditRecorder starts a recorder writing JSONL to path. A disabled config
+// returns nil, which every call site treats as "auditing off".
+func NewAuditRecorder(cfg *AuditConfig, path string) (*AuditRecorder, error) {
+	resolved := cfg.resolve()
+	if !resolved.Enabled {
+		return nil, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("audit log dir: %w", err)
+	}
+	w, err := openRotatingLogGenerations(path, resolved.MaxFileBytes, resolved.Generations)
+	if err != nil {
+		return nil, fmt.Errorf("open audit log: %w", err)
+	}
+
+	// Lowercase the operator-supplied keys once rather than per call.
+	extra := make([]string, 0, len(resolved.RedactKeys))
+	for _, k := range resolved.RedactKeys {
+		extra = append(extra, strings.ToLower(strings.TrimSpace(k)))
+	}
+	resolved.RedactKeys = extra
+
+	r := &AuditRecorder{
+		cfg:     resolved,
+		path:    path,
+		ch:      make(chan AuditEvent, auditQueueSize),
+		flushCh: make(chan chan struct{}),
+		ring:    newAuditRing(resolved.RingSize),
+		w:       w,
+		done:    make(chan struct{}),
+	}
+	go r.run()
+	return r, nil
+}
+
+// Enabled reports whether events should be built at all. Nil-safe.
+func (r *AuditRecorder) Enabled() bool { return r != nil && r.cfg.Enabled }
+
+// LogLists reports whether list_tools / list_skills events are recorded.
+func (r *AuditRecorder) LogLists() bool { return r != nil && r.cfg.LogLists }
+
+// Path returns the audit log file path (empty when auditing is off).
+func (r *AuditRecorder) Path() string {
+	if r == nil {
+		return ""
+	}
+	return r.path
+}
+
+// Dropped returns how many events were discarded because the queue was full.
+// Surfaced in the UI: a nonzero count means the log is incomplete, and an
+// incomplete audit log that looks complete is worse than no audit log.
+func (r *AuditRecorder) Dropped() uint64 {
+	if r == nil {
+		return 0
+	}
+	return r.dropped.Load()
+}
+
+// SetSink registers a callback invoked for every recorded event, used for live
+// push to an open settings window. Pass nil to detach.
+func (r *AuditRecorder) SetSink(fn func(AuditEvent)) {
+	if r == nil {
+		return
+	}
+	r.sinkMu.Lock()
+	r.sink = fn
+	r.sinkMu.Unlock()
+}
+
+// Record enqueues an event. Never blocks: a full queue drops the event and
+// increments the drop counter.
+func (r *AuditRecorder) Record(ev AuditEvent) {
+	if r == nil || !r.cfg.Enabled {
+		return
+	}
+	select {
+	case r.ch <- ev:
+	default:
+		if n := r.dropped.Add(1); n == 1 {
+			// Warn once on the first drop; the counter carries the rest.
+			slog.Warn("audit log queue full, dropping events", "path", r.path)
+		}
+	}
+}
+
+// run owns the file and the ring. Single goroutine, so neither needs
+// write-side locking beyond the ring's own (readers come from the UI thread).
+func (r *AuditRecorder) run() {
+	defer close(r.done)
+	enc := json.NewEncoder(r.w)
+	for {
+		select {
+		case ev, ok := <-r.ch:
+			if !ok {
+				return // Close() closed the queue; buffered events already drained
+			}
+			r.write(enc, ev)
+		case ack := <-r.flushCh:
+			// select gives no ordering guarantee between the two channels, so
+			// drain everything already queued before acknowledging. By the time
+			// a flush request lands, every event enqueued before it is sitting
+			// in r.ch, which makes "drain to empty" exactly Flush's contract.
+			for {
+				select {
+				case ev := <-r.ch:
+					r.write(enc, ev)
+					continue
+				default:
+				}
+				break
+			}
+			close(ack)
+		}
+	}
+}
+
+// write persists one event and fans it out to the live UI sink.
+func (r *AuditRecorder) write(enc *json.Encoder, ev AuditEvent) {
+	r.ring.add(ev)
+	if err := enc.Encode(ev); err != nil {
+		slog.Warn("audit log write failed", "error", err)
+	}
+	r.wrote.Add(1)
+
+	r.sinkMu.RLock()
+	sink := r.sink
+	r.sinkMu.RUnlock()
+	if sink != nil {
+		sink(ev)
+	}
+}
+
+// Close drains the queue and closes the file. Safe to call more than once.
+func (r *AuditRecorder) Close() {
+	if r == nil {
+		return
+	}
+	r.closeOnce.Do(func() {
+		close(r.ch)
+		<-r.done
+		_ = r.w.Close()
+	})
+}
+
+// Wrote returns how many events have been persisted this run.
+func (r *AuditRecorder) Wrote() uint64 {
+	if r == nil {
+		return 0
+	}
+	return r.wrote.Load()
+}
+
+// Flush blocks until every event enqueued before the call has been written.
+// Mainly a test seam, but also used before an export so the file on disk
+// includes everything the UI has already shown. Returns immediately if the
+// recorder is closed rather than blocking forever on a dead writer.
+func (r *AuditRecorder) Flush() {
+	if r == nil {
+		return
+	}
+	ack := make(chan struct{})
+	select {
+	case r.flushCh <- ack:
+	case <-r.done:
+		return
+	}
+	select {
+	case <-ack:
+	case <-r.done:
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+// AuditQuery filters recorded events. Empty fields don't filter.
+type AuditQuery struct {
+	ProjectID string `json:"project_id,omitempty"`
+	McpID     string `json:"mcp_id,omitempty"`
+	Outcome   string `json:"outcome,omitempty"`
+	Event     string `json:"event,omitempty"`
+	Text      string `json:"text,omitempty"` // substring over tool, args, error, project name
+	Limit     int    `json:"limit,omitempty"`
+	// Deep searches the log file rather than the in-memory ring, for history
+	// older than the ring holds. Bounded by auditTailBudget.
+	Deep bool `json:"deep,omitempty"`
+}
+
+func (q AuditQuery) matches(ev *AuditEvent) bool {
+	if q.ProjectID != "" && ev.Actor.ProjectID != q.ProjectID {
+		return false
+	}
+	if q.McpID != "" && ev.McpID != q.McpID {
+		return false
+	}
+	if q.Outcome != "" && ev.Outcome != q.Outcome {
+		return false
+	}
+	if q.Event != "" && ev.Event != q.Event {
+		return false
+	}
+	if q.Text != "" {
+		needle := strings.ToLower(q.Text)
+		hay := strings.ToLower(strings.Join([]string{
+			ev.Tool, ev.McpID, ev.Error, ev.Actor.ProjectName,
+			ev.Actor.Proc, ev.Actor.Parent, string(ev.Args),
+		}, "\x00"))
+		if !strings.Contains(hay, needle) {
+			return false
+		}
+	}
+	return true
+}
+
+// Query returns matching events, newest first. Reads the in-memory ring unless
+// q.Deep is set, in which case it scans the tail of the log file.
+func (r *AuditRecorder) Query(q AuditQuery) []AuditEvent {
+	if r == nil {
+		return []AuditEvent{}
+	}
+	limit := intOr(q.Limit, 200)
+
+	var candidates []AuditEvent
+	if q.Deep {
+		candidates = readAuditTail(r.path, auditTailBudget)
+	} else {
+		candidates = r.ring.snapshot()
+	}
+
+	out := make([]AuditEvent, 0, limit)
+	for i := range candidates {
+		if q.matches(&candidates[i]) {
+			out = append(out, candidates[i])
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out
+}
+
+// readAuditTail reads at most budget bytes from the end of the JSONL log and
+// returns the events newest-first. A partial first line (the seek lands
+// mid-record) is skipped. Unparseable lines are skipped rather than failing the
+// whole query — a truncated tail should still be readable.
+func readAuditTail(path string, budget int64) []AuditEvent {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil
+	}
+	start := int64(0)
+	partial := false
+	if info.Size() > budget {
+		start = info.Size() - budget
+		partial = true
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil
+	}
+
+	scanner := newAuditScanner(f)
+	var events []AuditEvent
+	first := true
+	for scanner.Scan() {
+		if first && partial {
+			first = false
+			continue // discard the record the seek cut in half
+		}
+		first = false
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev AuditEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		events = append(events, ev)
+	}
+
+	// Reverse into newest-first order to match the ring's contract.
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+	return events
+}
+
+// startAuditRecorder builds the recorder from settings, logging and returning
+// nil on any failure. Auditing is observability, not an authorization control,
+// so a broken sink degrades to "no audit log" rather than taking relay down —
+// the Tool Calls tab makes the disabled state visible instead of pretending.
+func startAuditRecorder(s *Settings) *AuditRecorder {
+	path, err := auditLogPath()
+	if err != nil {
+		slog.Error("audit log disabled: cannot resolve log dir", "error", err)
+		return nil
+	}
+	rec, err := NewAuditRecorder(s.Audit, path)
+	if err != nil {
+		slog.Error("audit log disabled", "path", path, "error", err)
+		return nil
+	}
+	if rec == nil {
+		slog.Info("tool-call audit log disabled by settings")
+		return nil
+	}
+	slog.Info("tool-call audit log started", "path", path,
+		"log_args", rec.cfg.LogArgs, "log_lists", rec.cfg.LogLists,
+		"max_file_bytes", rec.cfg.MaxFileBytes, "generations", rec.cfg.Generations)
+	return rec
+}
+
+// auditLogPath returns the audit log location under the relay config dir.
+func auditLogPath() (string, error) {
+	dir, err := serviceLogDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "audit", "toolcalls.jsonl"), nil
+}
+
+// newAuditScanner reads JSONL records. The buffer is sized for the largest
+// record the caps allow (redacted args plus an optional result preview) with
+// generous headroom, so an oversized line is skipped rather than truncating the
+// rest of the scan.
+func newAuditScanner(r io.Reader) *bufio.Scanner {
+	s := bufio.NewScanner(r)
+	s.Buffer(make([]byte, 64*1024), 4<<20)
+	return s
+}
+
+// newAuditID returns a unique event id. Separate function so tests can reason
+// about it without reaching for uuid directly.
+func newAuditID() string { return uuid.NewString() }

--- a/audit_call.go
+++ b/audit_call.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"relaygo/bridge"
+)
+
+// auditCall accumulates one audit event over the life of a router call.
+//
+// Every method tolerates a nil receiver, so the router instrumentation reads as
+// straight-line code with no `if r.audit != nil` noise at each step — and a
+// router built without a recorder (most tests, and any install that disabled
+// auditing) simply does nothing.
+type auditCall struct {
+	rec   *AuditRecorder
+	start time.Time
+	ev    AuditEvent
+}
+
+// beginAudit starts an event, capturing the caller's kernel-attested pid.
+// Returns nil when auditing is off or this event kind isn't being recorded, so
+// no work is done building an event that would be thrown away.
+func (r *appRouter) beginAudit(ctx context.Context, event string) *auditCall {
+	if !r.audit.Enabled() {
+		return nil
+	}
+	if event != AuditEventCallTool && !r.audit.LogLists() {
+		return nil
+	}
+	a := &auditCall{
+		rec:   r.audit,
+		start: time.Now(),
+		ev: AuditEvent{
+			ID:    newAuditID(),
+			Event: event,
+			Actor: AuditActor{Kind: AuditActorUnknown, Auth: AuditAuthNone},
+		},
+	}
+	// Resolve the caller's process now, while it is certainly still alive: a
+	// `relay mcp call` child exits as soon as it has its answer, so resolving
+	// after the call would frequently find nothing.
+	if pid := bridge.CallerPIDFromContext(ctx); pid > 0 {
+		a.ev.Actor.PID = pid
+		a.ev.Actor.Proc, a.ev.Actor.Parent = ProcessNames(pid)
+	}
+	return a
+}
+
+// setTool records the requested tool and its arguments. Arguments are redacted
+// and capped here rather than at write time so the raw values never sit in the
+// queue waiting to be persisted.
+func (a *auditCall) setTool(name string, args json.RawMessage) {
+	if a == nil {
+		return
+	}
+	a.ev.Tool = name
+	if !a.rec.cfg.LogArgs {
+		return
+	}
+	a.ev.Args, a.ev.ArgsBytes, a.ev.ArgsTruncated = redactArgs(args, a.rec.cfg.MaxArgBytes, a.rec.cfg.RedactKeys)
+}
+
+// setMcp records which MCP owns the tool. Known only after tool-owner lookup,
+// which is why it's separate from setTool.
+func (a *auditCall) setMcp(id string) {
+	if a == nil {
+		return
+	}
+	a.ev.McpID = id
+}
+
+// setActor fills in the authenticated identity. token is the credential the
+// caller presented (used only to distinguish a token hand-off from directory
+// auth — the value itself is never recorded).
+func (a *auditCall) setActor(ctx context.Context, stored *StoredToken, settings *Settings, token string) {
+	if a == nil || stored == nil {
+		return
+	}
+	switch {
+	case stored.Name == serviceTokenName:
+		a.ev.Actor.Kind = AuditActorService
+		a.ev.Actor.Auth = AuditAuthService
+	case token == "":
+		a.ev.Actor.Kind = AuditActorProject
+		a.ev.Actor.Auth = AuditAuthCwd
+		a.ev.Actor.Cwd = bridge.CallerCwdFromContext(ctx)
+	default:
+		a.ev.Actor.Kind = AuditActorProject
+		a.ev.Actor.Auth = AuditAuthToken
+	}
+	a.ev.Actor.ProjectID = stored.ProjectID
+	a.ev.Actor.ProjectName = projectNameFor(stored, settings)
+}
+
+// setUnauthenticated records the shape of a failed auth attempt. There is no
+// project to name, but whether a credential was presented at all — and from
+// what directory — is exactly what a review of failed calls needs.
+func (a *auditCall) setUnauthenticated(ctx context.Context, token string) {
+	if a == nil {
+		return
+	}
+	a.ev.Actor.Kind = AuditActorUnknown
+	if token == "" {
+		a.ev.Actor.Auth = AuditAuthNone
+		a.ev.Actor.Cwd = bridge.CallerCwdFromContext(ctx)
+	} else {
+		a.ev.Actor.Auth = AuditAuthToken
+	}
+}
+
+// setToolCount records how many tools a list call exposed.
+func (a *auditCall) setToolCount(n int) {
+	if a == nil {
+		return
+	}
+	a.ev.ToolCount = n
+}
+
+// done finalizes the event with an outcome and optional error, then hands it to
+// the recorder.
+func (a *auditCall) done(outcome string, err error) {
+	if a == nil {
+		return
+	}
+	a.ev.DurMs = time.Since(a.start).Milliseconds()
+	a.ev.TS = a.start.UTC()
+	a.ev.Outcome = outcome
+	if err != nil {
+		a.ev.Error = err.Error()
+	}
+	a.rec.Record(a.ev)
+}
+
+// doneResult finalizes a completed tool call, recording result metadata (and a
+// preview only when the operator opted into one).
+func (a *auditCall) doneResult(result json.RawMessage, err error) {
+	if a == nil {
+		return
+	}
+	if err != nil {
+		a.done(AuditOutcomeError, err)
+		return
+	}
+	a.ev.ResultBytes = len(result)
+	a.ev.ResultIsError = resultIsError(result)
+	if n := a.rec.cfg.MaxResultPreviewBytes; n > 0 && len(result) > 0 {
+		a.ev.ResultPreview = truncateRunes(string(result), n)
+	}
+	a.done(AuditOutcomeOK, nil)
+}
+
+// resultIsError reports whether an MCP CallToolResult carries isError: true.
+// A tool that fails *within* the protocol returns a normal result with that
+// flag set, so without this check every application-level failure would be
+// logged as a success.
+func resultIsError(result json.RawMessage) bool {
+	if len(result) == 0 {
+		return false
+	}
+	var probe struct {
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(result, &probe); err != nil {
+		return false
+	}
+	return probe.IsError
+}
+
+// projectNameFor resolves a display name for the audited project. Prefers the
+// live settings lookup; falls back to the "project:<name>" form already carried
+// on the StoredToken when the project has since been deleted.
+func projectNameFor(stored *StoredToken, settings *Settings) string {
+	if settings != nil && stored.ProjectID != "" {
+		if proj, _ := settings.findProjectByID(stored.ProjectID); proj != nil {
+			return proj.Name
+		}
+	}
+	return strings.TrimPrefix(stored.Name, "project:")
+}

--- a/audit_cmd.go
+++ b/audit_cmd.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runAuditCommand implements `relay audit` — a read-only tail of the tool-call
+// log for the case where the tray isn't open, or you want to pipe events into
+// something else.
+//
+// It reads the log file directly rather than going over the bridge. The log is
+// owned by the tray process, but appending JSONL and reading it are independent;
+// a reader never needs the writer's cooperation, and this keeps `relay audit`
+// working when the tray is stopped, which is exactly when you'd reach for it.
+func runAuditCommand(args []string) {
+	fs := flag.NewFlagSet("audit", flag.ExitOnError)
+	tail := fs.Int("tail", 50, "show the most recent N events")
+	project := fs.String("project", "", "filter by project id")
+	mcpID := fs.String("mcp", "", "filter by MCP id")
+	outcome := fs.String("outcome", "", "filter by outcome: ok, error, denied, unauthorized")
+	event := fs.String("event", "", "filter by event kind: call_tool, list_tools, list_skills")
+	text := fs.String("grep", "", "substring match over tool, MCP, error, project, caller, args")
+	asJSON := fs.Bool("json", false, "emit raw JSONL instead of a table")
+	pathOnly := fs.Bool("path", false, "print the log file path and exit")
+	fs.Parse(args)
+
+	path, err := auditLogPath()
+	if err != nil {
+		exitError("audit: cannot resolve log path: %v", err)
+	}
+	if *pathOnly {
+		fmt.Println(path)
+		return
+	}
+	if _, err := os.Stat(path); err != nil {
+		exitError("audit: no log at %s (auditing may be disabled, or relay has not run yet)", path)
+	}
+
+	q := AuditQuery{
+		ProjectID: *project,
+		McpID:     *mcpID,
+		Outcome:   *outcome,
+		Event:     *event,
+		Text:      *text,
+		Limit:     *tail,
+	}
+
+	events := readAuditTail(path, auditTailBudget)
+	matched := make([]AuditEvent, 0, *tail)
+	for i := range events {
+		if q.matches(&events[i]) {
+			matched = append(matched, events[i])
+			if len(matched) >= *tail {
+				break
+			}
+		}
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		// Oldest-first so piping into another tool reads forwards in time.
+		for i := len(matched) - 1; i >= 0; i-- {
+			if err := enc.Encode(matched[i]); err != nil {
+				exitError("audit: %v", err)
+			}
+		}
+		return
+	}
+
+	if len(matched) == 0 {
+		fmt.Println("no matching tool calls")
+		return
+	}
+
+	w := newTabWriter()
+	fmt.Fprintln(w, "TIME\tOUTCOME\tPROJECT\tMCP\tTOOL\tMS\tCALLER\tDETAIL")
+	for i := len(matched) - 1; i >= 0; i-- {
+		ev := matched[i]
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+			ev.TS.Local().Format("15:04:05"),
+			ev.Outcome,
+			dash(ev.Actor.ProjectName),
+			dash(ev.McpID),
+			dash(ev.Tool),
+			ev.DurMs,
+			dash(auditCallerLabel(ev.Actor)),
+			auditDetail(ev),
+		)
+	}
+	w.Flush()
+}
+
+// auditCallerLabel renders the actor as "parent→proc", falling back to whatever
+// half is known. The parent is listed first because it's the agent that asked;
+// the process is often just a short-lived `relay mcp` child.
+func auditCallerLabel(a AuditActor) string {
+	switch {
+	case a.Parent != "" && a.Proc != "":
+		return a.Parent + "→" + a.Proc
+	case a.Proc != "":
+		return a.Proc
+	case a.Parent != "":
+		return a.Parent
+	default:
+		return ""
+	}
+}
+
+// auditDetail is the one-line summary: the error for a failure, the redacted
+// args for a success.
+func auditDetail(ev AuditEvent) string {
+	if ev.Error != "" {
+		return collapseWhitespace(ev.Error)
+	}
+	if len(ev.Args) > 0 {
+		return collapseWhitespace(truncateRunes(string(ev.Args), 120))
+	}
+	if ev.ToolCount > 0 {
+		return fmt.Sprintf("%d tools visible", ev.ToolCount)
+	}
+	return ""
+}
+
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/audit_process_darwin.go
+++ b/audit_process_darwin.go
@@ -1,0 +1,58 @@
+//go:build darwin
+
+package main
+
+/*
+#include <libproc.h>
+#include <sys/proc_info.h>
+*/
+import "C"
+
+import "unsafe"
+
+// ProcessNames returns the command name for pid and for its parent, or empty
+// strings when either can't be read (the process exited, or it belongs to
+// another user).
+//
+// Uses libproc's proc_pidinfo rather than shelling out to `ps`: this sits on
+// the tool-call path, and two syscalls cost microseconds where a fork+exec
+// costs milliseconds.
+//
+// The parent matters more than the process itself. `relay mcp` opens a fresh
+// connection — and often a fresh process — per call, so the peer pid alone
+// names a throwaway subprocess; its parent is the agent that actually asked for
+// the tool.
+func ProcessNames(pid int) (proc, parent string) {
+	name, ppid, ok := procInfo(pid)
+	if !ok {
+		return "", ""
+	}
+	if ppid > 0 {
+		if parentName, _, ok := procInfo(ppid); ok {
+			parent = parentName
+		}
+	}
+	return name, parent
+}
+
+// procInfo reads one process's name and parent pid via PROC_PIDTBSDINFO.
+func procInfo(pid int) (name string, ppid int, ok bool) {
+	if pid <= 0 {
+		return "", 0, false
+	}
+	var info C.struct_proc_bsdinfo
+	size := C.int(unsafe.Sizeof(info))
+	n := C.proc_pidinfo(C.int(pid), C.PROC_PIDTBSDINFO, 0, unsafe.Pointer(&info), size)
+	if n < size {
+		// Short read means the pid is gone or unreadable; report "unknown"
+		// rather than a partially-populated struct.
+		return "", 0, false
+	}
+	// pbi_name is the fuller name (32 chars) but is empty for some processes,
+	// where pbi_comm (16 chars) still has the short form.
+	name = C.GoString(&info.pbi_name[0])
+	if name == "" {
+		name = C.GoString(&info.pbi_comm[0])
+	}
+	return name, int(info.pbi_ppid), true
+}

--- a/audit_process_other.go
+++ b/audit_process_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package main
+
+// ProcessNames is a no-op outside darwin, matching bridge.PeerPID: relay's tray
+// host is macOS-only, and an unknown caller process is recorded as empty rather
+// than treated as an error.
+func ProcessNames(int) (proc, parent string) { return "", "" }

--- a/audit_test.go
+++ b/audit_test.go
@@ -1,0 +1,649 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"relaygo/bridge"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newTestAudit returns a recorder writing into a temp dir, closed on cleanup.
+func newTestAudit(t *testing.T, cfg *AuditConfig) *AuditRecorder {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "audit", "toolcalls.jsonl")
+	rec, err := NewAuditRecorder(cfg, path)
+	if err != nil {
+		t.Fatalf("NewAuditRecorder: %v", err)
+	}
+	if rec != nil {
+		t.Cleanup(rec.Close)
+	}
+	return rec
+}
+
+// auditedRouter is setupRouter plus an attached recorder.
+func auditedRouter(t *testing.T, perms map[string]Permission, disabled map[string][]string, mocks map[string]*mockMcpConn, cfg *AuditConfig) (*appRouter, *AuditRecorder) {
+	t.Helper()
+	r := setupRouter(t, perms, disabled, nil, mocks)
+	rec := newTestAudit(t, cfg)
+	r.audit = rec
+	return r, rec
+}
+
+// readLoggedEvents flushes and parses every event written to the log file.
+func readLoggedEvents(t *testing.T, rec *AuditRecorder) []AuditEvent {
+	t.Helper()
+	rec.Flush()
+	data, err := os.ReadFile(rec.Path())
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	var out []AuditEvent
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev AuditEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("audit log line is not valid JSON: %v\nline: %s", err, line)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+func onlyEvent(t *testing.T, events []AuditEvent) AuditEvent {
+	t.Helper()
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 audit event, got %d: %+v", len(events), events)
+	}
+	return events[0]
+}
+
+// ---------------------------------------------------------------------------
+// Router instrumentation
+// ---------------------------------------------------------------------------
+
+func TestAudit_RecordsSuccessfulCall(t *testing.T) {
+	mock := newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{"content":[{"type":"text","text":"hi"}]}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	args := json.RawMessage(`{"path":"/tmp/notes.md"}`)
+	if _, err := r.CallTool(context.Background(), "read_file", args, testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Event != AuditEventCallTool {
+		t.Errorf("event = %q, want %q", ev.Event, AuditEventCallTool)
+	}
+	if ev.Outcome != AuditOutcomeOK {
+		t.Errorf("outcome = %q, want ok (error=%q)", ev.Outcome, ev.Error)
+	}
+	if ev.Tool != "read_file" || ev.McpID != "fsmcp" {
+		t.Errorf("tool/mcp = %q/%q, want read_file/fsmcp", ev.Tool, ev.McpID)
+	}
+	// The project id must come from relay's own auth resolution, not the caller.
+	if ev.Actor.ProjectID != "test-project" || ev.Actor.ProjectName != "test" {
+		t.Errorf("actor project = %q/%q, want test-project/test", ev.Actor.ProjectID, ev.Actor.ProjectName)
+	}
+	if ev.Actor.Kind != AuditActorProject || ev.Actor.Auth != AuditAuthToken {
+		t.Errorf("actor kind/auth = %q/%q, want project/token", ev.Actor.Kind, ev.Actor.Auth)
+	}
+	if string(ev.Args) != `{"path":"/tmp/notes.md"}` {
+		t.Errorf("args = %s, want the original object", ev.Args)
+	}
+	if ev.ResultBytes == 0 {
+		t.Error("result_bytes = 0, want the size of the tool result")
+	}
+	if ev.ID == "" || ev.TS.IsZero() {
+		t.Errorf("event id/timestamp not set: id=%q ts=%v", ev.ID, ev.TS)
+	}
+}
+
+// A refused call is the record a security review is actually looking for, so
+// it must be logged just as reliably as a successful one.
+func TestAudit_RecordsDeniedCall(t *testing.T) {
+	mock := newMockConn("fsmcp", simpleTools("read_file", "fs_bash"), okHandler(`{}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn},
+		map[string][]string{"fsmcp": {"fs_bash"}},
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	if _, err := r.CallTool(context.Background(), "fs_bash", json.RawMessage(`{"cmd":"ls"}`), testToken); err == nil {
+		t.Fatal("expected a denial for a disabled tool")
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Outcome != AuditOutcomeDenied {
+		t.Errorf("outcome = %q, want denied", ev.Outcome)
+	}
+	if ev.Tool != "fs_bash" || ev.McpID != "fsmcp" {
+		t.Errorf("tool/mcp = %q/%q, want fs_bash/fsmcp", ev.Tool, ev.McpID)
+	}
+	if ev.Actor.ProjectID != "test-project" {
+		t.Errorf("denied call lost the project attribution: %+v", ev.Actor)
+	}
+	if !strings.Contains(ev.Error, "disabled") {
+		t.Errorf("error = %q, want the denial reason", ev.Error)
+	}
+}
+
+func TestAudit_RecordsUnauthorizedCall(t *testing.T) {
+	mock := newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	if _, err := r.CallTool(context.Background(), "read_file", json.RawMessage(`{}`), "not-a-real-token"); err == nil {
+		t.Fatal("expected an auth failure for an unknown token")
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Outcome != AuditOutcomeUnauthorized {
+		t.Errorf("outcome = %q, want unauthorized", ev.Outcome)
+	}
+	if ev.Actor.Kind != AuditActorUnknown {
+		t.Errorf("actor kind = %q, want unknown", ev.Actor.Kind)
+	}
+	// A credential was presented, it just didn't resolve. That distinction is
+	// the point of recording the attempt at all.
+	if ev.Actor.Auth != AuditAuthToken {
+		t.Errorf("actor auth = %q, want token", ev.Actor.Auth)
+	}
+	if ev.Actor.ProjectID != "" {
+		t.Errorf("unauthenticated call attributed to project %q", ev.Actor.ProjectID)
+	}
+}
+
+func TestAudit_RecordsUnknownTool(t *testing.T) {
+	r, rec := auditedRouter(t, map[string]Permission{"fsmcp": PermOn}, nil, nil, nil)
+
+	if _, err := r.CallTool(context.Background(), "no_such_tool", nil, testToken); err == nil {
+		t.Fatal("expected an error for an unknown tool")
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Outcome != AuditOutcomeError || ev.Tool != "no_such_tool" {
+		t.Errorf("got outcome=%q tool=%q, want error/no_such_tool", ev.Outcome, ev.Tool)
+	}
+}
+
+// Directory auth has no deliberate credential hand-off to point at, so the log
+// is its only audit trail — it must record both the method and the directory.
+func TestAudit_RecordsDirectoryAuth(t *testing.T) {
+	dir := t.TempDir()
+
+	// Opt the project into directory auth and root it at a real directory
+	// before the router is built: the store hands out settings by value.
+	settings := makeSettings(map[string]Permission{"fsmcp": PermOn}, nil, nil)
+	settings.Projects[0].Path = dir
+	settings.Projects[0].AllowCwdAuth = true
+
+	mgr := NewExternalMcpManager(nil)
+	addMockConn(mgr, "fsmcp", newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{}`)))
+	r := newTestRouter(t, settings, mgr)
+	rec := newTestAudit(t, nil)
+	r.audit = rec
+
+	ctx := bridge.WithCallerCwd(context.Background(), dir)
+	if _, err := r.CallTool(ctx, "read_file", json.RawMessage(`{}`), ""); err != nil {
+		t.Fatalf("CallTool with directory auth: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Actor.Auth != AuditAuthCwd {
+		t.Errorf("actor auth = %q, want cwd", ev.Actor.Auth)
+	}
+	if ev.Actor.Cwd != dir {
+		t.Errorf("actor cwd = %q, want %q", ev.Actor.Cwd, dir)
+	}
+	if ev.Actor.ProjectID != "test-project" {
+		t.Errorf("actor project = %q, want test-project", ev.Actor.ProjectID)
+	}
+}
+
+// A tool that fails inside the protocol returns a normal result with
+// isError set; without the probe it would be logged as a plain success.
+func TestAudit_RecordsProtocolLevelToolError(t *testing.T) {
+	mock := newMockConn("fsmcp", simpleTools("read_file"),
+		okHandler(`{"isError":true,"content":[{"type":"text","text":"no such file"}]}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	if _, err := r.CallTool(context.Background(), "read_file", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if !ev.ResultIsError {
+		t.Error("result_is_error = false, want true for an isError result")
+	}
+}
+
+// List events are off by default: skill regeneration lists the tool surface for
+// every project on every reconcile, which would bury the calls that matter.
+func TestAudit_ListEventsOffByDefault(t *testing.T) {
+	mock := newMockConn("fsmcp", simpleTools("read_file"), nil)
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	if _, err := r.ListTools(context.Background(), testToken); err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	rec.Flush()
+	if n := rec.Wrote(); n != 0 {
+		t.Errorf("recorded %d events with log_lists off, want 0", n)
+	}
+}
+
+func TestAudit_ListEventsWhenEnabled(t *testing.T) {
+	on := true
+	mock := newMockConn("fsmcp", simpleTools("read_file", "write_file"), nil)
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock},
+		&AuditConfig{LogLists: &on})
+
+	if _, err := r.ListTools(context.Background(), testToken); err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Event != AuditEventListTools {
+		t.Errorf("event = %q, want %q", ev.Event, AuditEventListTools)
+	}
+	if ev.ToolCount != 2 {
+		t.Errorf("tool_count = %d, want 2", ev.ToolCount)
+	}
+}
+
+// A router with no recorder must behave exactly as it did before auditing
+// existed — the nil-safe helpers are what make the instrumentation free.
+func TestAudit_NilRecorderIsInert(t *testing.T) {
+	mock := newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{}`))
+	r := setupRouter(t, map[string]Permission{"fsmcp": PermOn}, nil, nil,
+		map[string]*mockMcpConn{"fsmcp": mock})
+	r.audit = nil
+
+	if _, err := r.CallTool(context.Background(), "read_file", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("CallTool with no recorder: %v", err)
+	}
+	if _, err := r.ListTools(context.Background(), testToken); err != nil {
+		t.Fatalf("ListTools with no recorder: %v", err)
+	}
+}
+
+func TestAudit_DisabledConfigYieldsNoRecorder(t *testing.T) {
+	off := false
+	rec := newTestAudit(t, &AuditConfig{Enabled: &off})
+	if rec != nil {
+		t.Fatal("disabled config produced a recorder")
+	}
+	if rec.Enabled() {
+		t.Error("nil recorder reports Enabled")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redaction and truncation
+// ---------------------------------------------------------------------------
+
+func TestRedactArgs_RedactsCredentialKeys(t *testing.T) {
+	in := json.RawMessage(`{
+		"path": "/tmp/x",
+		"api_key": "sk-live-1234",
+		"nested": {"Authorization": "Bearer abc", "keep": 1},
+		"list": [{"password": "hunter2"}, {"ok": true}]
+	}`)
+	out, _, truncated := redactArgs(in, 4096, nil)
+	if truncated {
+		t.Fatal("small args were reported as truncated")
+	}
+	s := string(out)
+	for _, secret := range []string{"sk-live-1234", "Bearer abc", "hunter2"} {
+		if strings.Contains(s, secret) {
+			t.Errorf("redacted output still contains %q: %s", secret, s)
+		}
+	}
+	// Non-credential values must survive, or the log stops being useful.
+	if !strings.Contains(s, "/tmp/x") || !strings.Contains(s, `"keep":1`) {
+		t.Errorf("redaction removed non-credential values: %s", s)
+	}
+}
+
+func TestRedactArgs_HonorsExtraKeys(t *testing.T) {
+	in := json.RawMessage(`{"patient_name":"Jane","path":"/tmp/x"}`)
+	out, _, _ := redactArgs(in, 4096, []string{"patient"})
+	if strings.Contains(string(out), "Jane") {
+		t.Errorf("configured redact key was ignored: %s", out)
+	}
+	if !strings.Contains(string(out), "/tmp/x") {
+		t.Errorf("configured redact key over-matched: %s", out)
+	}
+}
+
+func TestRedactArgs_TruncatesOversizedArgs(t *testing.T) {
+	big, err := json.Marshal(map[string]string{"blob": strings.Repeat("x", 500)})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out, size, truncated := redactArgs(big, 100, nil)
+	if !truncated {
+		t.Fatal("oversized args were not flagged as truncated")
+	}
+	if size != len(big) {
+		t.Errorf("recorded size = %d, want the original %d", size, len(big))
+	}
+	// Truncated or not, every line in the log must parse.
+	var v interface{}
+	if err := json.Unmarshal(out, &v); err != nil {
+		t.Fatalf("truncated args are not valid JSON: %v (%s)", err, out)
+	}
+	if _, ok := v.(string); !ok {
+		t.Errorf("truncated args should be stored as a JSON string, got %T", v)
+	}
+}
+
+func TestRedactArgs_MalformedJSONIsStoredAsText(t *testing.T) {
+	out, _, _ := redactArgs(json.RawMessage(`{not json`), 4096, nil)
+	var v interface{}
+	if err := json.Unmarshal(out, &v); err != nil {
+		t.Fatalf("malformed args produced an unparseable record: %v", err)
+	}
+	if s, ok := v.(string); !ok || !strings.Contains(s, "not json") {
+		t.Errorf("malformed args lost their content: %v", v)
+	}
+}
+
+func TestTruncateRunes_DoesNotSplitMultibyte(t *testing.T) {
+	// "é" is two bytes; cutting at 3 must drop it rather than halve it.
+	got := truncateRunes("aéb", 3)
+	if got != "aé" {
+		t.Errorf("truncateRunes = %q, want %q", got, "aé")
+	}
+	if !json.Valid(mustJSON(t, got)) {
+		t.Error("truncated string does not encode as valid JSON")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ring, queue, and query
+// ---------------------------------------------------------------------------
+
+func TestAuditRing_EvictsOldestAndReturnsNewestFirst(t *testing.T) {
+	ring := newAuditRing(3)
+	for _, id := range []string{"a", "b", "c", "d"} {
+		ring.add(AuditEvent{ID: id})
+	}
+	got := ring.snapshot()
+	want := []string{"d", "c", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("snapshot len = %d, want %d", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Errorf("snapshot[%d] = %q, want %q", i, got[i].ID, id)
+		}
+	}
+}
+
+func TestAuditRing_PartiallyFilled(t *testing.T) {
+	ring := newAuditRing(5)
+	ring.add(AuditEvent{ID: "a"})
+	ring.add(AuditEvent{ID: "b"})
+	got := ring.snapshot()
+	if len(got) != 2 || got[0].ID != "b" || got[1].ID != "a" {
+		t.Fatalf("snapshot = %+v, want [b a]", got)
+	}
+}
+
+func TestAuditQuery_FiltersRing(t *testing.T) {
+	rec := newTestAudit(t, nil)
+	rec.Record(AuditEvent{ID: "1", Event: AuditEventCallTool, McpID: "fsmcp", Tool: "read_file", Outcome: AuditOutcomeOK,
+		Actor: AuditActor{ProjectID: "p1", ProjectName: "alpha"}})
+	rec.Record(AuditEvent{ID: "2", Event: AuditEventCallTool, McpID: "macmcp", Tool: "send_mail", Outcome: AuditOutcomeDenied,
+		Actor: AuditActor{ProjectID: "p2", ProjectName: "beta"}})
+	rec.Flush()
+
+	if got := rec.Query(AuditQuery{ProjectID: "p1"}); len(got) != 1 || got[0].ID != "1" {
+		t.Errorf("project filter returned %+v", got)
+	}
+	if got := rec.Query(AuditQuery{Outcome: AuditOutcomeDenied}); len(got) != 1 || got[0].ID != "2" {
+		t.Errorf("outcome filter returned %+v", got)
+	}
+	if got := rec.Query(AuditQuery{McpID: "macmcp"}); len(got) != 1 || got[0].ID != "2" {
+		t.Errorf("mcp filter returned %+v", got)
+	}
+	if got := rec.Query(AuditQuery{Text: "READ_FILE"}); len(got) != 1 || got[0].ID != "1" {
+		t.Errorf("text filter should be case-insensitive, returned %+v", got)
+	}
+	if got := rec.Query(AuditQuery{Limit: 1}); len(got) != 1 {
+		t.Errorf("limit ignored, returned %d events", len(got))
+	}
+	if got := rec.Query(AuditQuery{}); len(got) != 2 {
+		t.Errorf("empty query returned %d events, want 2", len(got))
+	}
+}
+
+// The deep path answers from the file, so it still works for history the ring
+// has already evicted.
+func TestAuditQuery_DeepReadsBeyondTheRing(t *testing.T) {
+	rec := newTestAudit(t, &AuditConfig{RingSize: 2})
+	for _, id := range []string{"1", "2", "3", "4"} {
+		rec.Record(AuditEvent{ID: id, Event: AuditEventCallTool, Tool: "t" + id, Outcome: AuditOutcomeOK})
+	}
+	rec.Flush()
+
+	if got := rec.Query(AuditQuery{Text: "t1"}); len(got) != 0 {
+		t.Errorf("ring query found an evicted event: %+v", got)
+	}
+	got := rec.Query(AuditQuery{Text: "t1", Deep: true})
+	if len(got) != 1 || got[0].ID != "1" {
+		t.Errorf("deep query = %+v, want the evicted event 1", got)
+	}
+}
+
+// The sink must never be able to stall a tool call: past the queue bound,
+// events are dropped and counted rather than made to wait.
+func TestAuditRecorder_DropsRatherThanBlocks(t *testing.T) {
+	rec := newTestAudit(t, nil)
+	// Wedge the writer goroutine so the queue can actually fill.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	blocked := make(chan struct{})
+	rec.SetSink(func(AuditEvent) {
+		close(blocked)
+		wg.Wait()
+	})
+	rec.Record(AuditEvent{ID: "wedge"})
+	<-blocked
+
+	for i := 0; i < auditQueueSize+50; i++ {
+		rec.Record(AuditEvent{ID: "flood"})
+	}
+	if rec.Dropped() == 0 {
+		t.Error("a full queue did not drop any events")
+	}
+	rec.SetSink(nil)
+	wg.Done()
+}
+
+func TestAuditRecorder_ConcurrentRecord(t *testing.T) {
+	rec := newTestAudit(t, nil)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				rec.Record(AuditEvent{ID: "x", Event: AuditEventCallTool, Outcome: AuditOutcomeOK})
+			}
+		}()
+	}
+	wg.Wait()
+	rec.Flush()
+	// Concurrent readers must not race the writer.
+	_ = rec.Query(AuditQuery{Limit: 10})
+	if rec.Wrote()+rec.Dropped() != 160 {
+		t.Errorf("wrote %d + dropped %d != 160", rec.Wrote(), rec.Dropped())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config defaults
+// ---------------------------------------------------------------------------
+
+// An install predating this feature has no audit block at all and must start
+// logging without a settings.json migration.
+func TestAuditConfig_NilResolvesToEnabledDefaults(t *testing.T) {
+	var cfg *AuditConfig
+	got := cfg.resolve()
+	if !got.Enabled || !got.LogArgs {
+		t.Errorf("nil config resolved to enabled=%v log_args=%v, want both true", got.Enabled, got.LogArgs)
+	}
+	if got.LogLists {
+		t.Error("list events should default off")
+	}
+	if got.MaxResultPreviewBytes != 0 {
+		t.Errorf("result preview defaults to %d, want 0 (metadata only)", got.MaxResultPreviewBytes)
+	}
+	if got.MaxArgBytes != auditDefaultMaxArgBytes || got.RingSize != auditDefaultRingSize {
+		t.Errorf("size defaults not applied: %+v", got)
+	}
+	if got.Generations != auditDefaultGenerations || got.MaxFileBytes != auditDefaultMaxFileBytes {
+		t.Errorf("rotation defaults not applied: %+v", got)
+	}
+}
+
+func TestAuditConfig_ExplicitFalseIsHonored(t *testing.T) {
+	off := false
+	got := (&AuditConfig{LogArgs: &off}).resolve()
+	if got.LogArgs {
+		t.Error("explicit log_args=false was overridden by the default")
+	}
+	if !got.Enabled {
+		t.Error("unrelated field lost its default")
+	}
+}
+
+func TestAudit_ArgsOmittedWhenLogArgsDisabled(t *testing.T) {
+	off := false
+	mock := newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock},
+		&AuditConfig{LogArgs: &off})
+
+	if _, err := r.CallTool(context.Background(), "read_file", json.RawMessage(`{"path":"/secret"}`), testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if len(ev.Args) != 0 {
+		t.Errorf("args recorded despite log_args=false: %s", ev.Args)
+	}
+	if ev.Tool != "read_file" {
+		t.Errorf("tool name should still be recorded, got %q", ev.Tool)
+	}
+}
+
+func TestAudit_ResultPreviewOptIn(t *testing.T) {
+	mock := newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{"content":"hello world"}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock},
+		&AuditConfig{MaxResultPreviewBytes: 8})
+
+	if _, err := r.CallTool(context.Background(), "read_file", nil, testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.ResultPreview == "" {
+		t.Fatal("result preview not recorded despite opt-in")
+	}
+	if len(ev.ResultPreview) > 8 {
+		t.Errorf("result preview = %q, longer than the configured cap", ev.ResultPreview)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end over a real bridge socket
+// ---------------------------------------------------------------------------
+
+// The caller attribution is only worth anything if it survives the real
+// transport: the pid is read off the socket by the bridge server, not passed in
+// by the caller, so it can only be verified end to end.
+func TestAudit_CallerIdentityOverBridge(t *testing.T) {
+	dir := mkSandboxRelayHome(t)
+	store := NewSettingsStoreAt(dir)
+	if err := store.EnsureInitialized(); err != nil {
+		t.Fatalf("EnsureInitialized: %v", err)
+	}
+	if err := store.With(func(s *Settings) {
+		s.ExternalMcps = append(s.ExternalMcps, ExternalMcp{ID: "audite2e", DisplayName: "Audit E2E"})
+		s.Projects = append(s.Projects, Project{
+			ID:            "audit-e2e",
+			Name:          "audit-e2e",
+			Path:          dir,
+			AllowedMcpIDs: []string{"audite2e"},
+			Token:         testToken,
+			TokenHash:     hashToken(testToken),
+		})
+	}); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	mgr := NewExternalMcpManager(nil)
+	addMockConn(mgr, "audite2e", newMockConn("audite2e", simpleTools("probe"), okHandler(`{"content":[]}`)))
+	rec := newTestAudit(t, nil)
+	r := &appRouter{
+		store:    store,
+		tools:    mgr,
+		services: &fakeServiceReloader{},
+		enhanced: NewEnhancedServiceRegistry(nil),
+		onChange: func() {},
+		audit:    rec,
+	}
+
+	bs, err := bridge.NewBridgeServer(context.Background(), r)
+	if err != nil {
+		t.Fatalf("NewBridgeServer: %v", err)
+	}
+	go bs.Serve()
+	t.Cleanup(bs.Close)
+
+	client := bridge.NewClient(testToken)
+	if _, err := client.CallTool("probe", json.RawMessage(`{"q":1}`)); err != nil {
+		t.Fatalf("CallTool over bridge: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Outcome != AuditOutcomeOK {
+		t.Fatalf("outcome = %q (%s)", ev.Outcome, ev.Error)
+	}
+	// Client and server are the same process here, so the peer pid is ours.
+	if ev.Actor.PID != os.Getpid() {
+		t.Errorf("actor pid = %d, want %d", ev.Actor.PID, os.Getpid())
+	}
+	if ev.Actor.Proc == "" {
+		t.Error("actor process name not resolved from the peer pid")
+	}
+	if ev.Actor.ProjectID != "audit-e2e" {
+		t.Errorf("actor project = %q, want audit-e2e", ev.Actor.ProjectID)
+	}
+}

--- a/bridge/peer_darwin.go
+++ b/bridge/peer_darwin.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package bridge
+
+import (
+	"net"
+	"syscall"
+)
+
+// Darwin's LOCAL_PEERPID socket option, from <sys/un.h> and <sys/socket.h>.
+// Not exported by the syscall package, so they're spelled out here.
+const (
+	solLocal     = 0     // SOL_LOCAL
+	localPeerPID = 0x002 // LOCAL_PEERPID
+)
+
+// PeerPID returns the process id at the other end of a Unix-domain connection,
+// or 0 when it can't be determined (not a unix socket, peer already exited,
+// or the syscall failed).
+//
+// This is kernel-attested, unlike the caller-asserted Cwd on a BridgeRequest:
+// the pid comes from the socket itself, so a caller cannot claim to be another
+// process. It is used for audit attribution only and never for authorization —
+// a pid is reusable and racy, which is fine for "who called this" and not fine
+// for "may they call it".
+func PeerPID(conn net.Conn) int {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0
+	}
+	raw, err := unixConn.SyscallConn()
+	if err != nil {
+		return 0
+	}
+	var pid int
+	// Control runs fn with the socket fd, guaranteeing it stays valid for the
+	// duration; the inner error is captured separately from Control's own.
+	var inner error
+	if err := raw.Control(func(fd uintptr) {
+		pid, inner = syscall.GetsockoptInt(int(fd), solLocal, localPeerPID)
+	}); err != nil || inner != nil {
+		return 0
+	}
+	return pid
+}

--- a/bridge/peer_other.go
+++ b/bridge/peer_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package bridge
+
+import "net"
+
+// PeerPID is a no-op outside darwin: relay's tray host is macOS-only, and the
+// audit log treats a zero pid as "unknown caller" rather than an error. Kept so
+// the bridge package still builds and tests on other platforms.
+func PeerPID(net.Conn) int { return 0 }

--- a/bridge/peer_test.go
+++ b/bridge/peer_test.go
@@ -1,0 +1,96 @@
+package bridge
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The peer pid is what lets the audit log name the process behind a tool call.
+// It must be the *caller's* pid, read from the socket rather than asserted.
+func TestPeerPID_ReportsConnectingProcess(t *testing.T) {
+	// A short /tmp path: Unix socket paths cap at ~104 chars and t.TempDir()
+	// routinely exceeds that on macOS.
+	dir, err := os.MkdirTemp("/tmp", "peer")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	sock := filepath.Join(dir, "p.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	got := make(chan int, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			got <- -1
+			return
+		}
+		defer conn.Close()
+		got <- PeerPID(conn)
+	}()
+
+	client, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	pid := <-got
+	// Both ends are this process, so the peer pid is our own.
+	if want := os.Getpid(); pid != want {
+		t.Errorf("PeerPID = %d, want %d (this process)", pid, want)
+	}
+}
+
+// A non-Unix connection has no peer pid to read; "unknown" is a valid answer
+// and must not be an error.
+func TestPeerPID_ZeroForNonUnixConn(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	got := make(chan int, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			got <- -1
+			return
+		}
+		defer conn.Close()
+		got <- PeerPID(conn)
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	if pid := <-got; pid != 0 {
+		t.Errorf("PeerPID over TCP = %d, want 0", pid)
+	}
+}
+
+func TestCallerPIDContext(t *testing.T) {
+	ctx := context.Background()
+	if got := CallerPIDFromContext(ctx); got != 0 {
+		t.Errorf("bare context yields pid %d, want 0", got)
+	}
+	if got := CallerPIDFromContext(WithCallerPID(ctx, 4242)); got != 4242 {
+		t.Errorf("CallerPIDFromContext = %d, want 4242", got)
+	}
+	// A zero or negative pid means "unknown" and must not be stored.
+	if got := CallerPIDFromContext(WithCallerPID(ctx, 0)); got != 0 {
+		t.Errorf("zero pid was stored, got %d", got)
+	}
+}

--- a/bridge/server.go
+++ b/bridge/server.go
@@ -105,6 +105,11 @@ func (s *BridgeServer) handleConn(conn net.Conn) {
 	ctx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
 
+	// Resolve the peer pid once per connection rather than per request: it can't
+	// change for the life of the socket, and the getsockopt is pure overhead on
+	// every subsequent frame. Audit attribution only.
+	ctx = WithCallerPID(ctx, PeerPID(conn))
+
 	// Close the connection when the server (or this handler) is cancelled so a
 	// handler blocked in scanner.Scan() unblocks promptly at shutdown. Without
 	// this, StopAccepting() only cancels the context and closes the *listener* —

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -218,6 +218,28 @@ func CallerCwdFromContext(ctx context.Context) string {
 	return dir
 }
 
+type callerPIDCtxKey struct{}
+
+// WithCallerPID returns ctx carrying the process id at the far end of the
+// bridge connection (see PeerPID). Carried in the context for the same reason
+// as the cwd: the ToolRouter interface is implemented across repos and must not
+// grow a parameter for every piece of caller metadata. A zero pid means
+// "unknown" and returns ctx unchanged.
+//
+// Audit attribution only. Never consult this for an authorization decision.
+func WithCallerPID(ctx context.Context, pid int) context.Context {
+	if pid <= 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, callerPIDCtxKey{}, pid)
+}
+
+// CallerPIDFromContext returns the peer pid set by WithCallerPID, or 0.
+func CallerPIDFromContext(ctx context.Context) int {
+	pid, _ := ctx.Value(callerPIDCtxKey{}).(int)
+	return pid
+}
+
 // ToolRouter handles bridge requests. Implemented by the main app.
 type ToolRouter interface {
 	ListTools(ctx context.Context, token string) (json.RawMessage, error)

--- a/cmd/devui/main.go
+++ b/cmd/devui/main.go
@@ -120,6 +120,8 @@ var mockBridgeScript = `<script>
 (function () {
   var FIXTURE_CONFIG_TEXT = ` + jsString(fixtureConfigText) + `;
   var FIXTURE_TOOLS = ` + inlineJSON(fixtureMcpToolCacheTools) + `;
+  var FIXTURE_AUDIT = ` + inlineJSON(fixtureAuditEvents) + `;
+  var FIXTURE_AUDIT_STATUS = ` + inlineJSON(fixtureAuditStatus) + `;
   window.webkit = { messageHandlers: { ipc: { postMessage: function (raw) {
     var msg; try { msg = JSON.parse(raw); } catch (e) { console.warn('[devui] bad ipc', raw); return; }
     console.log('[devui ipc →]', msg);
@@ -133,6 +135,9 @@ var mockBridgeScript = `<script>
         break;
       case 'list_mcp_tools': window.onMcpToolsListed(msg.mcp_id, FIXTURE_TOOLS[msg.mcp_id] || []); break;
       case 'service_action': window.onServiceActionResult({ serviceId: msg.serviceId, actionId: msg.actionId, row: msg.row, ok: true }); break;
+      case 'query_audit': window.onAuditEvents(FIXTURE_AUDIT, FIXTURE_AUDIT_STATUS); break;
+      case 'export_audit': window.onAuditExported('/Users/you/Library/Application Support/relay/logs/audit/toolcalls-export-20260819-150000.jsonl'); break;
+      case 'reveal_audit_log': console.log('[devui] would reveal the audit log'); break;
       // add/update/remove/start/stop etc. — no-op in the harness, just logged above
     }
   }
@@ -154,6 +159,43 @@ var pollSimScript = `<script>
   setInterval(fire, 2000); // mirrors StatusPollInterval
 })();
 </script>`
+
+// fixtureAuditEvents covers every outcome the Tool Calls tab renders
+// differently: a plain success, a protocol-level tool error, a permission
+// denial, an unauthenticated attempt, a directory-auth grant, and a record
+// whose arguments were truncated.
+const fixtureAuditEvents = `[
+  {"id":"ev-1","ts":"2026-08-19T10:24:02.117Z","dur_ms":412,"event":"call_tool",
+   "actor":{"kind":"project","project_id":"proj-acme","project_name":"Acme Website","auth":"token","pid":41221,"proc":"relay","parent":"claude"},
+   "mcp_id":"fsmcp","tool":"read_file","args":{"path":"/Users/you/projects/acme/README.md"},"args_bytes":48,
+   "outcome":"ok","result_bytes":20431},
+
+  {"id":"ev-2","ts":"2026-08-19T10:23:58.004Z","dur_ms":1,"event":"call_tool",
+   "actor":{"kind":"project","project_id":"proj-internal","project_name":"Internal Tools","auth":"token","pid":41219,"proc":"relay","parent":"node"},
+   "mcp_id":"fsmcp","tool":"write_file","args":{"path":"/etc/hosts","content":"…"},"args_bytes":96,
+   "outcome":"denied","error":"access denied: tool 'write_file' is disabled for this token"},
+
+  {"id":"ev-3","ts":"2026-08-19T10:23:44.882Z","dur_ms":88,"event":"call_tool",
+   "actor":{"kind":"project","project_id":"proj-internal","project_name":"Internal Tools","auth":"cwd","cwd":"/Users/you/projects/internal/pkg","pid":41210,"proc":"relay","parent":"zsh"},
+   "mcp_id":"fsmcp","tool":"list_dir","args":{"path":"/Users/you/projects/internal/pkg"},"args_bytes":52,
+   "outcome":"ok","result_bytes":812},
+
+  {"id":"ev-4","ts":"2026-08-19T10:22:31.412Z","dur_ms":1503,"event":"call_tool",
+   "actor":{"kind":"project","project_id":"proj-acme","project_name":"Acme Website","auth":"token","pid":41180,"proc":"relay","parent":"claude"},
+   "mcp_id":"macmcp","tool":"calendar_events","args":{"range":"today","api_key":"[redacted]"},"args_bytes":64,
+   "outcome":"ok","result_bytes":4096,"result_is_error":true},
+
+  {"id":"ev-5","ts":"2026-08-19T10:21:09.230Z","dur_ms":0,"event":"call_tool",
+   "actor":{"kind":"unknown","auth":"token","pid":40997,"proc":"curl","parent":"zsh"},
+   "tool":"read_file","outcome":"unauthorized","error":"invalid token"},
+
+  {"id":"ev-6","ts":"2026-08-19T10:20:55.100Z","dur_ms":233,"event":"call_tool",
+   "actor":{"kind":"project","project_id":"proj-acme","project_name":"Acme Website","auth":"token","pid":40940,"proc":"relay","parent":"claude"},
+   "mcp_id":"fsmcp","tool":"write_file","args":"{\"path\":\"/Users/you/projects/acme/bundle.js\",\"content\":\"(function(){var a=1;","args_bytes":184320,"args_truncated":true,
+   "outcome":"ok","result_bytes":32}
+]`
+
+const fixtureAuditStatus = `{"enabled":true,"path":"/Users/you/Library/Application Support/relay/logs/audit/toolcalls.jsonl","dropped":0,"recorded":6,"log_args":true,"log_lists":false}`
 
 // fixtureMcpToolCacheTools is the tool list keyed by MCP id, served to
 // list_mcp_tools requests (the project tri-state picker).

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -1,0 +1,172 @@
+# Tool-call audit log
+
+Every tool call that passes through relay is recorded: what was called, by which
+project, from which process, with what arguments, and whether it was allowed.
+
+Read it in the tray under **Settings → Tool Calls**, or from a terminal with
+`relay audit`.
+
+## What is recorded
+
+All three of these produce a record, because a refusal is usually the more
+interesting event:
+
+| Outcome | Meaning |
+|---|---|
+| `ok` | The call reached the MCP and returned |
+| `error` | The call failed (transport error, unknown tool, or the MCP errored) |
+| `denied` | A resolved credential was refused a tool it may not use |
+| `unauthorized` | The credential itself did not resolve |
+
+One JSONL line per event:
+
+```json
+{
+  "id": "9c1f…",
+  "ts": "2026-08-19T10:22:31.412Z",
+  "dur_ms": 412,
+  "event": "call_tool",
+  "actor": {
+    "kind": "project",
+    "project_id": "proj_7f2a",
+    "project_name": "relay",
+    "auth": "token",
+    "pid": 41221,
+    "proc": "relay",
+    "parent": "claude"
+  },
+  "mcp_id": "fsmcp",
+  "tool": "read_file",
+  "args": { "path": "/Users/me/notes.md" },
+  "args_bytes": 34,
+  "outcome": "ok",
+  "result_bytes": 20431
+}
+```
+
+### The actor
+
+Everything in `actor` comes from relay's own resolution or from the kernel, not
+from anything the caller asserted:
+
+- `project_id` / `project_name` are taken from the authenticated `StoredToken`,
+  the same value relay injects into `_meta.project_id`.
+- `auth` is how the caller was identified: `token` (a project token was
+  presented), `cwd` ([directory auth](tokens.md#directory-auth-allow_cwd_auth)),
+  or `service` (a full-access service token).
+- `cwd` appears only for directory auth. That grant has no deliberate credential
+  hand-off to point at afterwards, so the log is its audit trail.
+- `pid` is read off the bridge socket with `getsockopt(LOCAL_PEERPID)`, so it
+  cannot be forged by the caller. `proc` and `parent` are resolved from it via
+  `proc_pidinfo`.
+
+`parent` is usually the field you want. `relay mcp` opens a fresh connection —
+and often a fresh process — per call, so `proc` names a throwaway subprocess
+while `parent` names the agent that actually asked for the tool.
+
+The pid is for attribution only. It is never consulted for an authorization
+decision: pids are reusable and racy, which is fine for "who called this" and
+not fine for "may they call it".
+
+### Arguments and results
+
+**Arguments** are recorded with values under credential-like keys replaced by
+`[redacted]`. Keys are matched as case-insensitive substrings, so `mcp_token`,
+`X-Api-Key`, and `userPassword` are all caught. Redaction walks nested objects
+and arrays. The built-in set is `token`, `secret`, `password`, `passwd`,
+`apikey`, `api_key`, `api-key`, `authorization`, `credential`, `privatekey`,
+`private_key`, `cookie`, `bearer`, `passphrase`; add your own with
+`audit.redact_keys`.
+
+Over `max_arg_bytes` (4 KiB by default), arguments are stored as a truncated
+string with `args_truncated: true` and the original size in `args_bytes`. Every
+line stays valid JSON either way.
+
+**Results** are recorded as size and `isError` only. Tool results carry file
+contents, mail bodies, and calendar entries; storing them by default would make
+this the most sensitive file on the machine. Set
+`audit.max_result_preview_bytes` to store a capped prefix when an investigation
+needs one.
+
+`isError` is probed from the MCP result rather than the Go error: a tool that
+fails *inside* the protocol returns a normal result with that flag set, so
+without the probe every application-level failure would read as a success.
+
+## Configuration
+
+Optional `audit` block in `settings.json`. Absent means defaults, so an install
+predating this feature starts logging with no migration. Changes take effect on
+relay restart.
+
+```jsonc
+{
+  "audit": {
+    "enabled": true,
+    "log_args": true,
+    "log_lists": false,
+    "max_arg_bytes": 4096,
+    "max_result_preview_bytes": 0,
+    "ring_size": 1000,
+    "max_file_bytes": 33554432,
+    "generations": 5,
+    "redact_keys": []
+  }
+}
+```
+
+`log_lists` covers `list_tools` and `list_skills` events — what tool surface a
+credential was shown. Off by default because skill regeneration lists the tool
+surface for every project on every MCP reconcile, which buries the calls that
+matter.
+
+## Storage and retention
+
+`<config-dir>/logs/audit/toolcalls.jsonl`, mode 0600, size-rotated. At the
+defaults that is 32 MiB per file with five backups (`.1` … `.5`), so roughly
+160 MiB. Retention is by size rather than by time: no scanning pass, and the
+bound is the one that actually matters on a laptop.
+
+A bounded in-memory ring of the most recent `ring_size` events backs the Tool
+Calls tab's first paint and its live tail, so opening the tab never re-reads the
+file.
+
+## Fail-open, visibly
+
+Events are handed to a single writer goroutine over a bounded channel. If that
+channel is full the event is **dropped and counted** — a tool call is never
+delayed by, and never fails because of, the audit sink. The drop count is shown
+as a warning in the Tool Calls tab, because an incomplete log that looks
+complete is worse than no log.
+
+This is a deliberate choice for local use: logging must not be able to break
+your tooling. It is the wrong choice for a remote caller, where the trust
+boundary justifies refusing a call that cannot be recorded; a fail-closed mode
+is planned alongside remote access.
+
+If the log file itself can't be opened at startup, relay logs the error and runs
+with auditing off. The Tool Calls tab says so rather than showing an empty table.
+
+## Reading it from a terminal
+
+```
+relay audit                          # 50 most recent, as a table
+relay audit --tail 200 --outcome denied
+relay audit --project proj_7f2a --mcp fsmcp
+relay audit --grep read_file --json  # JSONL, oldest first, for piping
+relay audit --path                   # print the log path and exit
+```
+
+`relay audit` reads the file directly rather than going over the bridge, so it
+works when the tray is stopped — which is when you are most likely to want it.
+
+## Where it hooks in
+
+One place: `appRouter.CallTool` in `router.go`. Every tool invocation in the
+ecosystem funnels through it — `relay mcp`, `relay mcp call`, relayLLM's MCP
+client, project shells — because that is also where auth is resolved and the
+permission check is made. `ListTools` and `ListSkillBuckets` are instrumented
+the same way.
+
+Instrumentation goes through nil-safe helpers on `*auditCall` (`audit_call.go`),
+so a router built without a recorder behaves exactly as it did before auditing
+existed, and the router code has no `if audit != nil` noise.

--- a/docs/decisions/000-readme.md
+++ b/docs/decisions/000-readme.md
@@ -32,6 +32,10 @@ ADR that references the old one. Do not edit accepted ADRs in place.
 - [007 — Relay is the sole broker of project tokens](007-project-token-brokering.md):
   Eve references projects by id only; relay resolves and injects the scoped
   project token just-in-time and never hands it to the frontend.
+- [008 — Tool-call audit log at the router chokepoint](008-tool-call-audit-log.md):
+  every call, denial, and auth failure is logged at `appRouter.CallTool`;
+  attribution from relay + the kernel, redacted args, metadata-only results,
+  fail-open but visibly so.
 
 ## Format
 

--- a/docs/decisions/008-tool-call-audit-log.md
+++ b/docs/decisions/008-tool-call-audit-log.md
@@ -1,0 +1,114 @@
+# ADR-008: Tool-call audit log at the router chokepoint
+
+**Status:** Accepted
+**Date:** 2026-08-19
+
+## Context
+
+Relay brokers every MCP tool call in the ecosystem but kept no record of them.
+The security model was entirely preventive: a project token scopes what a caller
+may reach (ADR-007), `checkToolAccess` enforces it, and that was the end of it.
+There was no way to answer, after the fact, what an LLM actually did — which
+files it read, which tools it was refused, or which process asked.
+
+That gap becomes load-bearing with the planned remote client: a machine outside
+this host reaching relay for tool access is exactly the situation where "we
+prevent the wrong calls" is not a sufficient answer on its own. Detection has to
+exist before the attack surface widens.
+
+Three properties had to hold:
+
+1. **Complete.** No transport may be able to reach a tool without being logged.
+2. **Attributed.** Each record must name the project and the calling process
+   from relay's own knowledge, not from anything the caller asserts.
+3. **Harmless.** Adding a log must not be able to break, slow, or fail a tool
+   call, and must not itself become a new place secrets accumulate.
+
+## Decision
+
+### One instrumentation point
+
+Log at `appRouter.CallTool`. Every path — the `relay mcp` stdio server,
+`relay mcp call`, relayLLM's MCP client, project shells, and any future remote
+client — funnels through the bridge into that method, and it is also where auth
+is resolved and the permission check is made. Instrumenting anywhere else would
+mean either duplicating the logic per transport or logging before relay knows
+who the caller is.
+
+`ListTools` and `ListSkillBuckets` are instrumented the same way, off by
+default (`audit.log_lists`).
+
+### Refusals are events
+
+A `denied` (credential refused a tool) or `unauthorized` (credential did not
+resolve) record is written with the same reliability as a success. The naive
+shape of this feature logs completed calls and silently drops the refusals,
+which are the records a security review is looking for.
+
+### Attribution from relay and the kernel, never the caller
+
+The project id comes from the resolved `StoredToken`, the same value relay
+injects into `_meta.project_id`. The caller's pid is read off the Unix socket
+with `getsockopt(LOCAL_PEERPID)` in the bridge server and carried in the request
+context; process and parent names come from `proc_pidinfo`. Nothing self-reported
+is trusted, with one marked exception: the working directory recorded for a
+directory-auth grant, which is caller-asserted by construction and already
+documented as such in `docs/tokens.md`.
+
+The pid is attribution only and is never consulted for authorization. Pids are
+reusable and racy — adequate for "who called this", not for "may they call it".
+
+### Redacted arguments, metadata-only results
+
+Arguments are recorded with credential-like keys redacted by case-insensitive
+substring match, capped at 4 KiB. Results are recorded as size and `isError`
+only, with a capped preview available behind an explicit opt-in.
+
+The asymmetry is deliberate. Arguments are what the model *asked for* and are
+the point of the log; results are what came back, and tool results carry file
+contents, mail bodies, and calendar entries. Logging them by default would turn
+the audit log into the highest-value file on the machine and quietly undo the
+scoping the project token exists to provide.
+
+### Fail open, and say so
+
+Events cross to a single writer goroutine over a bounded channel. A full queue
+drops the event and increments a counter; a broken sink at startup means relay
+runs with auditing off. In both cases the state is surfaced in the Tool Calls
+tab rather than hidden.
+
+Fail-open is correct for the local case — an audit log that can wedge every
+agent on the machine when a disk fills is a worse failure than a gap in the
+record — but it is only defensible because the gap is *visible*. An incomplete
+log that looks complete would be worse than no log at all.
+
+### Nil recorder is the no-op
+
+Instrumentation goes through nil-safe methods on `*auditCall`. A router built
+without a recorder behaves exactly as before, and `router.go` carries no
+`if audit != nil` branching.
+
+## Consequences
+
+- Relay gains a new persistent artifact under `<config-dir>/logs/audit/`,
+  0600, size-rotated with several generations. `rotatingWriter` grew a
+  `generations` field; existing callers pass 1 and are unchanged.
+- `bridge.ToolRouter` did **not** change. Peer pid rides in the context, the
+  same technique the caller-asserted cwd already used, so cross-repo
+  implementers are unaffected.
+- The audit log is a new confidentiality surface. It is 0600 and holds redacted
+  arguments and no results by default, but "grep the audit log" is now a way to
+  learn what a project has been doing, and `audit.max_result_preview_bytes`
+  should be turned on deliberately and turned back off afterwards.
+- Redaction is heuristic. A secret passed under a key that does not look like a
+  credential (`"value"`, `"input"`) will be logged. The cap bounds the exposure;
+  the heuristic does not eliminate it.
+- Fail-open means the log is not admissible as proof that something did *not*
+  happen. A future `audit.required` mode for remote callers is where that
+  guarantee gets bought, at the cost of refusing calls that cannot be recorded.
+
+## See also
+
+- `docs/audit-log.md` — operator-facing reference.
+- ADR-007 — the token brokering model the actor attribution rests on.
+- `docs/tokens.md` — the credential inventory, including directory auth.

--- a/ipc_audit.go
+++ b/ipc_audit.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Tool Calls tab IPC handlers
+// ---------------------------------------------------------------------------
+
+// ipcAuditQueryMsg is the Tool Calls tab's filter payload. It mirrors
+// AuditQuery so the UI can send its filter state verbatim.
+type ipcAuditQueryMsg struct {
+	Type string `json:"type"`
+	AuditQuery
+}
+
+// auditStatus is the header payload for the Tool Calls tab: enough for the UI
+// to tell the difference between "no calls yet" and "not logging".
+type auditStatus struct {
+	Enabled  bool   `json:"enabled"`
+	Path     string `json:"path"`
+	Dropped  uint64 `json:"dropped"`
+	Recorded uint64 `json:"recorded"`
+	LogArgs  bool   `json:"log_args"`
+	LogLists bool   `json:"log_lists"`
+}
+
+func auditStatusOf(rec *AuditRecorder) auditStatus {
+	st := auditStatus{
+		Enabled:  rec.Enabled(),
+		Path:     rec.Path(),
+		Dropped:  rec.Dropped(),
+		Recorded: rec.Wrote(),
+	}
+	if rec != nil {
+		st.LogArgs = rec.cfg.LogArgs
+		st.LogLists = rec.cfg.LogLists
+	}
+	return st
+}
+
+// ipcQueryAudit answers the Tool Calls tab's list request. A deep query touches
+// the log file, so it runs off the UI thread; a ring query is a slice copy and
+// answers inline.
+func ipcQueryAudit(ctx *IPCContext, raw json.RawMessage) {
+	msg, ok := unmarshalIPC[ipcAuditQueryMsg](raw, MsgQueryAudit)
+	if !ok {
+		return
+	}
+	rec := ctx.Audit
+	if !rec.Enabled() {
+		ctx.UI.EmitEvent("onAuditEvents", []AuditEvent{}, auditStatusOf(rec))
+		return
+	}
+	if msg.Deep {
+		ctx.GoFunc(func() {
+			events := rec.Query(msg.AuditQuery)
+			dispatchEmit(ctx, "onAuditEvents", events, auditStatusOf(rec))
+		})
+		return
+	}
+	ctx.UI.EmitEvent("onAuditEvents", rec.Query(msg.AuditQuery), auditStatusOf(rec))
+}
+
+// ipcExportAudit writes a filtered snapshot to a timestamped JSONL file next to
+// the log and reveals it. Exporting a *filtered* view is the point: handing
+// someone the whole log to answer one question over-shares by default.
+func ipcExportAudit(ctx *IPCContext, raw json.RawMessage) {
+	msg, ok := unmarshalIPC[ipcAuditQueryMsg](raw, MsgExportAudit)
+	if !ok {
+		return
+	}
+	rec := ctx.Audit
+	if !rec.Enabled() {
+		ctx.UI.EmitEvent("onAuditError", "auditing is disabled")
+		return
+	}
+	// Export always searches history, not just what the ring happens to hold.
+	q := msg.AuditQuery
+	q.Deep = true
+	q.Limit = intOr(q.Limit, 100000)
+
+	ctx.GoFunc(func() {
+		rec.Flush()
+		path, err := exportAuditEvents(rec, q)
+		if err != nil {
+			dispatchEmit(ctx, "onAuditError", err.Error())
+			return
+		}
+		ctx.Platform.DispatchToMain(func() {
+			ctx.Platform.OpenURL(fileURL(filepath.Dir(path)))
+			ctx.UI.EmitEvent("onAuditExported", path)
+		})
+	})
+}
+
+// fileURL renders a filesystem path as a file:// URL, escaping spaces and other
+// characters that would otherwise break the hand-off to the platform opener.
+func fileURL(path string) string {
+	return (&url.URL{Scheme: "file", Path: path}).String()
+}
+
+// exportAuditEvents writes matching events as JSONL and returns the file path.
+func exportAuditEvents(rec *AuditRecorder, q AuditQuery) (string, error) {
+	events := rec.Query(q)
+	dir := filepath.Dir(rec.Path())
+	name := fmt.Sprintf("toolcalls-export-%s.jsonl", time.Now().UTC().Format("20060102-150405"))
+	path := filepath.Join(dir, name)
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create export: %w", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	// Oldest-first in the export: a log read top-to-bottom should run forwards
+	// in time, even though the UI shows newest-first.
+	for i := len(events) - 1; i >= 0; i-- {
+		if err := enc.Encode(events[i]); err != nil {
+			return "", fmt.Errorf("write export: %w", err)
+		}
+	}
+	return path, nil
+}
+
+// ipcRevealAuditLog opens the audit log's directory in Finder.
+func ipcRevealAuditLog(ctx *IPCContext, _ json.RawMessage) {
+	rec := ctx.Audit
+	if !rec.Enabled() {
+		ctx.UI.EmitEvent("onAuditError", "auditing is disabled")
+		return
+	}
+	ctx.Platform.OpenURL(fileURL(filepath.Dir(rec.Path())))
+}

--- a/ipc_handlers.go
+++ b/ipc_handlers.go
@@ -122,24 +122,27 @@ func (a *App) EmitEvent(name string, args ...interface{}) {
 
 // IPCContext provides dependencies to IPC handlers, replacing *App coupling.
 type IPCContext struct {
-	Ctx                     context.Context
-	Store                   SettingsStore
-	UI                      SettingsUI
-	Platform                Platform
-	Registry                ServiceManager
-	Enhanced                *EnhancedServiceRegistry
-	UpdateMenu              func()
-	PushServiceStatusBatch  func() // re-poll and emit after an action lands
-	GoFunc                  func(fn func()) // tracked goroutine launcher
-	NotifyReconcile         func(string) error
-	NotifyReloadMcp         func(id, secret string) error
+	Ctx                    context.Context
+	Store                  SettingsStore
+	UI                     SettingsUI
+	Platform               Platform
+	Registry               ServiceManager
+	Enhanced               *EnhancedServiceRegistry
+	UpdateMenu             func()
+	PushServiceStatusBatch func()          // re-poll and emit after an action lands
+	GoFunc                 func(fn func()) // tracked goroutine launcher
+	NotifyReconcile        func(string) error
+	NotifyReloadMcp        func(id, secret string) error
 	// Tools is the live tool registry used by the Projects tab tri-state
 	// picker. nil means "no tool data available" — handlers degrade by
 	// emitting empty lists rather than panicking.
-	Tools                   MCPToolsProvider
+	Tools MCPToolsProvider
 	// SkillLister is the same interface skills.go uses; threaded here so the
 	// Regen Now button can run without re-importing *appRouter.
-	SkillLister             SkillLister
+	SkillLister SkillLister
+	// Audit backs the Tool Calls tab. Nil when auditing is off; every method
+	// on the recorder is nil-safe, so handlers don't guard on it.
+	Audit *AuditRecorder
 }
 
 // withSettingsReconcile atomically mutates settings, then asynchronously sends
@@ -229,10 +232,10 @@ type ipcUpdateServiceAutostartMsg struct {
 // ---------------------------------------------------------------------------
 
 const (
-	MsgAddExternalMcp        = "add_external_mcp"
-	MsgAuthenticateMcp       = "authenticate_mcp"
-	MsgRemoveExternalMcp     = "remove_external_mcp"
-	MsgResetMcpPermissions   = "reset_mcp_permissions"
+	MsgAddExternalMcp      = "add_external_mcp"
+	MsgAuthenticateMcp     = "authenticate_mcp"
+	MsgRemoveExternalMcp   = "remove_external_mcp"
+	MsgResetMcpPermissions = "reset_mcp_permissions"
 
 	MsgAddService             = "add_service"
 	MsgRemoveService          = "remove_service"
@@ -249,6 +252,11 @@ const (
 	MsgRegenProjectSkill          = "regen_project_skill"
 	MsgUpdateProjectDisabledTools = "update_project_disabled_tools"
 	MsgListMcpTools               = "list_mcp_tools"
+
+	// Tool Calls / audit log (ipc_audit.go)
+	MsgQueryAudit     = "query_audit"
+	MsgExportAudit    = "export_audit"
+	MsgRevealAuditLog = "reveal_audit_log"
 )
 
 // ---------------------------------------------------------------------------
@@ -283,6 +291,11 @@ var ipcHandlers = map[string]func(*IPCContext, json.RawMessage){
 	MsgRegenProjectSkill:          ipcRegenProjectSkill,
 	MsgUpdateProjectDisabledTools: ipcUpdateProjectDisabledTools,
 	MsgListMcpTools:               ipcListMcpTools,
+
+	// Tool Calls (ipc_audit.go)
+	MsgQueryAudit:     ipcQueryAudit,
+	MsgExportAudit:    ipcExportAudit,
+	MsgRevealAuditLog: ipcRevealAuditLog,
 }
 
 // onSettingsIpc is called from the WKWebView IPC handler.
@@ -302,4 +315,3 @@ func (a *App) onSettingsIpc(body string) {
 	}
 	handler(a.ipcCtx, raw)
 }
-

--- a/log_rotate.go
+++ b/log_rotate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"sync"
 )
@@ -13,27 +14,41 @@ import (
 const maxLogBytes = 8 << 20 // 8 MiB
 
 // rotatingWriter is a minimal size-capped log writer. When a write would push
-// the file past maxBytes, the current file is renamed to "<path>.1" (replacing
-// any prior backup) and a fresh file is started. Safe for concurrent use: slog
-// writes relay's own log from many goroutines, and a managed service's merged
-// stdout+stderr arrive on a single copy goroutine.
+// the file past maxBytes, the current file is renamed to "<path>.1" and the
+// older generations shift down ("<path>.1" → "<path>.2", and so on) until
+// generations is reached, at which point the oldest is discarded. Safe for
+// concurrent use: slog writes relay's own log from many goroutines, and a
+// managed service's merged stdout+stderr arrive on a single copy goroutine.
 type rotatingWriter struct {
 	mu       sync.Mutex
 	path     string
 	maxBytes int64
-	f        *os.File
-	size     int64
+	// generations is how many rotated backups to retain. 1 keeps only "<path>.1"
+	// (relay's own log and service logs, where recent output is what matters);
+	// the audit log keeps more because history there is the point.
+	generations int
+	f           *os.File
+	size        int64
 }
 
 // openRotatingLog opens (creating/appending) a size-capped log file at path,
-// using the default maxLogBytes cap.
+// using the default maxLogBytes cap and a single retained generation.
 func openRotatingLog(path string) (*rotatingWriter, error) {
 	return openRotatingLogSized(path, maxLogBytes)
 }
 
 // openRotatingLogSized is openRotatingLog with an explicit cap (used by tests).
 func openRotatingLogSized(path string, maxBytes int64) (*rotatingWriter, error) {
-	w := &rotatingWriter{path: path, maxBytes: maxBytes}
+	return openRotatingLogGenerations(path, maxBytes, 1)
+}
+
+// openRotatingLogGenerations is openRotatingLogSized with an explicit backup
+// count. generations below 1 is clamped to 1.
+func openRotatingLogGenerations(path string, maxBytes int64, generations int) (*rotatingWriter, error) {
+	if generations < 1 {
+		generations = 1
+	}
+	w := &rotatingWriter{path: path, maxBytes: maxBytes, generations: generations}
 	if err := w.reopen(); err != nil {
 		return nil, err
 	}
@@ -63,7 +78,7 @@ func (w *rotatingWriter) Write(p []byte) (int, error) {
 	// empty, so a single oversized record is written rather than looping.
 	if w.size > 0 && w.size+int64(len(p)) > w.maxBytes {
 		w.f.Close()
-		_ = os.Rename(w.path, w.path+".1") // replace prior backup; one generation kept
+		w.shiftGenerations()
 		if err := w.reopen(); err != nil {
 			return 0, err
 		}
@@ -71,6 +86,26 @@ func (w *rotatingWriter) Write(p []byte) (int, error) {
 	n, err := w.f.Write(p)
 	w.size += int64(n)
 	return n, err
+}
+
+// shiftGenerations ages the backups down by one and moves the current file
+// into ".1". The oldest generation is dropped by being overwritten via rename.
+// Caller holds mu and has already closed the current file.
+//
+// Renames are best-effort: a missing generation just means the log hasn't
+// rotated that many times yet, which is not an error worth failing a write for.
+func (w *rotatingWriter) shiftGenerations() {
+	gens := w.generations
+	if gens < 1 {
+		gens = 1
+	}
+	for i := gens - 1; i >= 1; i-- {
+		_ = os.Rename(
+			fmt.Sprintf("%s.%d", w.path, i),
+			fmt.Sprintf("%s.%d", w.path, i+1),
+		)
+	}
+	_ = os.Rename(w.path, w.path+".1")
 }
 
 func (w *rotatingWriter) Close() error {

--- a/log_rotate_test.go
+++ b/log_rotate_test.go
@@ -98,3 +98,74 @@ func TestRotatingWriter_ConcurrentWritesAreSafe(t *testing.T) {
 		t.Fatalf("concurrent write failed: %v", e)
 	}
 }
+
+// Audit retention keeps several generations, unlike relay's own log which keeps
+// one. Each rotation must age the backups down rather than clobber ".1".
+func TestRotatingWriter_KeepsMultipleGenerations(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+
+	w, err := openRotatingLogGenerations(path, 8, 3)
+	if err != nil {
+		t.Fatalf("openRotatingLogGenerations: %v", err)
+	}
+	defer w.Close()
+
+	// Each write exceeds the cap, so every write after the first rotates.
+	for _, line := range []string{"aaaaaaaaaa\n", "bbbbbbbbbb\n", "cccccccccc\n", "dddddddddd\n"} {
+		if _, err := w.Write([]byte(line)); err != nil {
+			t.Fatalf("write %q: %v", line, err)
+		}
+	}
+
+	// Newest content in the live file, older content aging down .1 → .3.
+	want := map[string]string{
+		path:        "dddddddddd\n",
+		path + ".1": "cccccccccc\n",
+		path + ".2": "bbbbbbbbbb\n",
+		path + ".3": "aaaaaaaaaa\n",
+	}
+	for p, contents := range want {
+		got, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		if string(got) != contents {
+			t.Errorf("%s = %q, want %q", p, got, contents)
+		}
+	}
+
+	// The 4th generation is beyond the retention bound and must not exist.
+	if _, err := os.Stat(path + ".4"); !os.IsNotExist(err) {
+		t.Errorf("generation .4 exists despite a retention of 3")
+	}
+}
+
+// The default rotator keeps exactly one backup, unchanged by the generations
+// support.
+func TestRotatingWriter_DefaultKeepsOneGeneration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "relay.log")
+
+	w, err := openRotatingLogSized(path, 8)
+	if err != nil {
+		t.Fatalf("openRotatingLogSized: %v", err)
+	}
+	defer w.Close()
+
+	for _, line := range []string{"aaaaaaaaaa\n", "bbbbbbbbbb\n", "cccccccccc\n"} {
+		if _, err := w.Write([]byte(line)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if _, err := os.Stat(path + ".2"); !os.IsNotExist(err) {
+		t.Error("single-generation writer created a .2 backup")
+	}
+	got, err := os.ReadFile(path + ".1")
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(got) != "bbbbbbbbbb\n" {
+		t.Errorf(".1 = %q, want the previous generation", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -54,10 +54,12 @@ func main() {
 		runMcpOrServer(args[1:])
 	case "mcpExec":
 		runMcpExec(args[1:])
+	case "audit":
+		runAuditCommand(args[1:])
 	case "mcpList":
 		exitError("mcpList has been removed. Use: relay mcpExec --token <TOKEN> --list")
 	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\nUsage: relay [--config-dir DIR] [service|mcp|mcpExec]\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown command: %s\nUsage: relay [--config-dir DIR] [service|mcp|mcpExec|audit]\n", args[0])
 		os.Exit(1)
 	}
 }

--- a/router.go
+++ b/router.go
@@ -64,11 +64,15 @@ func checkToolAccess(tok *StoredToken, mcpID, toolName string) error {
 // ---------------------------------------------------------------------------
 
 type appRouter struct {
-	store         SettingsStore
-	tools         ToolManager
-	services      ServiceReloader
-	enhanced      *EnhancedServiceRegistry
-	onChange      func()
+	store    SettingsStore
+	tools    ToolManager
+	services ServiceReloader
+	enhanced *EnhancedServiceRegistry
+	onChange func()
+	// audit records every tool call, denial, and auth failure that passes
+	// through this router. Nil disables auditing entirely — every call site
+	// goes through nil-safe helpers, so nothing branches on it.
+	audit         *AuditRecorder
 	serviceTokens serviceTokenStore
 }
 
@@ -177,10 +181,15 @@ func (r *appRouter) resolveCwdAuth(ctx context.Context) (*StoredToken, *Settings
 }
 
 func (r *appRouter) ListTools(ctx context.Context, token string) (json.RawMessage, error) {
+	au := r.beginAudit(ctx, AuditEventListTools)
+
 	stored, settings, err := r.resolveAuth(ctx, token)
 	if err != nil {
+		au.setUnauthenticated(ctx, token)
+		au.done(AuditOutcomeUnauthorized, err)
 		return nil, err
 	}
+	au.setActor(ctx, stored, settings, token)
 
 	isServiceToken := stored.Name == serviceTokenName
 	tools := make([]mcp.Tool, 0)
@@ -198,6 +207,8 @@ func (r *appRouter) ListTools(ctx context.Context, token string) (json.RawMessag
 		}
 	}
 
+	au.setToolCount(len(tools))
+	au.done(AuditOutcomeOK, nil)
 	return json.Marshal(tools)
 }
 
@@ -210,10 +221,15 @@ func (r *appRouter) ListTools(ctx context.Context, token string) (json.RawMessag
 // noise like "Generate" from generate_image; uncategorized tools route by
 // their MCP instead). Buckets are returned in a deterministic order.
 func (r *appRouter) ListSkillBuckets(ctx context.Context, token string) ([]SkillBucket, error) {
+	au := r.beginAudit(ctx, AuditEventListSkills)
+
 	stored, settings, err := r.resolveAuth(ctx, token)
 	if err != nil {
+		au.setUnauthenticated(ctx, token)
+		au.done(AuditOutcomeUnauthorized, err)
 		return nil, err
 	}
+	au.setActor(ctx, stored, settings, token)
 
 	isServiceToken := stored.Name == serviceTokenName
 	groups := map[string][]mcp.Tool{}
@@ -254,38 +270,58 @@ func (r *appRouter) ListSkillBuckets(ctx context.Context, token string) ([]Skill
 	}
 
 	buckets := make([]SkillBucket, 0, len(order))
+	total := 0
 	for _, slug := range order {
 		buckets = append(buckets, *bySlug[slug])
+		total += len(bySlug[slug].Tools)
 	}
+	au.setToolCount(total)
+	au.done(AuditOutcomeOK, nil)
 	return buckets, nil
 }
 
 func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMessage, token string) (json.RawMessage, error) {
-	stored, _, err := r.resolveAuth(ctx, token)
+	// Every tool call in the ecosystem funnels through here, which makes this
+	// the one place auditing has to be correct. Note that the refusals are
+	// audited too: a denied or unauthenticated call is precisely what a
+	// security review is looking for.
+	au := r.beginAudit(ctx, AuditEventCallTool)
+	au.setTool(name, args)
+
+	stored, settings, err := r.resolveAuth(ctx, token)
 	if err != nil {
+		au.setUnauthenticated(ctx, token)
+		au.done(AuditOutcomeUnauthorized, err)
 		return nil, err
 	}
+	au.setActor(ctx, stored, settings, token)
 
 	isServiceToken := stored.Name == serviceTokenName
 
 	// Check external MCPs.
 	extID, extMcp := r.tools.FindToolOwner(name)
-	if extMcp != nil {
-		if !isServiceToken {
-			if err := checkToolAccess(stored, extID, name); err != nil {
-				return nil, err
-			}
+	if extMcp == nil {
+		err := fmt.Errorf("unknown tool: %s", name)
+		au.done(AuditOutcomeError, err)
+		return nil, err
+	}
+	au.setMcp(extID)
+
+	if !isServiceToken {
+		if err := checkToolAccess(stored, extID, name); err != nil {
+			au.done(AuditOutcomeDenied, err)
+			return nil, err
 		}
-
-		// Inject per-token context as _meta for this MCP, plus the authenticated
-		// project id so an MCP can attribute the call to a project without
-		// trusting LLM-supplied values. Relay is the project authority here.
-		meta := mergeProjectID(stored.Context[extID], stored.ProjectID)
-
-		return r.tools.CallTool(ctx, extID, name, args, meta)
 	}
 
-	return nil, fmt.Errorf("unknown tool: %s", name)
+	// Inject per-token context as _meta for this MCP, plus the authenticated
+	// project id so an MCP can attribute the call to a project without
+	// trusting LLM-supplied values. Relay is the project authority here.
+	meta := mergeProjectID(stored.Context[extID], stored.ProjectID)
+
+	result, err := r.tools.CallTool(ctx, extID, name, args, meta)
+	au.doneResult(result, err)
+	return result, err
 }
 
 // mergeProjectID returns base with a top-level "project_id" added when

--- a/settings.go
+++ b/settings.go
@@ -14,6 +14,11 @@ type Settings struct {
 	Services     []ServiceConfig `json:"services"`
 	Projects     []Project       `json:"projects"`
 	AdminSecret  string          `json:"admin_secret,omitempty"`
+
+	// Audit configures the tool-call log. Absent means defaults (enabled),
+	// so an install that predates this feature starts logging without any
+	// settings.json migration.
+	Audit *AuditConfig `json:"audit,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/settings_audit_ui_test.go
+++ b/settings_audit_ui_test.go
@@ -1,0 +1,248 @@
+package main
+
+// Tool Calls tab (the audit-log viewer) under goja, using the same bundle +
+// DOM shim as settings_bundle_test.go. The tab is the primary way anyone will
+// actually read the audit log, so the tests pin the things a reviewer depends
+// on: that refusals are visually distinct from successes, that the caller and
+// project attribution reach the screen, and that a truncated or disabled state
+// says so rather than looking like a complete record.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+// seedAuditVM loads the app bundle and puts the given events on the Tool Calls
+// tab. Returns the VM with state.page already switched to 'audit'.
+func seedAuditVM(t *testing.T, eventsJSON, statusJSON string) *goja.Runtime {
+	t.Helper()
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.page = 'audit';
+		window.state.auditLoaded = true;
+		window.state.auditEvents = ` + eventsJSON + `;
+		window.state.auditStatus = ` + statusJSON + `;
+		return true;
+	})()`
+	if _, err := vm.RunString(script); err != nil {
+		t.Fatalf("seeding audit state: %v", err)
+	}
+	return vm
+}
+
+const auditEventFixture = `[{
+	id: 'ev1', ts: '2026-08-19T10:22:31.412Z', dur_ms: 412, event: 'call_tool',
+	actor: { kind:'project', project_id:'p1', project_name:'relay', auth:'token',
+	         pid: 4242, proc:'relay', parent:'claude' },
+	mcp_id: 'fsmcp', tool: 'read_file', args: {path:'/tmp/notes.md'},
+	args_bytes: 24, outcome: 'ok', result_bytes: 2048
+}, {
+	id: 'ev2', ts: '2026-08-19T10:22:35.000Z', dur_ms: 1, event: 'call_tool',
+	actor: { kind:'project', project_id:'p2', project_name:'sandbox', auth:'cwd',
+	         cwd:'/Users/x/sandbox', pid: 99 },
+	mcp_id: 'macmcp', tool: 'send_mail', outcome: 'denied',
+	error: "access denied: tool 'send_mail' is disabled for this token"
+}]`
+
+const auditStatusOn = `{enabled:true, path:'/tmp/toolcalls.jsonl', dropped:0, recorded:2, log_args:true, log_lists:false}`
+
+func TestAuditTab_RendersEventsWithAttribution(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, auditStatusOn)
+	html := evalString(t, vm, `window.renderAudit()`)
+
+	for _, want := range []string{
+		"Tool Calls", // page heading
+		"read_file",  // tool name
+		"send_mail",  // the denied tool
+		"relay",      // project name
+		"sandbox",    // second project
+		"fsmcp",      // owning MCP
+		"claude",     // the parent process that actually asked
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered Tool Calls tab is missing %q", want)
+		}
+	}
+}
+
+// A denial must not look like a success at a glance — that distinction is the
+// whole reason the tab exists.
+func TestAuditTab_OutcomesAreVisuallyDistinct(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, auditStatusOn)
+	html := evalString(t, vm, `window.renderAudit()`)
+
+	if !strings.Contains(html, "audit-ok") {
+		t.Error("successful call did not get the ok pill class")
+	}
+	if !strings.Contains(html, "audit-denied") {
+		t.Error("denied call did not get the denied pill class")
+	}
+}
+
+// Typing in the filter box must not cross the IPC boundary — it filters what is
+// already loaded, so the tab stays responsive on every keystroke.
+func TestAuditTab_TextFilterIsLocal(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, auditStatusOn)
+
+	got := evalString(t, vm, `(function(){
+		window.state.auditFilter.text = 'send_mail';
+		var rows = window.auditVisible();
+		return rows.length + ':' + rows[0].tool;
+	})()`)
+	if got != "1:send_mail" {
+		t.Errorf("text filter returned %q, want 1:send_mail", got)
+	}
+
+	// The filter searches the caller and the arguments too, not just the tool.
+	got = evalString(t, vm, `(function(){
+		window.state.auditFilter.text = 'notes.md';
+		return window.auditVisible().length;
+	})()`)
+	if got != "1" {
+		t.Errorf("filtering by an argument value returned %q, want 1", got)
+	}
+
+	got = evalString(t, vm, `(function(){
+		window.state.auditFilter.text = 'CLAUDE';
+		return window.auditVisible().length;
+	})()`)
+	if got != "1" {
+		t.Errorf("caller filter should be case-insensitive, got %q", got)
+	}
+}
+
+func TestAuditTab_ServerSideFiltersApplyLocallyToo(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, auditStatusOn)
+	got := evalString(t, vm, `(function(){
+		window.state.auditFilter.outcome = 'denied';
+		var rows = window.auditVisible();
+		return rows.length + ':' + rows[0].id;
+	})()`)
+	if got != "1:ev2" {
+		t.Errorf("outcome filter returned %q, want 1:ev2", got)
+	}
+}
+
+// Expanding a row is where the full record lives: the arguments, the working
+// directory behind a directory-auth grant, the caller pid.
+func TestAuditTab_ExpandedRowShowsFullRecord(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, auditStatusOn)
+	html := evalString(t, vm, `(function(){
+		window.state.auditExpanded['ev2'] = true;
+		return window.renderAudit();
+	})()`)
+
+	for _, want := range []string{"/Users/x/sandbox", "Working dir", "Caller pid", "disabled for this token"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expanded row is missing %q", want)
+		}
+	}
+}
+
+func TestAuditTab_TruncatedArgsAreLabelled(t *testing.T) {
+	events := `[{
+		id:'ev3', ts:'2026-08-19T10:00:00Z', event:'call_tool', outcome:'ok',
+		actor:{kind:'project', project_name:'relay', auth:'token'},
+		mcp_id:'fsmcp', tool:'write_file',
+		args:'{"blob":"xxxxx', args_bytes: 90210, args_truncated: true
+	}]`
+	vm := seedAuditVM(t, events, auditStatusOn)
+	html := evalString(t, vm, `(function(){
+		window.state.auditExpanded['ev3'] = true;
+		return window.renderAudit();
+	})()`)
+
+	// A truncated record that looks complete is worse than no record.
+	if !strings.Contains(html, "truncated") || !strings.Contains(html, "90210") {
+		t.Errorf("truncated arguments were not labelled as such:\n%s", html)
+	}
+}
+
+// Disabled auditing must be stated outright. An empty table would otherwise
+// read as "nothing happened".
+func TestAuditTab_DisabledStateIsExplicit(t *testing.T) {
+	vm := seedAuditVM(t, `[]`, `{enabled:false, path:'', dropped:0, recorded:0}`)
+	html := evalString(t, vm, `window.renderAudit()`)
+
+	if !strings.Contains(html, "Auditing is disabled") {
+		t.Errorf("disabled auditing was not surfaced:\n%s", html)
+	}
+	if strings.Contains(html, "<table") {
+		t.Error("a table was rendered while auditing is disabled")
+	}
+}
+
+// Dropped events mean the log is incomplete, which the reader has to be told.
+func TestAuditTab_DropCountIsSurfaced(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, `{enabled:true, path:'/tmp/x', dropped:7, recorded:2}`)
+	html := evalString(t, vm, `window.renderAudit()`)
+
+	if !strings.Contains(html, "7 event(s) were dropped") || !strings.Contains(html, "incomplete") {
+		t.Errorf("drop count was not surfaced as a warning:\n%s", html)
+	}
+}
+
+func TestAuditTab_EmptyStateDistinguishesLoadingFromNoMatches(t *testing.T) {
+	vm := seedAuditVM(t, `[]`, auditStatusOn)
+	if html := evalString(t, vm, `window.renderAudit()`); !strings.Contains(html, "No tool calls match") {
+		t.Errorf("loaded-but-empty state is wrong:\n%s", html)
+	}
+
+	vm2 := newAppVM(t)
+	html := evalString(t, vm2, `(function(){
+		window.state.page='audit'; window.state.auditLoaded=false;
+		window.state.auditStatus=`+auditStatusOn+`;
+		return window.renderAudit();
+	})()`)
+	if !strings.Contains(html, "Loading") {
+		t.Errorf("unloaded state should say it is loading:\n%s", html)
+	}
+}
+
+// A live event appends without a full repaint, so whatever the user is typing
+// in the filter box survives an inbound tool call.
+func TestAuditTab_LiveEventPrepends(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, auditStatusOn)
+	got := evalString(t, vm, `(function(){
+		window.onAuditEvent({id:'ev-live', ts:'2026-08-19T11:00:00Z', event:'call_tool',
+			outcome:'ok', tool:'live_tool', mcp_id:'fsmcp',
+			actor:{kind:'project', project_name:'relay', auth:'token'}});
+		return window.state.auditEvents.length + ':' + window.state.auditEvents[0].id;
+	})()`)
+	if got != "3:ev-live" {
+		t.Errorf("live event handling = %q, want 3:ev-live", got)
+	}
+}
+
+// With Follow off, the view must stay where the reader put it.
+func TestAuditTab_FollowOffIgnoresLiveEvents(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture, auditStatusOn)
+	got := evalString(t, vm, `(function(){
+		window.toggleAuditFollow(false);
+		window.onAuditEvent({id:'ev-live', event:'call_tool', outcome:'ok', tool:'t', actor:{}});
+		return window.state.auditEvents.length;
+	})()`)
+	if got != "2" {
+		t.Errorf("live event was appended with Follow off: length = %q", got)
+	}
+}
+
+// Switching to the tab must load it: it is the one tab not seeded by the
+// initial payload.
+func TestAuditTab_ShowPageTriggersInitialLoad(t *testing.T) {
+	vm := newAppVM(t)
+	// Intercept at the WebKit message handler rather than window.ipc: the
+	// bundled module calls its own module-scoped ipc(), so replacing the global
+	// would not see the message the tab actually sends.
+	got := evalString(t, vm, `(function(){
+		var sent = [];
+		window.webkit = { messageHandlers: { ipc: { postMessage: function(msg){ sent.push(msg); } } } };
+		window.showPage('audit');
+		return sent.filter(function(m){ return m.indexOf('query_audit') >= 0; }).length;
+	})()`)
+	if got != "1" {
+		t.Errorf("showPage('audit') sent %q query_audit messages, want 1", got)
+	}
+}

--- a/settings_bundle_test.go
+++ b/settings_bundle_test.go
@@ -182,6 +182,11 @@ function __mkEl(id){
     classList:{ toggle:function(){}, add:function(){}, remove:function(){} },
     querySelector:function(){ return null; }, closest:function(){ return null; },
     appendChild:function(){}, remove:function(){},
+    focus:function(){}, setSelectionRange:function(){},
+    children:[], lastChild:null, removeChild:function(){},
+    insertAdjacentHTML:function(pos, html){
+      this._html = (pos === 'afterbegin') ? String(html) + this._html : this._html + String(html);
+    },
     get innerHTML(){ return this._html; }, set innerHTML(v){ this._html = String(v); }
   };
 }

--- a/trayapp.go
+++ b/trayapp.go
@@ -32,6 +32,9 @@ type App struct {
 	bridgeServer   *bridge.BridgeServer
 	frontendServer *FrontendServer
 	ipcCtx         *IPCContext // pre-built once, reused on every IPC call
+	// audit is the tool-call recorder. Nil when auditing is disabled or failed
+	// to start; every method on it is nil-safe.
+	audit *AuditRecorder
 	// settingsOpen gates UI emits on whether the Settings window is up. Written
 	// on the main thread (open/close) but read from background goroutines (the
 	// status poller, HTTP-driven project refresh), so it must be atomic.
@@ -152,6 +155,13 @@ func runTrayApp() {
 		Tools:                  extMgr,
 	}
 
+	// Tool-call audit log. A failure here is logged and auditing stays off
+	// rather than taking the tray down with it: the recorder is observability,
+	// not an authorization control, and relay is more useful running blind than
+	// not running at all. The Tool Calls tab surfaces the disabled state.
+	audit := startAuditRecorder(store.Get())
+	app.audit = audit
+
 	// Create and start bridge server.
 	router := &appRouter{
 		store:    store,
@@ -159,10 +169,20 @@ func runTrayApp() {
 		services: app.registry,
 		enhanced: enhancedRegistry,
 		onChange: app.onExternalChange,
+		audit:    audit,
 	}
 	// router implements SkillLister (ListTools); set it on the IPC context
 	// now that it exists so the Projects-tab "Regen Now" button can run.
 	app.ipcCtx.SkillLister = router
+	app.ipcCtx.Audit = audit
+	// Live-tail the Tool Calls tab. Fires on the audit writer goroutine, so
+	// hop to main before touching the WebView.
+	audit.SetSink(func(ev AuditEvent) {
+		if !app.settingsOpen.Load() {
+			return
+		}
+		app.platform.DispatchToMain(func() { app.emitSettingsEvent("onAuditEvent", ev) })
+	})
 	// Share the in-memory service token store between the router (auth) and
 	// the registry (token lifecycle). Tokens live only in memory — no cleanup
 	// needed on crash.
@@ -488,5 +508,9 @@ func (a *App) cleanup() {
 		// exits.
 		a.registry.CloseFrontendChannel()
 		a.wg.Wait()
+		// Last: nothing can produce a tool call any more, so drain the audit
+		// queue and close the log. Closing earlier would drop the shutdown-time
+		// events that a post-incident review is most likely to want.
+		a.audit.Close()
 	})
 }

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -362,6 +362,32 @@ textarea:focus {
 .proj-form-actions { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--border); display: flex; gap: 8px; }
 .proj-error { color: var(--danger); font-size: 12px; margin-top: 8px; }
 .proj-ok { color: var(--ok); font-size: 12px; margin-top: 8px; }
+
+/* ---- Tool Calls (audit log) ---- */
+.audit-bar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+.audit-bar input[type="search"], .audit-bar select { margin-top: 0; width: auto; min-width: 120px; }
+.audit-bar .grow { flex: 1 1 180px; min-width: 140px; }
+.audit-note { font-size: 12px; color: var(--text-2); margin-bottom: 10px; }
+.audit-note.warn { color: var(--warn); }
+.audit-table { width: 100%; border-collapse: collapse; font-size: 12px; table-layout: fixed; }
+.audit-table th { text-align: left; padding: 6px 8px; color: var(--text-2); font-weight: 500; border-bottom: 1px solid var(--border); }
+.audit-table td { padding: 6px 8px; border-bottom: 1px solid var(--hairline); color: var(--text); vertical-align: top; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.audit-table tr.row { cursor: pointer; }
+.audit-table tr.row:hover td { background: var(--bg-hover); }
+.audit-time, .audit-ms { font-variant-numeric: tabular-nums; color: var(--text-2); }
+.audit-tool { font-family: var(--mono); }
+.audit-detail { color: var(--text-2); font-family: var(--mono); }
+.audit-pill { display: inline-block; padding: 1px 7px; border-radius: 9px; font-size: 11px; font-weight: 500; }
+.audit-ok { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
+.audit-error { background: color-mix(in srgb, var(--danger) 18%, transparent); color: var(--danger); }
+.audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
+.audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
+.audit-expand td { background: var(--bg-card); white-space: normal; }
+.audit-kv { display: grid; grid-template-columns: max-content 1fr; gap: 2px 14px; font-size: 12px; }
+.audit-kv dt { color: var(--text-2); }
+.audit-kv dd { margin: 0; font-family: var(--mono); word-break: break-all; }
+.audit-args { margin-top: 8px; padding: 8px; background: var(--bg-field); border: 1px solid var(--border); border-radius: var(--radius-sm); font-family: var(--mono); font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 260px; overflow: auto; }
+.audit-empty { color: var(--text-2); font-size: 13px; padding: 24px 0; text-align: center; }
 </style></head>
 <body>
 <div class="sidebar">
@@ -369,6 +395,7 @@ textarea:focus {
     <div class="sidebar-item" onclick="showPage('mcps')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>MCP Servers</div>
     <div class="sidebar-item" onclick="showPage('projects')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Projects</div>
     <div class="sidebar-item" onclick="showPage('inspector')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>Service Inspector</div>
+    <div class="sidebar-item" onclick="showPage('audit')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Tool Calls</div>
 </div>
 <div class="content" id="content"></div>
 
@@ -662,14 +689,30 @@ window.__RELAY_INIT__ = {
     projectSkillRegen: {},
     // id -> { ok, message, t } (last regen result)
     projectError: null,
-    rotatingProjectId: null
+    rotatingProjectId: null,
+    // Tool Calls tab. Events arrive newest-first from the recorder's ring (or
+    // from a deep query over the log file); `auditFilter` mirrors AuditQuery
+    // on the Go side so it can be sent verbatim.
+    auditEvents: [],
+    auditStatus: null,
+    // {enabled, path, dropped, recorded, ...}
+    auditFilter: { project_id: "", mcp_id: "", outcome: "", event: "", text: "", deep: false },
+    auditExpanded: {},
+    // event id -> bool
+    auditFollow: true,
+    // append live events as they arrive
+    auditLoaded: false,
+    auditError: null,
+    auditExportPath: null
   };
+  var AUDIT_MAX_ROWS = 500;
   function showPage(page) {
     state.page = page;
-    const pages = ["services", "mcps", "projects", "inspector"];
+    const pages = ["services", "mcps", "projects", "inspector", "audit"];
     document.querySelectorAll(".sidebar-item").forEach((el, i) => {
       el.classList.toggle("active", pages[i] === page);
     });
+    if (page === "audit" && !state.auditLoaded) queryAudit();
     render();
   }
   var JSON_PLACEHOLDER = JSON.stringify({ "my-server": { "command": "npx", "args": ["-y", "@example/server"], "env": { "API_KEY": "..." } } }, null, 2);
@@ -685,6 +728,9 @@ window.__RELAY_INIT__ = {
     } else if (state.page === "projects") {
       if (fromPush && state.editingProjectId) return;
       el.innerHTML = renderProjects();
+    } else if (state.page === "audit") {
+      el.innerHTML = renderAudit();
+      restoreAuditFocus();
     } else {
       if (fromPush && state.editingMcpId) return;
       el.innerHTML = renderMcpServers();
@@ -2428,6 +2474,265 @@ window.__RELAY_INIT__ = {
       row: row || void 0
     }));
   }
+  var AUDIT_OUTCOMES = ["ok", "error", "denied", "unauthorized"];
+  var AUDIT_EVENT_KINDS = [
+    ["call_tool", "Tool calls"],
+    ["list_tools", "Tool lists"],
+    ["list_skills", "Skill lists"]
+  ];
+  function queryAudit(deep) {
+    const f = state.auditFilter;
+    state.auditError = null;
+    f.deep = !!deep;
+    ipc(JSON.stringify({
+      type: "query_audit",
+      project_id: f.project_id || void 0,
+      mcp_id: f.mcp_id || void 0,
+      outcome: f.outcome || void 0,
+      event: f.event || void 0,
+      text: deep ? f.text || void 0 : void 0,
+      limit: deep ? 2e3 : 0,
+      deep: !!deep
+    }));
+  }
+  function exportAudit() {
+    const f = state.auditFilter;
+    ipc(JSON.stringify({
+      type: "export_audit",
+      project_id: f.project_id || void 0,
+      mcp_id: f.mcp_id || void 0,
+      outcome: f.outcome || void 0,
+      event: f.event || void 0,
+      text: f.text || void 0
+    }));
+  }
+  function revealAuditLog() {
+    ipc(JSON.stringify({ type: "reveal_audit_log" }));
+  }
+  function setAuditFilter(key, value) {
+    state.auditFilter[key] = value;
+    if (key !== "text") queryAudit(state.auditFilter.deep);
+    render();
+  }
+  function toggleAuditFollow(on) {
+    state.auditFollow = !!on;
+    render();
+  }
+  function toggleAuditRow(id) {
+    state.auditExpanded[id] = !state.auditExpanded[id];
+    render();
+  }
+  function auditMatches(ev) {
+    const f = state.auditFilter;
+    if (f.project_id && (ev.actor || {}).project_id !== f.project_id) return false;
+    if (f.mcp_id && ev.mcp_id !== f.mcp_id) return false;
+    if (f.outcome && ev.outcome !== f.outcome) return false;
+    if (f.event && ev.event !== f.event) return false;
+    if (f.text) {
+      const a = ev.actor || {};
+      const hay = [
+        ev.tool,
+        ev.mcp_id,
+        ev.error,
+        a.project_name,
+        a.proc,
+        a.parent,
+        typeof ev.args === "string" ? ev.args : JSON.stringify(ev.args || "")
+      ].join("\0").toLowerCase();
+      if (hay.indexOf(f.text.toLowerCase()) === -1) return false;
+    }
+    return true;
+  }
+  function auditVisible() {
+    return state.auditEvents.filter(auditMatches);
+  }
+  function auditFmtTime(ts) {
+    if (!ts) return "";
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return "";
+    const p = (n) => String(n).padStart(2, "0");
+    return p(d.getHours()) + ":" + p(d.getMinutes()) + ":" + p(d.getSeconds());
+  }
+  function auditCaller(a) {
+    a = a || {};
+    if (a.parent && a.proc) return a.parent + " \u2192 " + a.proc;
+    return a.proc || a.parent || (a.pid ? "pid " + a.pid : "");
+  }
+  function auditDetail(ev) {
+    if (ev.error) return ev.error;
+    if (ev.args) return typeof ev.args === "string" ? ev.args : JSON.stringify(ev.args);
+    if (ev.tool_count) return ev.tool_count + " tools visible";
+    return "";
+  }
+  function auditPretty(args) {
+    if (args === void 0 || args === null) return "";
+    if (typeof args === "string") return args;
+    try {
+      return JSON.stringify(args, null, 2);
+    } catch (e) {
+      return String(args);
+    }
+  }
+  function auditSelect(key, label, options, current) {
+    let html = `<select onchange="setAuditFilter('` + key + `', this.value)">`;
+    html += '<option value="">' + esc(label) + "</option>";
+    for (const [val, text] of options) {
+      html += '<option value="' + esc(val) + '"' + (current === val ? " selected" : "") + ">" + esc(text) + "</option>";
+    }
+    return html + "</select>";
+  }
+  function renderAudit() {
+    const st = state.auditStatus;
+    let html = '<div class="page-header"><h2>Tool Calls</h2><div style="display:flex;gap:8px">';
+    html += '<button class="btn btn-sm" onclick="queryAudit(false)">Refresh</button>';
+    html += '<button class="btn btn-sm" onclick="queryAudit(true)">Search History</button>';
+    html += '<button class="btn btn-sm" onclick="exportAudit()">Export</button>';
+    html += '<button class="btn btn-sm" onclick="revealAuditLog()">Reveal Log</button>';
+    html += "</div></div>";
+    if (st && !st.enabled) {
+      html += '<div class="audit-note warn">Auditing is disabled. Set <code>audit.enabled</code> to true in settings.json and restart Relay.</div>';
+      return html;
+    }
+    if (state.auditError) {
+      html += '<div class="audit-note warn">' + esc(state.auditError) + "</div>";
+    }
+    if (st && st.dropped > 0) {
+      html += '<div class="audit-note warn">' + st.dropped + " event(s) were dropped because the audit queue was full \u2014 this log is incomplete.</div>";
+    }
+    if (state.auditExportPath) {
+      html += '<div class="audit-note">Exported to <code>' + esc(state.auditExportPath) + "</code></div>";
+    }
+    const f = state.auditFilter;
+    html += '<div class="audit-bar">';
+    html += '<input type="search" class="grow" placeholder="Filter by tool, project, caller, arguments\u2026" value="' + esc(f.text) + `" id="auditText" oninput="setAuditFilter('text', this.value)">`;
+    html += auditSelect("project_id", "All projects", (state.projects || []).map((p) => [p.id, p.name]), f.project_id);
+    html += auditSelect("mcp_id", "All MCPs", (state.externalMcps || []).map((m) => [m.id, m.display_name || m.id]), f.mcp_id);
+    html += auditSelect("outcome", "Any outcome", AUDIT_OUTCOMES.map((o) => [o, o]), f.outcome);
+    html += auditSelect("event", "All events", AUDIT_EVENT_KINDS, f.event);
+    html += '<label style="font-size:12px;color:var(--text-2);display:flex;align-items:center;gap:5px">';
+    html += '<input type="checkbox"' + (state.auditFollow ? " checked" : "") + ' onchange="toggleAuditFollow(this.checked)">Follow</label>';
+    html += "</div>";
+    const rows = auditVisible();
+    if (!rows.length) {
+      html += '<div class="audit-empty">' + (state.auditLoaded ? "No tool calls match this filter." : "Loading\u2026") + "</div>";
+      if (st && !st.log_lists) {
+        html += '<div class="audit-note">Tool-list events are not being recorded. Set <code>audit.log_lists</code> to true to include them.</div>';
+      }
+      return html;
+    }
+    html += '<table class="audit-table"><colgroup>';
+    html += '<col style="width:70px"><col style="width:100px"><col style="width:14%"><col style="width:12%">';
+    html += '<col style="width:18%"><col style="width:60px"><col style="width:16%"><col>';
+    html += "</colgroup><thead><tr>";
+    html += "<th>Time</th><th>Outcome</th><th>Project</th><th>MCP</th><th>Tool</th><th>ms</th><th>Caller</th><th>Detail</th>";
+    html += '</tr></thead><tbody id="auditRows">';
+    for (const ev of rows) html += renderAuditRow(ev);
+    html += "</tbody></table>";
+    return html;
+  }
+  function renderAuditRow(ev) {
+    const a = ev.actor || {};
+    const expanded = !!state.auditExpanded[ev.id];
+    let html = `<tr class="row" onclick="toggleAuditRow('` + esc(ev.id) + `')">`;
+    html += '<td class="audit-time">' + esc(auditFmtTime(ev.ts)) + "</td>";
+    html += '<td><span class="audit-pill audit-' + esc(ev.outcome) + '">' + esc(ev.outcome) + "</span></td>";
+    html += '<td title="' + esc(a.project_name || "") + '">' + esc(a.project_name || "\u2014") + "</td>";
+    html += "<td>" + esc(ev.mcp_id || "\u2014") + "</td>";
+    html += '<td class="audit-tool" title="' + esc(ev.tool || "") + '">' + esc(ev.tool || ev.event) + "</td>";
+    html += '<td class="audit-ms">' + (ev.dur_ms || 0) + "</td>";
+    html += '<td title="' + esc(auditCaller(a)) + '">' + esc(auditCaller(a) || "\u2014") + "</td>";
+    const detail = auditDetail(ev);
+    html += '<td class="audit-detail" title="' + esc(detail) + '">' + esc(detail) + "</td>";
+    html += "</tr>";
+    if (expanded) html += renderAuditDetail(ev);
+    return html;
+  }
+  function renderAuditDetail(ev) {
+    const a = ev.actor || {};
+    const kv = [];
+    const add = (k, v) => {
+      if (v !== void 0 && v !== null && v !== "") kv.push([k, String(v)]);
+    };
+    add("Event", ev.event);
+    add("When", ev.ts);
+    add("Duration", (ev.dur_ms || 0) + " ms");
+    add("Project", a.project_name ? a.project_name + " (" + (a.project_id || "") + ")" : "");
+    add("Actor", a.kind);
+    add("Auth", a.auth);
+    add("Working dir", a.cwd);
+    add("Caller pid", a.pid);
+    add("Process", a.proc);
+    add("Parent", a.parent);
+    add("MCP", ev.mcp_id);
+    add("Tool", ev.tool);
+    add("Outcome", ev.outcome);
+    add("Error", ev.error);
+    if (ev.result_bytes) add("Result", ev.result_bytes + " bytes" + (ev.result_is_error ? " (isError)" : ""));
+    if (ev.tool_count) add("Tools visible", ev.tool_count);
+    add("Event id", ev.id);
+    let html = '<tr class="audit-expand"><td colspan="8">';
+    html += '<dl class="audit-kv">';
+    for (const [k, v] of kv) html += "<dt>" + esc(k) + "</dt><dd>" + esc(v) + "</dd>";
+    html += "</dl>";
+    if (ev.args !== void 0 && ev.args !== null && ev.args !== "") {
+      const label = ev.args_truncated ? "Arguments (truncated from " + (ev.args_bytes || 0) + " bytes)" : "Arguments";
+      html += '<div style="margin-top:10px;font-size:11px;color:var(--text-2)">' + esc(label) + "</div>";
+      html += '<div class="audit-args">' + esc(auditPretty(ev.args)) + "</div>";
+    }
+    if (ev.result_preview) {
+      html += '<div style="margin-top:10px;font-size:11px;color:var(--text-2)">Result preview</div>';
+      html += '<div class="audit-args">' + esc(ev.result_preview) + "</div>";
+    }
+    html += "</td></tr>";
+    return html;
+  }
+  function restoreAuditFocus() {
+    const el = document.getElementById("auditText");
+    if (!el || !state._auditTextFocused) return;
+    el.focus();
+    const n = el.value.length;
+    try {
+      el.setSelectionRange(n, n);
+    } catch (e) {
+    }
+  }
+  window.onAuditEvents = function(events, status) {
+    state.auditEvents = events || [];
+    state.auditStatus = status || null;
+    state.auditLoaded = true;
+    if (state.page === "audit") render();
+  };
+  window.onAuditEvent = function(ev) {
+    if (!ev) return;
+    if (state.auditStatus) {
+      state.auditStatus.recorded = (state.auditStatus.recorded || 0) + 1;
+    }
+    if (!state.auditFollow) return;
+    state.auditEvents.unshift(ev);
+    if (state.auditEvents.length > AUDIT_MAX_ROWS) state.auditEvents.length = AUDIT_MAX_ROWS;
+    if (state.page !== "audit") return;
+    const tbody = document.getElementById("auditRows");
+    if (!tbody || !auditMatches(ev)) {
+      render();
+      return;
+    }
+    tbody.insertAdjacentHTML("afterbegin", renderAuditRow(ev));
+    while (tbody.children.length > AUDIT_MAX_ROWS) tbody.removeChild(tbody.lastChild);
+  };
+  window.onAuditError = function(msg) {
+    state.auditError = msg || "audit error";
+    if (state.page === "audit") render();
+  };
+  window.onAuditExported = function(path) {
+    state.auditExportPath = path;
+    if (state.page === "audit") render();
+  };
+  document.addEventListener("focusin", (e) => {
+    if (e.target && e.target.id === "auditText") state._auditTextFocused = true;
+  });
+  document.addEventListener("focusout", (e) => {
+    if (e.target && e.target.id === "auditText") state._auditTextFocused = false;
+  });
   function setsEqual(a, b) {
     if (a.size !== b.size) return false;
     for (const x of a) if (!b.has(x)) return false;
@@ -2470,6 +2775,23 @@ window.__RELAY_INIT__ = {
   };
   render();
   Object.assign(window, {
+    auditCaller,
+    auditDetail,
+    auditFmtTime,
+    auditMatches,
+    auditPretty,
+    auditSelect,
+    auditVisible,
+    exportAudit,
+    queryAudit,
+    renderAudit,
+    renderAuditDetail,
+    renderAuditRow,
+    restoreAuditFocus,
+    revealAuditLog,
+    setAuditFilter,
+    toggleAuditFollow,
+    toggleAuditRow,
     addExternalMcp,
     addExternalMcpFromJson,
     addExternalMcpHttp,

--- a/web/shell.html
+++ b/web/shell.html
@@ -362,6 +362,32 @@ textarea:focus {
 .proj-form-actions { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--border); display: flex; gap: 8px; }
 .proj-error { color: var(--danger); font-size: 12px; margin-top: 8px; }
 .proj-ok { color: var(--ok); font-size: 12px; margin-top: 8px; }
+
+/* ---- Tool Calls (audit log) ---- */
+.audit-bar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+.audit-bar input[type="search"], .audit-bar select { margin-top: 0; width: auto; min-width: 120px; }
+.audit-bar .grow { flex: 1 1 180px; min-width: 140px; }
+.audit-note { font-size: 12px; color: var(--text-2); margin-bottom: 10px; }
+.audit-note.warn { color: var(--warn); }
+.audit-table { width: 100%; border-collapse: collapse; font-size: 12px; table-layout: fixed; }
+.audit-table th { text-align: left; padding: 6px 8px; color: var(--text-2); font-weight: 500; border-bottom: 1px solid var(--border); }
+.audit-table td { padding: 6px 8px; border-bottom: 1px solid var(--hairline); color: var(--text); vertical-align: top; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.audit-table tr.row { cursor: pointer; }
+.audit-table tr.row:hover td { background: var(--bg-hover); }
+.audit-time, .audit-ms { font-variant-numeric: tabular-nums; color: var(--text-2); }
+.audit-tool { font-family: var(--mono); }
+.audit-detail { color: var(--text-2); font-family: var(--mono); }
+.audit-pill { display: inline-block; padding: 1px 7px; border-radius: 9px; font-size: 11px; font-weight: 500; }
+.audit-ok { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
+.audit-error { background: color-mix(in srgb, var(--danger) 18%, transparent); color: var(--danger); }
+.audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
+.audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
+.audit-expand td { background: var(--bg-card); white-space: normal; }
+.audit-kv { display: grid; grid-template-columns: max-content 1fr; gap: 2px 14px; font-size: 12px; }
+.audit-kv dt { color: var(--text-2); }
+.audit-kv dd { margin: 0; font-family: var(--mono); word-break: break-all; }
+.audit-args { margin-top: 8px; padding: 8px; background: var(--bg-field); border: 1px solid var(--border); border-radius: var(--radius-sm); font-family: var(--mono); font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 260px; overflow: auto; }
+.audit-empty { color: var(--text-2); font-size: 13px; padding: 24px 0; text-align: center; }
 </style></head>
 <body>
 <div class="sidebar">
@@ -369,6 +395,7 @@ textarea:focus {
     <div class="sidebar-item" onclick="showPage('mcps')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>MCP Servers</div>
     <div class="sidebar-item" onclick="showPage('projects')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Projects</div>
     <div class="sidebar-item" onclick="showPage('inspector')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>Service Inspector</div>
+    <div class="sidebar-item" onclick="showPage('audit')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Tool Calls</div>
 </div>
 <div class="content" id="content"></div>
 

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -67,14 +67,33 @@ let state = {
     projectSkillRegen: {},                  // id -> { ok, message, t } (last regen result)
     projectError: null,
     rotatingProjectId: null,
+
+    // Tool Calls tab. Events arrive newest-first from the recorder's ring (or
+    // from a deep query over the log file); `auditFilter` mirrors AuditQuery
+    // on the Go side so it can be sent verbatim.
+    auditEvents: [],
+    auditStatus: null,                      // {enabled, path, dropped, recorded, ...}
+    auditFilter: { project_id: '', mcp_id: '', outcome: '', event: '', text: '', deep: false },
+    auditExpanded: {},                      // event id -> bool
+    auditFollow: true,                      // append live events as they arrive
+    auditLoaded: false,
+    auditError: null,
+    auditExportPath: null,
 };
+
+// How many live events the Tool Calls tab keeps in the DOM. The Go-side ring
+// is the real buffer; this only bounds what one open window renders.
+const AUDIT_MAX_ROWS = 500;
 
 function showPage(page) {
     state.page = page;
-    const pages = ['services', 'mcps', 'projects', 'inspector'];
+    const pages = ['services', 'mcps', 'projects', 'inspector', 'audit'];
     document.querySelectorAll('.sidebar-item').forEach((el, i) => {
         el.classList.toggle('active', pages[i] === page);
     });
+    // The Tool Calls tab is the only one not seeded by the initial payload:
+    // the log can be large, so it's fetched the first time it's shown.
+    if (page === 'audit' && !state.auditLoaded) queryAudit();
     render();
 }
 
@@ -101,6 +120,9 @@ function render(source) {
     } else if (state.page === 'projects') {
         if (fromPush && state.editingProjectId) return;
         el.innerHTML = renderProjects();
+    } else if (state.page === 'audit') {
+        el.innerHTML = renderAudit();
+        restoreAuditFocus();
     } else {
         if (fromPush && state.editingMcpId) return;
         el.innerHTML = renderMcpServers();
@@ -2216,6 +2238,306 @@ function dispatchServiceAction(serviceId, actionId, row) {
 
 
 
+// ---------------------------------------------------------------------------
+// Tool Calls tab — the audit log viewer.
+//
+// Filtering is two-tier. The recorder holds a bounded in-memory ring of recent
+// events; that is what loads by default and what live events append to, and
+// filtering it happens here in the page so typing stays instant. "Search
+// history" re-runs the same filter server-side against the log file, for events
+// older than the ring holds.
+// ---------------------------------------------------------------------------
+
+const AUDIT_OUTCOMES = ['ok', 'error', 'denied', 'unauthorized'];
+const AUDIT_EVENT_KINDS = [
+    ['call_tool', 'Tool calls'],
+    ['list_tools', 'Tool lists'],
+    ['list_skills', 'Skill lists'],
+];
+
+function queryAudit(deep) {
+    const f = state.auditFilter;
+    state.auditError = null;
+    // Remember the mode so a subsequent dropdown change re-runs the same kind
+    // of query rather than silently dropping the user back to the ring.
+    f.deep = !!deep;
+    ipc(JSON.stringify({
+        type: 'query_audit',
+        project_id: f.project_id || undefined,
+        mcp_id: f.mcp_id || undefined,
+        outcome: f.outcome || undefined,
+        event: f.event || undefined,
+        text: deep ? (f.text || undefined) : undefined,
+        limit: deep ? 2000 : 0,
+        deep: !!deep,
+    }));
+}
+
+function exportAudit() {
+    const f = state.auditFilter;
+    ipc(JSON.stringify({
+        type: 'export_audit',
+        project_id: f.project_id || undefined,
+        mcp_id: f.mcp_id || undefined,
+        outcome: f.outcome || undefined,
+        event: f.event || undefined,
+        text: f.text || undefined,
+    }));
+}
+
+function revealAuditLog() {
+    ipc(JSON.stringify({ type: 'reveal_audit_log' }));
+}
+
+function setAuditFilter(key, value) {
+    state.auditFilter[key] = value;
+    // Server-side fields need a refetch; text is applied locally so each
+    // keystroke doesn't cross the IPC boundary.
+    if (key !== 'text') queryAudit(state.auditFilter.deep);
+    render();
+}
+
+function toggleAuditFollow(on) {
+    state.auditFollow = !!on;
+    render();
+}
+
+function toggleAuditRow(id) {
+    state.auditExpanded[id] = !state.auditExpanded[id];
+    render();
+}
+
+// auditMatches applies the locally-evaluated part of the filter. The
+// server-side fields are already applied by the query; text is not, so a
+// keystroke re-filters what is loaded without a round trip.
+function auditMatches(ev) {
+    const f = state.auditFilter;
+    if (f.project_id && (ev.actor || {}).project_id !== f.project_id) return false;
+    if (f.mcp_id && ev.mcp_id !== f.mcp_id) return false;
+    if (f.outcome && ev.outcome !== f.outcome) return false;
+    if (f.event && ev.event !== f.event) return false;
+    if (f.text) {
+        const a = ev.actor || {};
+        const hay = [ev.tool, ev.mcp_id, ev.error, a.project_name, a.proc, a.parent,
+                     typeof ev.args === 'string' ? ev.args : JSON.stringify(ev.args || '')]
+            .join('\u0000').toLowerCase();
+        if (hay.indexOf(f.text.toLowerCase()) === -1) return false;
+    }
+    return true;
+}
+
+function auditVisible() {
+    return state.auditEvents.filter(auditMatches);
+}
+
+function auditFmtTime(ts) {
+    if (!ts) return '';
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return '';
+    const p = (n) => String(n).padStart(2, '0');
+    return p(d.getHours()) + ':' + p(d.getMinutes()) + ':' + p(d.getSeconds());
+}
+
+// auditCaller renders the actor as "parent \u2192 proc". The parent leads because
+// `relay mcp` spawns a fresh child per call, so the process itself is usually a
+// throwaway and the parent is the agent that actually asked.
+function auditCaller(a) {
+    a = a || {};
+    if (a.parent && a.proc) return a.parent + ' \u2192 ' + a.proc;
+    return a.proc || a.parent || (a.pid ? 'pid ' + a.pid : '');
+}
+
+function auditDetail(ev) {
+    if (ev.error) return ev.error;
+    if (ev.args) return typeof ev.args === 'string' ? ev.args : JSON.stringify(ev.args);
+    if (ev.tool_count) return ev.tool_count + ' tools visible';
+    return '';
+}
+
+function auditPretty(args) {
+    if (args === undefined || args === null) return '';
+    if (typeof args === 'string') return args;
+    try { return JSON.stringify(args, null, 2); } catch (e) { return String(args); }
+}
+
+function auditSelect(key, label, options, current) {
+    let html = '<select onchange="setAuditFilter(\'' + key + '\', this.value)">';
+    html += '<option value="">' + esc(label) + '</option>';
+    for (const [val, text] of options) {
+        html += '<option value="' + esc(val) + '"' + (current === val ? ' selected' : '') + '>' + esc(text) + '</option>';
+    }
+    return html + '</select>';
+}
+
+function renderAudit() {
+    const st = state.auditStatus;
+    let html = '<div class="page-header"><h2>Tool Calls</h2><div style="display:flex;gap:8px">';
+    html += '<button class="btn btn-sm" onclick="queryAudit(false)">Refresh</button>';
+    html += '<button class="btn btn-sm" onclick="queryAudit(true)">Search History</button>';
+    html += '<button class="btn btn-sm" onclick="exportAudit()">Export</button>';
+    html += '<button class="btn btn-sm" onclick="revealAuditLog()">Reveal Log</button>';
+    html += '</div></div>';
+
+    if (st && !st.enabled) {
+        html += '<div class="audit-note warn">Auditing is disabled. Set <code>audit.enabled</code> to true in settings.json and restart Relay.</div>';
+        return html;
+    }
+    if (state.auditError) {
+        html += '<div class="audit-note warn">' + esc(state.auditError) + '</div>';
+    }
+    if (st && st.dropped > 0) {
+        html += '<div class="audit-note warn">' + st.dropped + ' event(s) were dropped because the audit queue was full \u2014 this log is incomplete.</div>';
+    }
+    if (state.auditExportPath) {
+        html += '<div class="audit-note">Exported to <code>' + esc(state.auditExportPath) + '</code></div>';
+    }
+
+    // Filter bar.
+    const f = state.auditFilter;
+    html += '<div class="audit-bar">';
+    html += '<input type="search" class="grow" placeholder="Filter by tool, project, caller, arguments\u2026" value="' + esc(f.text) + '" id="auditText" oninput="setAuditFilter(\'text\', this.value)">';
+    html += auditSelect('project_id', 'All projects', (state.projects || []).map(p => [p.id, p.name]), f.project_id);
+    html += auditSelect('mcp_id', 'All MCPs', (state.externalMcps || []).map(m => [m.id, m.display_name || m.id]), f.mcp_id);
+    html += auditSelect('outcome', 'Any outcome', AUDIT_OUTCOMES.map(o => [o, o]), f.outcome);
+    html += auditSelect('event', 'All events', AUDIT_EVENT_KINDS, f.event);
+    html += '<label style="font-size:12px;color:var(--text-2);display:flex;align-items:center;gap:5px">';
+    html += '<input type="checkbox"' + (state.auditFollow ? ' checked' : '') + ' onchange="toggleAuditFollow(this.checked)">Follow</label>';
+    html += '</div>';
+
+    const rows = auditVisible();
+    if (!rows.length) {
+        html += '<div class="audit-empty">' + (state.auditLoaded ? 'No tool calls match this filter.' : 'Loading\u2026') + '</div>';
+        if (st && !st.log_lists) {
+            html += '<div class="audit-note">Tool-list events are not being recorded. Set <code>audit.log_lists</code> to true to include them.</div>';
+        }
+        return html;
+    }
+
+    html += '<table class="audit-table"><colgroup>';
+    html += '<col style="width:70px"><col style="width:100px"><col style="width:14%"><col style="width:12%">';
+    html += '<col style="width:18%"><col style="width:60px"><col style="width:16%"><col>';
+    html += '</colgroup><thead><tr>';
+    html += '<th>Time</th><th>Outcome</th><th>Project</th><th>MCP</th><th>Tool</th><th>ms</th><th>Caller</th><th>Detail</th>';
+    html += '</tr></thead><tbody id="auditRows">';
+    for (const ev of rows) html += renderAuditRow(ev);
+    html += '</tbody></table>';
+    return html;
+}
+
+function renderAuditRow(ev) {
+    const a = ev.actor || {};
+    const expanded = !!state.auditExpanded[ev.id];
+    let html = '<tr class="row" onclick="toggleAuditRow(\'' + esc(ev.id) + '\')">';
+    html += '<td class="audit-time">' + esc(auditFmtTime(ev.ts)) + '</td>';
+    html += '<td><span class="audit-pill audit-' + esc(ev.outcome) + '">' + esc(ev.outcome) + '</span></td>';
+    html += '<td title="' + esc(a.project_name || '') + '">' + esc(a.project_name || '\u2014') + '</td>';
+    html += '<td>' + esc(ev.mcp_id || '\u2014') + '</td>';
+    html += '<td class="audit-tool" title="' + esc(ev.tool || '') + '">' + esc(ev.tool || ev.event) + '</td>';
+    html += '<td class="audit-ms">' + (ev.dur_ms || 0) + '</td>';
+    html += '<td title="' + esc(auditCaller(a)) + '">' + esc(auditCaller(a) || '\u2014') + '</td>';
+    const detail = auditDetail(ev);
+    html += '<td class="audit-detail" title="' + esc(detail) + '">' + esc(detail) + '</td>';
+    html += '</tr>';
+    if (expanded) html += renderAuditDetail(ev);
+    return html;
+}
+
+function renderAuditDetail(ev) {
+    const a = ev.actor || {};
+    const kv = [];
+    const add = (k, v) => { if (v !== undefined && v !== null && v !== '') kv.push([k, String(v)]); };
+    add('Event', ev.event);
+    add('When', ev.ts);
+    add('Duration', (ev.dur_ms || 0) + ' ms');
+    add('Project', a.project_name ? a.project_name + ' (' + (a.project_id || '') + ')' : '');
+    add('Actor', a.kind);
+    add('Auth', a.auth);
+    add('Working dir', a.cwd);
+    add('Caller pid', a.pid);
+    add('Process', a.proc);
+    add('Parent', a.parent);
+    add('MCP', ev.mcp_id);
+    add('Tool', ev.tool);
+    add('Outcome', ev.outcome);
+    add('Error', ev.error);
+    if (ev.result_bytes) add('Result', ev.result_bytes + ' bytes' + (ev.result_is_error ? ' (isError)' : ''));
+    if (ev.tool_count) add('Tools visible', ev.tool_count);
+    add('Event id', ev.id);
+
+    let html = '<tr class="audit-expand"><td colspan="8">';
+    html += '<dl class="audit-kv">';
+    for (const [k, v] of kv) html += '<dt>' + esc(k) + '</dt><dd>' + esc(v) + '</dd>';
+    html += '</dl>';
+    if (ev.args !== undefined && ev.args !== null && ev.args !== '') {
+        const label = ev.args_truncated
+            ? 'Arguments (truncated from ' + (ev.args_bytes || 0) + ' bytes)'
+            : 'Arguments';
+        html += '<div style="margin-top:10px;font-size:11px;color:var(--text-2)">' + esc(label) + '</div>';
+        html += '<div class="audit-args">' + esc(auditPretty(ev.args)) + '</div>';
+    }
+    if (ev.result_preview) {
+        html += '<div style="margin-top:10px;font-size:11px;color:var(--text-2)">Result preview</div>';
+        html += '<div class="audit-args">' + esc(ev.result_preview) + '</div>';
+    }
+    html += '</td></tr>';
+    return html;
+}
+
+// restoreAuditFocus puts the caret back in the filter box after a re-render.
+// Every keystroke rebuilds the table (filtering is local), which would
+// otherwise blur the input on the first character typed.
+function restoreAuditFocus() {
+    const el = document.getElementById('auditText');
+    if (!el || !state._auditTextFocused) return;
+    el.focus();
+    const n = el.value.length;
+    try { el.setSelectionRange(n, n); } catch (e) { /* search inputs may refuse */ }
+}
+
+window.onAuditEvents = function(events, status) {
+    state.auditEvents = events || [];
+    state.auditStatus = status || null;
+    state.auditLoaded = true;
+    if (state.page === 'audit') render();
+};
+
+window.onAuditEvent = function(ev) {
+    if (!ev) return;
+    if (state.auditStatus) {
+        state.auditStatus.recorded = (state.auditStatus.recorded || 0) + 1;
+    }
+    if (!state.auditFollow) return;
+    state.auditEvents.unshift(ev);
+    if (state.auditEvents.length > AUDIT_MAX_ROWS) state.auditEvents.length = AUDIT_MAX_ROWS;
+    if (state.page !== 'audit') return;
+    // Prepend surgically rather than re-rendering: a full repaint on every
+    // inbound call would fight whatever the user is typing in the filter box.
+    const tbody = document.getElementById('auditRows');
+    if (!tbody || !auditMatches(ev)) { render(); return; }
+    tbody.insertAdjacentHTML('afterbegin', renderAuditRow(ev));
+    while (tbody.children.length > AUDIT_MAX_ROWS) tbody.removeChild(tbody.lastChild);
+};
+
+window.onAuditError = function(msg) {
+    state.auditError = msg || 'audit error';
+    if (state.page === 'audit') render();
+};
+
+window.onAuditExported = function(path) {
+    state.auditExportPath = path;
+    if (state.page === 'audit') render();
+};
+
+// Track focus on the filter input so restoreAuditFocus knows whether to
+// reclaim it. Delegated at the document level because the input is destroyed
+// and recreated on every render.
+document.addEventListener('focusin', (e) => {
+    if (e.target && e.target.id === 'auditText') state._auditTextFocused = true;
+});
+document.addEventListener('focusout', (e) => {
+    if (e.target && e.target.id === 'auditText') state._auditTextFocused = false;
+});
+
 // setsEqual reports whether two Sets hold the same members.
 function setsEqual(a, b) {
     if (a.size !== b.size) return false;
@@ -2280,6 +2602,7 @@ render();
 // the shared state object) on window — exactly the global surface the original
 // classic <script> had.
 Object.assign(window, {
+    auditCaller, auditDetail, auditFmtTime, auditMatches, auditPretty, auditSelect, auditVisible, exportAudit, queryAudit, renderAudit, renderAuditDetail, renderAuditRow, restoreAuditFocus, revealAuditLog, setAuditFilter, toggleAuditFollow, toggleAuditRow,
     addExternalMcp, addExternalMcpFromJson, addExternalMcpHttp, addService, authenticateMcp, blankProjectForm, cancelMcpEdit, cancelProjectEdit, cancelServiceEdit, cfgArrayAdd, cfgArrayRemove, cfgBind, cfgChevron, cfgDirty, cfgEdit, cfgEditJson, cfgExpandKey, cfgFieldAt, cfgFirstMissingRequired, cfgGetDraft, cfgHasBadJson, cfgIsExpanded, cfgKvAdd, cfgKvRemove, cfgKvRename, cfgKvSetVal, cfgKvState, cfgMapAdd, cfgMapRemove, cfgMapRename, cfgNodeLabel, cfgRefreshChrome, cfgRerender, cfgSetExpanded, cfgToggleExpand, copyProjectToken, dispatchConfigOp, dispatchServiceAction, editProject, editService, harvestProjectForm, ipc, isAnyActionPending, isProjMcpWildcard, isProjModelsWildcard, newMcp, newProject, newService, projMcpState, projectFormFromExisting, pruneStaleDisabledTool, regenProjectSkill, removeExternalMcp, removeProject, removeService, render, renderActionButton, renderArrayBlock, renderConfigArray, renderConfigItem, renderConfigKeyValue, renderConfigLeaf, renderConfigMap, renderConfigNode, renderConfigObject, renderConfigSection, renderMcpForm, renderMcpPush, renderMcpServers, renderObjectFields, renderProjToolPicker, renderProjectForm, renderProjects, renderServiceForm, renderServiceInspector, renderServicePanel, renderServiceStatus, renderServices, renderStatusPayload, resetMcpPermissions, revertConfig, rotateProjectToken, saveConfig, saveProjectForm, saveServiceEdit, serviceBadgeHTML, setMcpAddMode, setMcpTransport, setProjMcpState, setProjMcpWildcard, setProjModelsWildcard, setsEqual, showPage, svcFormValues, toggleConfigSection, toggleProjTool, toggleProjectTokenVisible, toggleServiceRunning, updateServiceAutostart, updateServiceStatusDOM
 });
 window.state = state;


### PR DESCRIPTION
Step 1 of the tighten-security-around-LLM-tool-calls effort. Phase 2 (a remote client on a VM reaching relay for tool access) depends on this: the security value of a remote client rests entirely on being able to see what it did.

## The seam

Every tool invocation in the ecosystem funnels through `appRouter.CallTool`: `relay mcp` stdio, `relay mcp call`, relayLLM's MCP client, project shells, and whatever the remote client turns out to be. That method also resolves auth and evaluates the permission check, so one instrumentation point yields the authenticated project, the auth method, the allow/deny decision, and the outcome. No caller changes, no transport cooperates. `ListTools` and `ListSkillBuckets` are instrumented the same way, off by default.

## What lands in the log

JSONL at `<config-dir>/logs/audit/toolcalls.jsonl`, 0600, size-rotated with 5 generations:

```json
{
  "id": "9c1f...", "ts": "2026-08-19T10:22:31.412Z", "dur_ms": 412,
  "event": "call_tool",
  "actor": { "kind": "project", "project_id": "proj_7f2a", "project_name": "relay",
             "auth": "token", "pid": 41221, "proc": "relay", "parent": "claude" },
  "mcp_id": "fsmcp", "tool": "read_file",
  "args": { "path": "/Users/me/notes.md" },
  "outcome": "ok", "result_bytes": 20431
}
```

Four decisions worth calling out:

**Refusals are events.** `denied` (a resolved credential refused a tool) and `unauthorized` (the credential did not resolve) are written as reliably as successes. The naive version of this feature logs completed calls and silently drops exactly the records a review is looking for.

**Attribution never trusts the caller.** The project id comes from the resolved `StoredToken`, the same value relay injects into `_meta.project_id`. The caller's pid is read off the Unix socket with `getsockopt(LOCAL_PEERPID)` in the bridge server and carried in the request context; process and parent names come from `proc_pidinfo` (two syscalls, no fork, cheap enough for the call path). `parent` is the field that matters: `relay mcp` spawns a fresh child per call, so the peer process is a throwaway and its parent is the agent that actually asked. The pid is attribution only and is never consulted for authorization.

The one caller-asserted field is the working directory recorded for a directory-auth grant, which is caller-asserted by construction and already documented as such in `docs/tokens.md`. That grant has no deliberate credential hand-off to point at afterwards, so this log is its audit trail.

**Redacted args, metadata-only results.** Arguments are recorded with credential-like keys replaced by `[redacted]` (case-insensitive substring match, walks nested objects and arrays, extendable via `audit.redact_keys`) and capped at 4 KiB with `args_truncated` set. Results are size and `isError` only. Tool results carry file contents, mail bodies, and calendar entries; storing them by default would make the audit log the highest-value file on the machine and quietly undo the scoping the project token exists to provide. A capped preview sits behind `audit.max_result_preview_bytes`.

`isError` is probed from the MCP result rather than the Go error, because a tool that fails inside the protocol returns a normal result with that flag set.

**Fail open, visibly.** Events cross to a single writer goroutine over a bounded channel. A full queue drops the event and increments a counter, and the Tool Calls tab shows the count as a warning. A tool call is never delayed by, and never fails because of, the audit sink. That is the right tradeoff locally (a full disk should not wedge every agent on the machine) and it is only defensible because the gap is surfaced. Phase 2 adds an `audit.required` mode for remote callers, where the trust boundary justifies refusing a call that cannot be recorded.

## Reading it

New **Tool Calls** tab in Settings: filterable table (project, MCP, outcome, event kind, free text), outcome pills so a denial does not look like a success at a glance, row expand for the full record, live follow, and a filtered JSONL export. Text filtering happens in the page over what is already loaded so typing stays instant; "Search History" re-runs the same filter server-side against the log file for events older than the in-memory ring holds.

Also `relay audit --tail N --project X --outcome denied --grep TEXT --json`, which reads the file directly so it works with the tray stopped.

## Configuration

Optional `audit` block in `settings.json`. Absent means defaults, so existing installs start logging with no migration.

```jsonc
{ "audit": { "enabled": true, "log_args": true, "log_lists": false,
             "max_arg_bytes": 4096, "max_result_preview_bytes": 0,
             "ring_size": 1000, "max_file_bytes": 33554432,
             "generations": 5, "redact_keys": [] } }
```

`log_lists` is off by default: skill regeneration lists the tool surface for every project on every MCP reconcile, which would bury the calls that matter.

## Notes for review

- `bridge.ToolRouter` did not change. Peer pid rides in the context, the same technique the caller-asserted cwd already used, so cross-repo implementers are unaffected.
- `rotatingWriter` gained a `generations` field. Existing callers (relay's own log, service logs) pass 1 and behave exactly as before; a test pins that.
- Instrumentation goes through nil-safe methods on `*auditCall`, so a router without a recorder behaves as it did before and `router.go` carries no `if audit != nil` branching. A test asserts the nil path.
- `gofmt` reformatted some pre-existing alignment in `ipc_handlers.go`. Formatting only.

## Testing

- Router instrumentation: success, denial, unauthorized, unknown tool, directory auth, protocol-level tool error, list events on and off, nil recorder.
- Redaction (nested, arrays, case variants, configured extras), truncation (flagged, still valid JSON, no split runes), malformed args stored as text.
- Ring eviction order, bounded-queue drop-rather-than-block, concurrent record under `-race`.
- Rotation across generations, and the single-generation default.
- End to end over a real bridge socket, asserting the peer pid and process name reach the log through the actual transport.
- Tool Calls tab under goja: attribution rendered, outcomes visually distinct, local filtering, expanded record, truncation labelled, disabled and dropped states surfaced, live event prepends, tab load on switch.

`go test ./...`, `go test -race ./...`, and `go vet ./...` all pass.

## Not verified

The Chrome visual pass on the new tab did not run: the browser extension was not connected. The tab is covered by goja tests and the `cmd/devui` harness has audit fixtures wired (`go run ./cmd/devui`, then Tool Calls), but nobody has looked at it rendered yet.

https://claude.ai/code/session_01VBnY1fhoZq8XA7puNkf3Vh