### PR TITLE
Phase 2a: remote projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,33 @@ authenticates as that project via `AuthenticateProjectByPath`, with identical
 scope. A present-but-invalid token never falls back. See
 [`docs/tokens.md`](docs/tokens.md#directory-auth-allow_cwd_auth).
 
+### Project kind: local vs. remote
+
+`Project.Kind` (`ProjectKindLocal` / `ProjectKindRemote`) distinguishes a
+host-directory project from a pure capability grant to a client on another
+machine — e.g. an LLM agent running on a separate VM that reaches relay for
+tool access instead of running on the host. Always test `proj.IsRemote()`,
+never compare `Kind` against `ProjectKindLocal`: the zero value is local, so
+every project written before this field existed round-trips unaffected, and
+an equality check invites a future bug where an unset field reads as remote.
+
+A remote project has no `Path` and cannot have anything that presumes a host
+directory — `AllowCwdAuth`, `GenerateSkill`, `ShellTemplates`, and the
+`allowed_mcp_ids: ["*"]` wildcard are all refused by `validateProjectShape`
+(`project.go`), as is a non-empty `allowed_models` (an empty allowlist is the
+only value `modelAllowedForProject` won't misread as "unrestricted"). A
+filesystem-scoped MCP (schema declares `allowed_dirs`) can't be granted to a
+remote project either (`ValidateProjectGrants`) — and `SyncProjectToken`
+independently refuses to derive `allowed_dirs` for one regardless, since an
+MCP's schema is discovered at runtime and could gain that field after a
+grant was already validated. Sessions (`refuseRemoteSession`) and PTY
+launches (`refuseRemotePty`) are refused at the point of use too, not just
+at validation — see ADR-009 for why each of these is defended twice rather
+than once. As of this writing a remote project cannot yet be *reached* by
+anything; only the model and its invariants exist so far.
+
+See [ADR-009](docs/decisions/009-remote-projects.md) for the full reasoning.
+
 ## Service manifest (enhanced services)
 
 Every spawned service gets `RELAY_BRIDGE_SOCKET` + `RELAY_SERVICE_ID`. Services

--- a/docs/decisions/000-readme.md
+++ b/docs/decisions/000-readme.md
@@ -32,6 +32,11 @@ ADR that references the old one. Do not edit accepted ADRs in place.
 - [007 — Relay is the sole broker of project tokens](007-project-token-brokering.md):
   Eve references projects by id only; relay resolves and injects the scoped
   project token just-in-time and never hands it to the frontend.
+- [009 — Remote projects are capability grants, not directories](009-remote-projects.md):
+  a `remote` project kind for agents running on a separate VM, with no
+  filesystem path; validation refuses incoherent local-only features, and
+  filesystem scope, sessions, and PTY launches are each refused twice —
+  once by validation, once at the point of use.
 
 ## Format
 

--- a/docs/decisions/009-remote-projects.md
+++ b/docs/decisions/009-remote-projects.md
@@ -1,0 +1,154 @@
+# ADR-009: Remote Projects Are Capability Grants, Not Directories
+
+**Status:** Accepted
+**Date:** 2026-08-19
+
+## Context
+
+Step 2a of letting a semi-trusted LLM agent run on a separate VM and reach
+relay for tool access, instead of running on the host where it would have the
+world. Relay becomes a gated control plane for sensitive HOST resources —
+mail, iMessage, calendar. The VM never touches the host filesystem, so whole
+tool classes (`fs_*`, `bash*`) do not apply to a project scoped to such a
+client. That is the intended outcome, not a limitation to work around.
+
+The threat model is **exfiltration, not privilege escalation**: the VM cannot
+escape to the host, so the risk worth designing against is an agent reading an
+entire mailbox and shipping it somewhere, not an agent breaking out of its
+sandbox.
+
+This PR makes the project model coherent for that shape of client. It does
+not make a remote project reachable — the listener, client certificates, and
+enrollment flow are 2b. See Consequences.
+
+## Decision
+
+Add a second `ProjectKind`, `remote`, alongside the existing (now-implicit)
+`local`. A remote project is a pure capability grant to a client on another
+machine, with no filesystem root of its own.
+
+1. **A remote project is a capability grant, not a folder.** `Kind`'s zero
+   value reads as local (`types.go`), so every project already on disk —
+   which predates this field — round-trips untouched. Nothing compares
+   against `ProjectKindLocal` directly anywhere in the codebase; every check
+   goes through `IsRemote()`. That is deliberate: an equality check against
+   `"local"` invites a future `Kind != ProjectKindRemote` written the wrong
+   way round, and an unset field must never be able to mean "remote" no
+   matter how it's tested. `normalizeProjectKind` mirrors this on write —
+   anything that isn't `ProjectKindRemote` collapses to `""` before it's
+   stored, so a local project never persists the literal string `"local"`.
+
+2. **Validation refuses incoherent combinations rather than degrading.**
+   `validateProjectShape` (`project.go`) is the single point that decides
+   whether a candidate project's shape is coherent, called from both the
+   create and update paths. For a remote project it refuses, in turn: a
+   non-empty `Path`; `AllowCwdAuth` (a remote caller's cwd is a path on a
+   *different* machine — there is nothing to compare it against); non-empty
+   `ShellTemplates` (they launch a terminal on the project's host directory,
+   which doesn't exist); and `GenerateSkill`. The `generate_skill` case is
+   the clearest illustration of the principle: `regenProjectSkills`
+   (`router.go`) already silently skips any project whose skill directory
+   resolves empty, so leaving the flag settable on a remote project wouldn't
+   break anything — it would just make the flag an inert toggle that lies
+   about what it does. Refusing it at the door is more honest than a control
+   that quietly no-ops.
+
+3. **`allowed_dirs` is defended twice.** `SyncProjectToken` (`settings.go`)
+   writes `allowed_dirs: [proj.Path]` into an MCP's context whenever that
+   MCP's runtime schema declares the field. For a pathless project, both
+   obvious behaviors are unsafe: writing `allowed_dirs: [""]` hands a
+   downstream MCP an empty root to interpret (a Node MCP's
+   `path.resolve("")` resolves to *its own* cwd, which can be far more
+   permissive than intended), and omitting the field entirely lets the MCP
+   fall back to whatever default it has, possibly unrestricted. Relay cannot
+   see how a given MCP resolves either case. So there are two independent
+   defences: `ValidateProjectGrants` refuses to *grant* a remote project any
+   MCP whose schema declares `allowed_dirs` in the first place, naming the
+   offending MCP; and `SyncProjectToken` separately skips the derivation for
+   any remote project, unconditionally, before it ever loops over
+   `mcpIDs`. Belt-and-braces is justified here specifically because the
+   failure mode is a *silent* widening of filesystem scope rather than a
+   loud error, and because MCP context schemas are discovered at runtime —
+   an MCP could add an `allowed_dirs` field to its schema *after* a grant
+   was already validated against an earlier version of that schema. The
+   second defence, living inside the function that actually writes context,
+   is what makes that later addition survivable instead of a silent hole.
+
+4. **`allowed_mcp_ids: ["*"]` is refused for remote projects.**
+   `validateProjectShape` rejects the wildcard outright. On a local project
+   the wildcard is a convenience meaning "every MCP relay currently knows
+   about." On a remote grant it would mean that registering a new MCP on the
+   host silently widens what another machine can reach — with no action
+   taken against the project itself and no diff to review. A remote grant
+   must be an enumeration someone typed by hand; an empty list is fine
+   (enroll now, widen deliberately later is the expected resting state).
+
+5. **Sessions are refused on remote projects, and this could not live in the
+   model allowlist.** `validateProjectShape` requires a remote project's
+   `AllowedModels` to be empty. But `modelAllowedForProject`
+   (`frontend_model_guard.go`) reads an *empty* allowlist as "unrestricted" —
+   so, left to the allowlist alone, the most restrictive configuration
+   (no path, no filesystem access, no models listed) would have produced the
+   most permissive outcome (every model permitted). `refuseRemoteSession`
+   is therefore a separate check in `newSessionModelGuard`, run before the
+   allowlist check, that rejects any session-create request naming a remote
+   project outright. `frontend_model_guard_test.go` carries the paired test:
+   `TestModelAllowedForProject_WouldPermitRemoteProject` asserts the
+   allowlist alone *would* permit it, so if that assertion ever starts
+   failing, `refuseRemoteSession` may have become redundant and the pair
+   should be revisited — the test exists to keep the guard from silently
+   rotting into dead code.
+
+6. **PTY launches are refused, and this closed a live hole.**
+   `dirWithinProject("", "")` (`router.go`) returns `true`: the empty-dir
+   branch ("no directory to validate") is checked before the
+   empty-project-path branch and short-circuits it. Without an explicit
+   guard, `ResolvePtyEnv` would succeed for a pathless remote project and
+   return its plaintext token with `WorkingDir: ""` — and Go's `exec.Cmd`
+   treats an empty `Dir` as the *parent process's* working directory, so a
+   host shell would come up holding a remote project's credential, rooted
+   wherever relay happens to be running. `refuseRemotePty` closes this at
+   both of `ResolvePtyEnv`'s resolution branches: the authoritative
+   `ProjectID` path and the legacy name/directory-match path
+   (`TestResolvePtyEnv_RefusesRemoteProject` and
+   `TestResolvePtyEnv_RefusesRemoteProjectViaLegacyPath`). The same
+   reasoning applies to `ResolveProjectTemplate`, which refuses a remote
+   project explicitly rather than relying on `ShellTemplates` being empty —
+   a directly-constructed `Project` (a migration, a hand-edited
+   `settings.json`) could still carry templates from a former life as a
+   local project (`TestResolveProjectTemplate_RefusesRemoteProject`).
+
+## Consequences
+
+- **Nothing can reach a remote project yet.** This PR makes the project
+  model coherent for a remote client; it does not add the listener, client
+  certificates, or the enrollment flow that would let one actually connect.
+  Those are 2b.
+- **Converting a local project to remote is possible but constrained.** It
+  is refused while the project still holds a filesystem-scoped grant,
+  because the stale `allowed_dirs` context on that project would otherwise
+  be inherited by the converted remote project — exactly the scope leak
+  `ValidateProjectGrants` exists to prevent on creation. Dropping the
+  filesystem-scoped MCP grant in the same update request makes the
+  conversion legal. See
+  `TestProjectConvertLocalToRemote_CannotInheritFilesystemScope`
+  (`project_convert_test.go`).
+- **Per-tool tri-state permissions (`allow`/`prompt`/`deny`) are deliberately
+  out of scope here**, deferred to their own PR rather than folded into this
+  one. The `disabled_tools` ↔ `tool_policy` dual-write that a tri-state model
+  implies is the riskiest part of that design and deserves review on its
+  own, separate from the remote-project shape.
+
+## See also
+
+- ADR-007 — the project-token brokering model this builds on
+  (`docs/decisions/007-project-token-brokering.md`)
+- `docs/tokens.md` — directory auth (`allow_cwd_auth`) and why remote
+  projects can't enable it
+- `project.go` — `validateProjectShape`, `CreateProjectWithTokenKind`
+- `settings.go` — `ValidateProjectGrants`, `SyncProjectToken`,
+  `UpdateProjectKind`
+- `router.go` — `refuseRemotePty`, `dirWithinProject`,
+  `ResolveProjectTemplate`
+- `frontend_model_guard.go` — `refuseRemoteSession`,
+  `modelAllowedForProject`

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -32,6 +32,14 @@ A project may opt into token-less bridge auth: with `allow_cwd_auth: true`, a
 caller that presents **no** token but whose working directory is inside the
 project's path is authenticated as that project. Default is off, per project.
 
+- **Remote projects can't enable it.** `allow_cwd_auth` compares a caller's
+  cwd against the project's `Path`, and a remote project — a capability
+  grant to a client on another machine, see ADR-009 — has no `Path`: a
+  remote caller's cwd is a path on a *different* machine, with nothing on
+  the host to compare it against. `validateProjectShape` (`project.go`)
+  refuses the combination outright rather than let it silently mean
+  nothing.
+
 - **Scope is unchanged.** The caller gets exactly the project's token scope —
   same derived permissions, same `disabled_tools`, same `_meta` context, same
   `project_id`. Directory auth changes how a caller is *identified*, never what

--- a/frontend_model_guard.go
+++ b/frontend_model_guard.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -84,6 +85,11 @@ func newSessionModelGuard(store SettingsStore, next http.Handler) http.HandlerFu
 			return
 		}
 
+		if err := refuseRemoteSession(store, payload.ProjectID); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
 		if !modelAllowedForProject(store, payload.ProjectID, payload.Model) {
 			slog.Warn("frontend: blocked session create with disallowed model",
 				"project", payload.ProjectID, "model", payload.Model)
@@ -102,6 +108,31 @@ func newSessionModelGuard(store SettingsStore, next http.Handler) http.HandlerFu
 // are intentionally excluded (see newSessionModelGuard).
 func isSessionCreatePath(p string) bool {
 	return p == "/api/sessions" || p == "/api/sessions/"
+}
+
+// refuseRemoteSession rejects a session-create request scoped to a remote
+// project. A remote project is a capability grant to a client on another
+// machine, not a context anything runs a session in.
+//
+// This has to be its own check rather than a case inside the model allowlist,
+// because the allowlist cannot express it: modelAllowedForProject treats an
+// EMPTY AllowedModels as "unrestricted", and validateProjectShape requires a
+// remote project's AllowedModels to be empty. Left to the allowlist alone, a
+// remote project would therefore permit every model — the most permissive
+// outcome reached through the most restrictive configuration.
+//
+// Fails open on an unknown project, matching the allowlist's posture: relay
+// only refuses what it can positively identify as remote, and lets relayLLM
+// produce the authoritative error otherwise.
+func refuseRemoteSession(store SettingsStore, projectID string) error {
+	if projectID == "" {
+		return nil
+	}
+	proj, _ := store.Get().findProjectByID(projectID)
+	if proj == nil || !proj.IsRemote() {
+		return nil
+	}
+	return fmt.Errorf("project %s is a remote project and cannot host a session", projectID)
 }
 
 // modelAllowedForProject reports whether a session-create request naming

--- a/frontend_model_guard_test.go
+++ b/frontend_model_guard_test.go
@@ -242,3 +242,77 @@ func TestSessionModelGuard_IgnoresNonPost(t *testing.T) {
 		t.Error("GET /api/sessions must be forwarded to the dispatcher")
 	}
 }
+
+// remoteProject stores a remote project directly. Built by hand rather than
+// through the create path so the guard is proven on its own: a session must be
+// refused because the project IS remote, not because validation happened to
+// run somewhere upstream.
+func remoteProject(t *testing.T, store SettingsStore) Project {
+	t.Helper()
+	var out Project
+	if err := store.With(func(s *Settings) {
+		out = Project{
+			ID:            "remote-session-proj",
+			Name:          "remote",
+			Kind:          ProjectKindRemote,
+			AllowedMcpIDs: []string{},
+			Token:         "tok-remote-session",
+			TokenHash:     hashToken("tok-remote-session"),
+		}
+		s.Projects = append(s.Projects, out)
+	}); err != nil {
+		t.Fatalf("seed remote project: %v", err)
+	}
+	return out
+}
+
+// A remote project is a grant to another machine, not a place a session runs.
+//
+// This cannot be left to the model allowlist: validateProjectShape requires a
+// remote project's AllowedModels to be EMPTY, and modelAllowedForProject reads
+// an empty allowlist as "unrestricted". So without an explicit refusal the most
+// restrictive configuration produces the most permissive outcome — every model
+// allowed, on a project that should host no session at all.
+func TestSessionModelGuard_RefusesRemoteProject(t *testing.T) {
+	store := newProjectsTestStore(t)
+	proj := remoteProject(t, store)
+
+	spy := &nextSpy{}
+	guard := newSessionModelGuard(store, spy)
+	rec := httptest.NewRecorder()
+	guard(rec, postSessions(`{"projectId":"`+proj.ID+`","model":"opus"}`))
+
+	if spy.called {
+		t.Fatal("a session on a remote project reached the dispatcher")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// Belt and braces on the above: prove the allowlist alone would have let this
+// through, so the test above is testing the guard and not an accident.
+func TestModelAllowedForProject_WouldPermitRemoteProject(t *testing.T) {
+	store := newProjectsTestStore(t)
+	proj := remoteProject(t, store)
+
+	if !modelAllowedForProject(store, proj.ID, "opus") {
+		t.Fatal("expected the model allowlist to permit a remote project's empty allowlist; " +
+			"if this now fails, refuseRemoteSession may be redundant and this pair should be revisited")
+	}
+}
+
+// A local project must still create sessions exactly as before.
+func TestSessionModelGuard_LocalProjectStillCreatesSessions(t *testing.T) {
+	store := newProjectsTestStore(t)
+	proj := restrictedProject(t, store, []string{"opus"})
+
+	spy := &nextSpy{}
+	guard := newSessionModelGuard(store, spy)
+	rec := httptest.NewRecorder()
+	guard(rec, postSessions(`{"projectId":"`+proj.ID+`","model":"opus"}`))
+
+	if !spy.called {
+		t.Fatalf("local project session was blocked, status = %d", rec.Code)
+	}
+}

--- a/ipc_projects.go
+++ b/ipc_projects.go
@@ -85,23 +85,23 @@ func ipcUpdateProject(ctx *IPCContext, raw json.RawMessage) {
 			return
 		}
 	}
-	// Validate path up front (before any mutation) so an invalid path can't
-	// leave a half-applied update behind — mirrors the HTTP PUT route.
-	if msg.Path != nil {
-		if err := validateProjectPath(*msg.Path); err != nil {
-			ctx.UI.EmitEvent("onProjectError", err.Error())
-			return
-		}
-	}
-
+	// Shape/grant validation (including path) now happens inside
+	// applyProjectUpdate against the fully-merged candidate — mirrors the HTTP
+	// PUT route. See project_routes.go for why a standalone path-only
+	// pre-check can no longer judge this correctly.
 	var updated Project
 	var found bool
+	var updateErr error
 	okSettings := ctx.withSettings(func(s *Settings) {
-		updated, found = applyProjectUpdate(s, msg.ID, msg.projectUpdateFields, func() map[string]json.RawMessage {
+		updated, found, updateErr = applyProjectUpdate(s, msg.ID, msg.projectUpdateFields, func() map[string]json.RawMessage {
 			return mcpContextSchemasFrom(ctx)
 		})
 	})
 	if !okSettings {
+		return
+	}
+	if updateErr != nil {
+		ctx.UI.EmitEvent("onProjectError", updateErr.Error())
 		return
 	}
 	if !found {

--- a/project.go
+++ b/project.go
@@ -10,23 +10,46 @@ import (
 	"github.com/google/uuid"
 )
 
-// CreateProjectWithToken generates a new project with an inline scoped token.
+// CreateProjectWithToken generates a new LOCAL project with an inline scoped
+// token. Kept with its original signature so no existing caller or test has
+// to change; it's a thin wrapper over CreateProjectWithTokenKind. Call within
+// store.With.
+func (s *Settings) CreateProjectWithToken(name, path string, mcpIDs, models []string, templates []ChatTemplate, schemas map[string]json.RawMessage) (Project, error) {
+	return s.CreateProjectWithTokenKind(ProjectKindLocal, name, path, mcpIDs, models, templates, schemas)
+}
+
+// CreateProjectWithTokenKind is CreateProjectWithToken's kind-aware variant.
 // The token's permissions, disabled tools, and context are configured based on
 // the project's allowedMcpIDs and path. schemas maps MCP IDs to their runtime
 // context schemas (from ExternalMcpManager) for filesystem auto-detection.
 // Call within store.With.
-func (s *Settings) CreateProjectWithToken(name, path string, mcpIDs, models []string, templates []ChatTemplate, schemas map[string]json.RawMessage) (Project, error) {
+func (s *Settings) CreateProjectWithTokenKind(kind ProjectKind, name, path string, mcpIDs, models []string, templates []ChatTemplate, schemas map[string]json.RawMessage) (Project, error) {
+	// See normalizeProjectKind: a local project's stored Kind is always "",
+	// never the literal "local" string, so every local project — however it
+	// was created — serializes identically with no "kind" key.
+	kind = normalizeProjectKind(kind)
 	if name == "" {
 		return Project{}, fmt.Errorf("project name is required")
-	}
-	if err := validateProjectPath(path); err != nil {
-		return Project{}, err
 	}
 	if mcpIDs == nil {
 		mcpIDs = []string{}
 	}
 	if models == nil {
 		models = []string{}
+	}
+	// Validate the shape (kind-specific invariants) and the grant list
+	// (filesystem-scoped MCPs need a path to scope) before anything is
+	// persisted. GenerateSkill/AllowCwdAuth/ShellTemplates aren't parameters
+	// here — they're applied by later mutators in applyProjectCreate — so this
+	// candidate only carries what this function actually knows about; a
+	// direct caller relying solely on this function (as every pre-remote test
+	// does) still gets full path/MCP/model validation.
+	candidate := Project{Kind: kind, Path: path, AllowedMcpIDs: mcpIDs, AllowedModels: models}
+	if err := validateProjectShape(&candidate); err != nil {
+		return Project{}, err
+	}
+	if err := s.ValidateProjectGrants(&candidate, schemas); err != nil {
+		return Project{}, err
 	}
 
 	plaintext, hash, err := generateProjectToken()
@@ -36,6 +59,7 @@ func (s *Settings) CreateProjectWithToken(name, path string, mcpIDs, models []st
 
 	proj := Project{
 		ID:            uuid.New().String(),
+		Kind:          kind,
 		Name:          name,
 		Path:          path,
 		AllowedMcpIDs: mcpIDs,
@@ -79,6 +103,66 @@ func validateProjectPath(path string) error {
 		if seg == ".." {
 			return fmt.Errorf("project path must not contain '..': %q", path)
 		}
+	}
+	return nil
+}
+
+// validateProjectShape enforces the invariants specific to a project's Kind.
+// It is the single point that decides whether a given combination of Kind,
+// Path, AllowCwdAuth, GenerateSkill, ShellTemplates, AllowedMcpIDs, and
+// AllowedModels is coherent — called from both the create and update paths
+// (project.go, project_apply.go) so a project can never reach settings.json
+// in a self-contradictory shape.
+//
+// A LOCAL project (the zero value — see the Kind field comment) keeps
+// today's rules exactly: validateProjectPath's absolute-path, no-".."
+// checks, nothing else.
+//
+// A REMOTE project is a capability grant to a client on another machine, not
+// a host directory, so every host-directory-flavored feature must be absent:
+func validateProjectShape(proj *Project) error {
+	if !proj.IsRemote() {
+		return validateProjectPath(proj.Path)
+	}
+	// There is no filesystem root to validate — and none to silently invent.
+	if proj.Path != "" {
+		return fmt.Errorf("remote project must not have a path: %q", proj.Path)
+	}
+	// A remote caller's cwd is a path on a DIFFERENT machine; relay has no way
+	// to compare it against a host project path, and if a host path happened
+	// to collide, this would grant a remote client's own directory guess the
+	// tool surface of an unrelated local project. Directory auth is
+	// meaningless without a directory.
+	if proj.AllowCwdAuth {
+		return fmt.Errorf("remote project must not enable allow_cwd_auth: directory auth compares a caller's cwd against Path, which a remote project doesn't have")
+	}
+	// Skill emission writes to <Path>/.claude/skills; regenProjectSkills
+	// already silently skips pathless projects, so leaving this flag on would
+	// make it an inert toggle that lies about what it does — refuse instead.
+	if proj.GenerateSkill {
+		return fmt.Errorf("remote project must not enable generate_skill: skills are written under <path>/.claude/skills, and a remote project has no path")
+	}
+	// Shell templates launch host terminals; there is no host to launch one on.
+	if len(proj.ShellTemplates) > 0 {
+		return fmt.Errorf("remote project must not have shell templates: shell templates launch a terminal on the project's host directory, which a remote project doesn't have")
+	}
+	// On a local project "*" is a convenience that always means "every MCP
+	// relay currently knows about." On a remote grant it would mean
+	// registering a new MCP on the host silently widens what the remote
+	// machine can reach — no action taken against the project, no diff to
+	// review. A remote grant must be an enumeration someone typed by hand.
+	// (An EMPTY list is fine: enrolling a client with zero grants and
+	// widening it deliberately later is the expected resting state.)
+	if isWildcard(proj.AllowedMcpIDs) {
+		return fmt.Errorf(`remote project must not use the "*" wildcard for allowed_mcp_ids: it would let a future MCP registration silently widen what the remote client can reach; list MCP IDs explicitly`)
+	}
+	// modelAllowedForProject (frontend_model_guard.go) treats both len==0 and
+	// ["*"] as "unrestricted" — there is no representation of "no models
+	// listed" that means anything other than "every model is allowed" today.
+	// A remote project has no scoping story for models yet, so the only safe
+	// value is the one that's unambiguous: empty.
+	if len(proj.AllowedModels) > 0 {
+		return fmt.Errorf("remote project must not set allowed_models: an allowlist here would either be misread as unrestricted (see modelAllowedForProject) or need a model-scoping story remote projects don't have yet — leave it empty")
 	}
 	return nil
 }

--- a/project_apply.go
+++ b/project_apply.go
@@ -8,6 +8,7 @@ import "encoding/json"
 type projectCreateFields struct {
 	Name             string              `json:"name"`
 	Path             string              `json:"path"`
+	Kind             ProjectKind         `json:"kind,omitempty"`
 	AllowedMcpIDs    []string            `json:"allowed_mcp_ids"`
 	AllowedModels    []string            `json:"allowed_models"`
 	ChatTemplates    []ChatTemplate      `json:"chat_templates"`
@@ -25,6 +26,7 @@ type projectCreateFields struct {
 type projectUpdateFields struct {
 	Name             *string              `json:"name,omitempty"`
 	Path             *string              `json:"path,omitempty"`
+	Kind             *ProjectKind         `json:"kind,omitempty"`
 	AllowedMcpIDs    *[]string            `json:"allowed_mcp_ids,omitempty"`
 	AllowedModels    *[]string            `json:"allowed_models,omitempty"`
 	ChatTemplates    *[]ChatTemplate      `json:"chat_templates,omitempty"`
@@ -43,8 +45,30 @@ type projectUpdateFields struct {
 // that has to be rolled back) and for fetching schemas the same way it always
 // has. Returns the fully-resolved project (re-read after the sub-mutations).
 func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]json.RawMessage) (Project, error) {
-	created, err := s.CreateProjectWithToken(
-		f.Name, f.Path,
+	// GenerateSkill, AllowCwdAuth, and ShellTemplates aren't parameters of
+	// CreateProjectWithTokenKind — they're applied by the sub-mutations below,
+	// after the project already exists. Validate the FULL requested shape
+	// (and its grant list) here, before anything is created, so a request
+	// that fails on e.g. remote+generate_skill never leaves a half-built
+	// project behind that then has to be rolled back.
+	candidate := Project{
+		Kind:           f.Kind,
+		Path:           f.Path,
+		AllowedMcpIDs:  f.AllowedMcpIDs,
+		AllowedModels:  f.AllowedModels,
+		ShellTemplates: f.ShellTemplates,
+		GenerateSkill:  f.GenerateSkill,
+		AllowCwdAuth:   f.AllowCwdAuth,
+	}
+	if err := validateProjectShape(&candidate); err != nil {
+		return Project{}, err
+	}
+	if err := s.ValidateProjectGrants(&candidate, schemas); err != nil {
+		return Project{}, err
+	}
+
+	created, err := s.CreateProjectWithTokenKind(
+		f.Kind, f.Name, f.Path,
 		f.AllowedMcpIDs, f.AllowedModels,
 		f.ChatTemplates,
 		schemas,
@@ -78,20 +102,71 @@ func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]j
 
 // applyProjectUpdate patches the project with id from the set fields of f inside
 // a single settings mutation. Call within store.With / withSettings. Returns
-// (updated, false) if no project has that id. The caller validates the path and
-// permission policy up front; schemas is a lazy fetch invoked only when a path
-// or MCP change actually needs it (the common rename stays allocation-free).
-func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas func() map[string]json.RawMessage) (Project, bool) {
-	if proj, _ := s.findProjectByID(id); proj == nil {
-		return Project{}, false
+// (_, false, nil) if no project has that id, and (_, true, err) if the patch
+// would produce an invalid shape or grant list — in that case NOTHING is
+// mutated. The caller validates the permission policy up front; schemas is a
+// lazy fetch invoked only when a path/MCP change or a remote-shaped result
+// actually needs it (the common rename stays allocation-free).
+func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas func() map[string]json.RawMessage) (Project, bool, error) {
+	proj, _ := s.findProjectByID(id)
+	if proj == nil {
+		return Project{}, false, nil
 	}
 
+	// Validate the FINAL shape the patch would produce, not the touched
+	// fields in isolation: a request that only flips AllowCwdAuth on an
+	// already-remote project must still be refused, and one that only clears
+	// Path on an already-remote project (a legal no-op) must still succeed.
+	// Build the candidate and check it before mutating anything.
+	candidate := *proj
+	if f.Kind != nil {
+		candidate.Kind = *f.Kind
+	}
+	if f.Path != nil {
+		candidate.Path = *f.Path
+	}
+	if f.AllowedMcpIDs != nil {
+		candidate.AllowedMcpIDs = *f.AllowedMcpIDs
+	}
+	if f.AllowedModels != nil {
+		candidate.AllowedModels = *f.AllowedModels
+	}
+	if f.ShellTemplates != nil {
+		candidate.ShellTemplates = *f.ShellTemplates
+	}
+	if f.GenerateSkill != nil {
+		candidate.GenerateSkill = *f.GenerateSkill
+	}
+	if f.AllowCwdAuth != nil {
+		candidate.AllowCwdAuth = *f.AllowCwdAuth
+	}
+	if err := validateProjectShape(&candidate); err != nil {
+		return Project{}, true, err
+	}
+
+	// schemas() is a lazy fetch (real callers wire it to a live MCP-manager
+	// call); fetch it once and reuse for both the grants check and the
+	// existing path/MCP resync below rather than fetching it twice. Grants
+	// only need re-checking when something that could have changed the
+	// grant-validity picture actually changed: Kind flipping to remote, or
+	// the MCP set changing on an already/still-remote project. A bare rename
+	// of an already-valid remote project doesn't need to pay for it.
+	needGrantsCheck := candidate.IsRemote() && (f.AllowedMcpIDs != nil || f.Kind != nil)
 	var sc map[string]json.RawMessage
-	if f.Path != nil || f.AllowedMcpIDs != nil {
+	if f.Path != nil || f.AllowedMcpIDs != nil || needGrantsCheck {
 		sc = schemas()
 	}
+	if needGrantsCheck {
+		if err := s.ValidateProjectGrants(&candidate, sc); err != nil {
+			return Project{}, true, err
+		}
+	}
+
 	if f.Name != nil {
 		s.UpdateProjectName(id, *f.Name)
+	}
+	if f.Kind != nil {
+		s.UpdateProjectKind(id, *f.Kind)
 	}
 	if f.Path != nil {
 		s.UpdateProjectPath(id, *f.Path, sc)
@@ -146,7 +221,7 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 	}
 
 	if proj, _ := s.findProjectByID(id); proj != nil {
-		return *proj, true
+		return *proj, true, nil
 	}
-	return Project{}, false
+	return Project{}, false, nil
 }

--- a/project_apply_test.go
+++ b/project_apply_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Tests for applyProjectCreate / applyProjectUpdate's remote-project
+// validation. GenerateSkill, AllowCwdAuth, and ShellTemplates aren't
+// parameters of CreateProjectWithTokenKind (project_test.go covers that
+// function directly) — they're applied by follow-on mutators inside
+// applyProjectCreate, so exercising their rejection requires going through
+// the full projectCreateFields path tested here. All hermetic: these use a
+// bare in-memory *Settings, never the real config dir (mirrors project_test.go).
+
+// TestApplyProjectCreate_RemoteRejectsAllowCwdAuth proves the full create
+// path (not just CreateProjectWithTokenKind) refuses allow_cwd_auth on a
+// remote project, and that nothing is left behind on rejection.
+func TestApplyProjectCreate_RemoteRejectsAllowCwdAuth(t *testing.T) {
+	s := &Settings{Version: 1}
+	f := projectCreateFields{
+		Name:         "Agent VM",
+		Kind:         ProjectKindRemote,
+		AllowCwdAuth: true,
+	}
+	if _, err := applyProjectCreate(s, f, nil); err == nil {
+		t.Fatal("expected rejection of remote project with allow_cwd_auth")
+	}
+	if len(s.Projects) != 0 {
+		t.Fatalf("rejected create must not persist a project; got %d", len(s.Projects))
+	}
+}
+
+// TestApplyProjectCreate_RemoteRejectsGenerateSkill proves generate_skill is
+// refused rather than silently accepted as an inert toggle — today
+// regenProjectSkills just skips pathless projects, which would make the flag
+// a lie about what it does.
+func TestApplyProjectCreate_RemoteRejectsGenerateSkill(t *testing.T) {
+	s := &Settings{Version: 1}
+	f := projectCreateFields{
+		Name:          "Agent VM",
+		Kind:          ProjectKindRemote,
+		GenerateSkill: true,
+	}
+	if _, err := applyProjectCreate(s, f, nil); err == nil {
+		t.Fatal("expected rejection of remote project with generate_skill")
+	}
+	if len(s.Projects) != 0 {
+		t.Fatalf("rejected create must not persist a project; got %d", len(s.Projects))
+	}
+}
+
+// TestApplyProjectCreate_RemoteRejectsShellTemplates proves shell templates
+// (which launch a host terminal) are refused on a project with no host.
+func TestApplyProjectCreate_RemoteRejectsShellTemplates(t *testing.T) {
+	s := &Settings{Version: 1}
+	f := projectCreateFields{
+		Name: "Agent VM",
+		Kind: ProjectKindRemote,
+		ShellTemplates: []ShellTemplate{
+			{ID: "ssh-1", Name: "SSH box"},
+		},
+	}
+	if _, err := applyProjectCreate(s, f, nil); err == nil {
+		t.Fatal("expected rejection of remote project with shell templates")
+	}
+	if len(s.Projects) != 0 {
+		t.Fatalf("rejected create must not persist a project; got %d", len(s.Projects))
+	}
+}
+
+// TestApplyProjectCreate_RemoteRejectsPathScopedGrant proves the full create
+// path also enforces ValidateProjectGrants (not just CreateProjectWithTokenKind
+// directly), naming the offending MCP.
+func TestApplyProjectCreate_RemoteRejectsPathScopedGrant(t *testing.T) {
+	s := &Settings{Version: 1}
+	f := projectCreateFields{
+		Name:          "Agent VM",
+		Kind:          ProjectKindRemote,
+		AllowedMcpIDs: []string{"fsmcp"},
+	}
+	_, err := applyProjectCreate(s, f, testSchemas())
+	if err == nil {
+		t.Fatal("expected rejection of remote project granted a path-scoped MCP")
+	}
+	if !strings.Contains(err.Error(), "fsmcp") {
+		t.Errorf("expected error to name the offending MCP (fsmcp), got: %v", err)
+	}
+}
+
+// TestApplyProjectCreate_RemoteZeroMcpsSucceeds proves the full create path
+// accepts a remote project enrolled with zero grants.
+func TestApplyProjectCreate_RemoteZeroMcpsSucceeds(t *testing.T) {
+	s := &Settings{Version: 1}
+	f := projectCreateFields{
+		Name: "Agent VM",
+		Kind: ProjectKindRemote,
+	}
+	created, err := applyProjectCreate(s, f, nil)
+	if err != nil {
+		t.Fatalf("expected zero-MCP remote project to be created, got: %v", err)
+	}
+	if !created.IsRemote() {
+		t.Errorf("expected created project to be remote, got Kind=%q", created.Kind)
+	}
+	if len(created.AllowedMcpIDs) != 0 {
+		t.Errorf("expected zero allowed MCPs, got %v", created.AllowedMcpIDs)
+	}
+}
+
+// TestApplyProjectUpdate_RemoteRejectsAllowCwdAuthFlip proves the update path
+// re-validates the FINAL shape, not just the touched field: flipping
+// AllowCwdAuth on an already-remote project must be refused, and — critically
+// — nothing about the project may change when it is (found=true, but the
+// stored project is untouched).
+func TestApplyProjectUpdate_RemoteRejectsAllowCwdAuthFlip(t *testing.T) {
+	s := &Settings{Version: 1}
+	created, err := applyProjectCreate(s, projectCreateFields{Name: "Agent VM", Kind: ProjectKindRemote}, nil)
+	if err != nil {
+		t.Fatalf("setup create: %v", err)
+	}
+
+	allow := true
+	_, found, err := applyProjectUpdate(s, created.ID, projectUpdateFields{AllowCwdAuth: &allow}, func() map[string]json.RawMessage { return nil })
+	_ = found
+	if err == nil {
+		t.Fatal("expected rejection of allow_cwd_auth flip on a remote project")
+	}
+	after, _ := s.findProjectByID(created.ID)
+	if after.AllowCwdAuth {
+		t.Error("rejected update must not mutate the project")
+	}
+}
+
+// TestApplyProjectUpdate_RemoteRejectsWildcardMcps proves the update path
+// re-checks the wildcard rule when allowed_mcp_ids changes.
+func TestApplyProjectUpdate_RemoteRejectsWildcardMcps(t *testing.T) {
+	s := &Settings{Version: 1}
+	created, err := applyProjectCreate(s, projectCreateFields{Name: "Agent VM", Kind: ProjectKindRemote}, nil)
+	if err != nil {
+		t.Fatalf("setup create: %v", err)
+	}
+
+	wildcard := []string{"*"}
+	_, _, err = applyProjectUpdate(s, created.ID, projectUpdateFields{AllowedMcpIDs: &wildcard}, func() map[string]json.RawMessage { return nil })
+	if err == nil {
+		t.Fatal("expected rejection of wildcard allowed_mcp_ids on update for a remote project")
+	}
+	after, _ := s.findProjectByID(created.ID)
+	if len(after.AllowedMcpIDs) != 0 {
+		t.Errorf("rejected update must not mutate the project, got AllowedMcpIDs=%v", after.AllowedMcpIDs)
+	}
+}

--- a/project_convert_test.go
+++ b/project_convert_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Converting an existing LOCAL project to remote is the sharp edge: the project
+// already carries allowed_dirs context from its former life, and that context is
+// what relay injects into _meta on every tool call. If a conversion could keep
+// it, a remote client would inherit host filesystem scope — precisely the thing
+// the remote kind exists to prevent.
+func TestProjectConvertLocalToRemote_CannotInheritFilesystemScope(t *testing.T) {
+	dir := t.TempDir()
+	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "fsmcp", DisplayName: "fsMCP"}}}
+	schemas := func() map[string]json.RawMessage {
+		return map[string]json.RawMessage{"fsmcp": json.RawMessage(`{"allowed_dirs":{"type":"array"}}`)}
+	}
+
+	proj, err := s.CreateProjectWithToken("Local", dir, []string{"fsmcp"}, nil, nil, schemas())
+	if err != nil {
+		t.Fatalf("create local: %v", err)
+	}
+	stored, _ := s.findProjectByID(proj.ID)
+	if len(stored.Context["fsmcp"]) == 0 {
+		t.Fatalf("precondition: local project should have fsmcp allowed_dirs context, got %+v", stored.Context)
+	}
+
+	// Conversion attempt 1: flip kind, clear path, keep the filesystem grant.
+	remote := ProjectKindRemote
+	empty := ""
+	_, _, err = applyProjectUpdate(s, proj.ID, projectUpdateFields{Kind: &remote, Path: &empty}, schemas)
+	if err == nil {
+		t.Fatal("converting a project holding a filesystem-scoped MCP to remote must be refused")
+	}
+
+	// The refusal must have changed nothing.
+	after, _ := s.findProjectByID(proj.ID)
+	if after.IsRemote() || after.Path != dir {
+		t.Fatalf("refused conversion mutated the project: kind=%q path=%q", after.Kind, after.Path)
+	}
+
+	// Conversion attempt 2: drop the filesystem grant in the same request.
+	// This is legal, and the stale allowed_dirs context must not survive it.
+	none := []string{}
+	if _, _, err := applyProjectUpdate(s, proj.ID, projectUpdateFields{
+		Kind: &remote, Path: &empty, AllowedMcpIDs: &none,
+	}, schemas); err != nil {
+		t.Fatalf("dropping the grant should make conversion legal: %v", err)
+	}
+	converted, _ := s.findProjectByID(proj.ID)
+	if !converted.IsRemote() {
+		t.Fatal("project did not convert to remote")
+	}
+	if raw, ok := converted.Context["fsmcp"]; ok {
+		t.Fatalf("converted project still carries host filesystem scope: %s", raw)
+	}
+}

--- a/project_routes.go
+++ b/project_routes.go
@@ -143,22 +143,23 @@ func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps Context
 				return
 			}
 		}
-		// Validate path up front (before any mutation) so an invalid path can't
-		// leave a half-applied update behind.
-		if body.Path != nil {
-			if err := validateProjectPath(*body.Path); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-				return
-			}
-		}
-
+		// Shape/grant validation (including path) now happens inside
+		// applyProjectUpdate against the fully-merged candidate. Whether an
+		// empty path is valid depends on Kind (required for local, mandatory
+		// for remote), so a standalone path-only pre-check can no longer judge
+		// it correctly — the merged candidate is the only place that knows.
 		var updated Project
 		var found bool
+		var updateErr error
 		if err := store.With(func(s *Settings) {
-			updated, found = applyProjectUpdate(s, id, body, mcps.AllContextSchemas)
+			updated, found, updateErr = applyProjectUpdate(s, id, body, mcps.AllContextSchemas)
 		}); err != nil {
 			slog.Error("update project: save failed", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save settings"})
+			return
+		}
+		if updateErr != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": updateErr.Error()})
 			return
 		}
 		if !found {

--- a/project_test.go
+++ b/project_test.go
@@ -36,6 +36,134 @@ func TestProjectCreate_RejectsUnsafePath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Remote projects — capability grants to a client on another machine, with
+// no host directory. See validateProjectShape (project.go) and
+// ValidateProjectGrants (settings.go).
+// ---------------------------------------------------------------------------
+
+// TestProjectCreateRemote_NoPathSucceeds proves the whole point of the
+// feature: a remote project needs no filesystem path at all.
+func TestProjectCreateRemote_NoPathSucceeds(t *testing.T) {
+	s := &Settings{Version: 1}
+	proj, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Agent VM", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected pathless remote project to be created, got: %v", err)
+	}
+	if proj.Path != "" {
+		t.Errorf("expected empty path, got %q", proj.Path)
+	}
+	if !proj.IsRemote() {
+		t.Errorf("expected IsRemote() true, got Kind=%q", proj.Kind)
+	}
+	if len(s.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(s.Projects))
+	}
+}
+
+// TestProjectCreateRemote_ZeroAllowedMcpsValid proves an empty grant list is
+// a valid resting state for a remote project (enroll now, grant tools
+// later), not an error — unlike the wildcard, which is always rejected.
+func TestProjectCreateRemote_ZeroAllowedMcpsValid(t *testing.T) {
+	s := &Settings{Version: 1}
+	proj, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Agent VM", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected zero-MCP remote project to be created, got: %v", err)
+	}
+	if len(proj.AllowedMcpIDs) != 0 {
+		t.Errorf("expected zero allowed MCPs, got %v", proj.AllowedMcpIDs)
+	}
+}
+
+// TestProjectCreateRemote_RejectsPath proves a remote project cannot carry a
+// filesystem path: it has no host directory for the path to mean anything.
+func TestProjectCreateRemote_RejectsPath(t *testing.T) {
+	s := &Settings{Version: 1}
+	if _, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Agent VM", "/some/host/dir", nil, nil, nil, nil); err == nil {
+		t.Fatal("expected rejection of remote project with a path")
+	}
+	if len(s.Projects) != 0 {
+		t.Fatalf("rejected create must not persist a project; got %d", len(s.Projects))
+	}
+}
+
+// TestProjectCreateRemote_RejectsWildcardMcps proves a remote grant can't use
+// "*": on a local project the wildcard is a convenience, but on a remote
+// grant it means a future MCP registration silently widens what the remote
+// machine can reach, with nothing to review.
+func TestProjectCreateRemote_RejectsWildcardMcps(t *testing.T) {
+	s := &Settings{Version: 1}
+	if _, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Agent VM", "", []string{"*"}, nil, nil, nil); err == nil {
+		t.Fatal("expected rejection of remote project with wildcard allowed_mcp_ids")
+	}
+}
+
+// TestProjectCreateRemote_RejectsNonEmptyModels proves a remote project can't
+// set allowed_models at all: modelAllowedForProject treats both an empty
+// list and ["*"] as unrestricted, so an explicit but non-empty list is the
+// only way to know it means something, and remote projects don't have a
+// model-scoping story yet.
+func TestProjectCreateRemote_RejectsNonEmptyModels(t *testing.T) {
+	s := &Settings{Version: 1}
+	if _, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Agent VM", "", nil, []string{"claude-opus"}, nil, nil); err == nil {
+		t.Fatal("expected rejection of remote project with non-empty allowed_models")
+	}
+}
+
+// TestProjectCreateRemote_RejectsPathScopedMcpGrant proves granting a
+// filesystem-scoped MCP (one whose schema declares allowed_dirs) to a remote
+// project is refused, and that the error names the offending MCP so the
+// caller knows what to remove.
+func TestProjectCreateRemote_RejectsPathScopedMcpGrant(t *testing.T) {
+	s := &Settings{Version: 1}
+	_, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Agent VM", "", []string{"fsmcp"}, nil, nil, testSchemas())
+	if err == nil {
+		t.Fatal("expected rejection of remote project granted a path-scoped MCP")
+	}
+	if !strings.Contains(err.Error(), "fsmcp") {
+		t.Errorf("expected error to name the offending MCP (fsmcp), got: %v", err)
+	}
+	if len(s.Projects) != 0 {
+		t.Fatalf("rejected create must not persist a project; got %d", len(s.Projects))
+	}
+}
+
+// TestProjectKind_ZeroValueRoundTripsAsLocal proves an old (or hand-edited)
+// project record with no "kind" key at all deserializes to the zero value
+// and is never mistaken for remote.
+func TestProjectKind_ZeroValueRoundTripsAsLocal(t *testing.T) {
+	raw := []byte(`{"id":"p1","name":"NoKindKey","path":"/tmp/x","allowed_mcp_ids":["*"],"allowed_models":["*"]}`)
+	var proj Project
+	if err := json.Unmarshal(raw, &proj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if proj.Kind != "" {
+		t.Fatalf("expected zero-value Kind, got %q", proj.Kind)
+	}
+	if proj.IsRemote() {
+		t.Fatal("a project loaded from JSON with no kind key must not read as remote")
+	}
+}
+
+// TestProjectKind_LocalSerializesWithNoKindKey proves a local project never
+// writes "kind":"local" — local always persists as the absent key, the same
+// wire shape as a project created before this field existed (see
+// normalizeProjectKind).
+func TestProjectKind_LocalSerializesWithNoKindKey(t *testing.T) {
+	s := &Settings{Version: 1}
+	proj, err := s.CreateProjectWithToken("Local", t.TempDir(), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateProjectWithToken: %v", err)
+	}
+	b, err := json.Marshal(proj)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"kind"`) {
+		t.Errorf("expected no kind key in serialized local project, got %s", b)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // TestProjectCreate — create a project with temp dir, verify inline token
 // ---------------------------------------------------------------------------
 
@@ -43,7 +171,7 @@ func TestProjectCreate(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	s := &Settings{
-		Version:      1,
+		Version: 1,
 		ExternalMcps: []ExternalMcp{
 			{ID: "fsmcp", DisplayName: "fsMCP"},
 			{ID: "macmcp", DisplayName: "macMCP"},
@@ -134,7 +262,7 @@ func TestProjectUpdate(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	s := &Settings{
-		Version:      1,
+		Version: 1,
 		ExternalMcps: []ExternalMcp{
 			{ID: "fsmcp", DisplayName: "fsMCP"},
 			{ID: "macmcp", DisplayName: "macMCP"},
@@ -181,7 +309,7 @@ func TestProjectDelete(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	s := &Settings{
-		Version:      1,
+		Version: 1,
 		ExternalMcps: []ExternalMcp{
 			{ID: "fsmcp", DisplayName: "fsMCP"},
 		},
@@ -219,7 +347,7 @@ func TestProjectTokenScoping(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	s := &Settings{
-		Version:      1,
+		Version: 1,
 		ExternalMcps: []ExternalMcp{
 			{ID: "fsmcp", DisplayName: "fsMCP"},
 			{ID: "macmcp", DisplayName: "macMCP"},

--- a/project_ui_payload_test.go
+++ b/project_ui_payload_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The settings UI builds its save payload in harvestProjectForm (web/src/app.js).
+// This pins the Go side against that exact JSON shape: a mismatch in a tag name
+// would fail silently, since every field on projectUpdateFields is optional and
+// an unrecognised key is simply ignored.
+func TestRemoteProjectPayloadFromSettingsUI(t *testing.T) {
+	raw := []byte(`{
+		"name":"Hermes VM",
+		"kind":"remote",
+		"allowed_mcp_ids":[],
+		"allowed_models":[],
+		"permission_policy":{"default_mode":"","allowed_tools":[],"denied_tools":[]},
+		"generate_skill":false,
+		"allow_cwd_auth":false,
+		"disabled_tools":{}
+	}`)
+	var f projectCreateFields
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("settings-UI payload did not decode: %v", err)
+	}
+	if f.Kind != ProjectKindRemote {
+		t.Fatalf(`"kind":"remote" did not reach projectCreateFields.Kind (got %q) — check the json tag`, f.Kind)
+	}
+	if f.Path != "" {
+		t.Errorf("payload with no path key produced Path=%q", f.Path)
+	}
+
+	s := &Settings{}
+	created, err := applyProjectCreate(s, f, nil)
+	if err != nil {
+		t.Fatalf("creating a zero-grant remote project from the UI payload failed: %v", err)
+	}
+	if !created.IsRemote() || created.Path != "" {
+		t.Fatalf("created project is not a pathless remote project: kind=%q path=%q", created.Kind, created.Path)
+	}
+}

--- a/router.go
+++ b/router.go
@@ -414,6 +414,8 @@ func (r *appRouter) GetProject(id string, token string) (json.RawMessage, error)
 // RelayToken in the response is the project's plaintext token; the caller
 // (relayLLM) must inject it as the project-token env (RELAY_PROJECT_TOKEN) in
 // the spawned process and never expose it in argv, files, or logs.
+//
+// Remote projects are refused outright — see refuseRemotePty.
 func (r *appRouter) ResolvePtyEnv(ctx context.Context, req bridge.PtyEnvRequest, token string) (bridge.PtyEnvResponse, error) {
 	if err := r.requireServiceToken(token, "ResolvePtyEnv"); err != nil {
 		return bridge.PtyEnvResponse{}, err
@@ -430,6 +432,9 @@ func (r *appRouter) ResolvePtyEnv(ctx context.Context, req bridge.PtyEnvRequest,
 		if proj == nil {
 			return bridge.PtyEnvResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeMethodNotFound, fmt.Errorf("project not found: project_id=%q", req.ProjectID))
 		}
+		if err := refuseRemotePty(proj); err != nil {
+			return bridge.PtyEnvResponse{}, err
+		}
 		if !dirWithinProject(req.Directory, proj.Path) {
 			return bridge.PtyEnvResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeInvalidParams, fmt.Errorf("directory %q is not within project %q", req.Directory, proj.ID))
 		}
@@ -438,6 +443,9 @@ func (r *appRouter) ResolvePtyEnv(ctx context.Context, req bridge.PtyEnvRequest,
 		proj = findProjectForPty(s, req.Project, req.Directory)
 		if proj == nil {
 			return bridge.PtyEnvResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeMethodNotFound, fmt.Errorf("project not found: project=%q directory=%q", req.Project, req.Directory))
+		}
+		if err := refuseRemotePty(proj); err != nil {
+			return bridge.PtyEnvResponse{}, err
 		}
 	}
 
@@ -469,6 +477,16 @@ func (r *appRouter) ResolveProjectTemplate(ctx context.Context, req bridge.Shell
 	if proj == nil {
 		return bridge.ShellTemplateResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeMethodNotFound, fmt.Errorf("project not found: project_id=%q", req.ProjectID))
 	}
+	// Validation already keeps ShellTemplates empty on a remote project, so the
+	// loop below would fall through to "not found" anyway. Refuse explicitly
+	// regardless: a Project constructed directly (a migration, a hand-edited
+	// settings.json) could carry templates from a former life as a local
+	// project, and resolving one would hand a host launch command to a caller
+	// acting for another machine.
+	if proj.IsRemote() {
+		return bridge.ShellTemplateResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeInvalidParams,
+			fmt.Errorf("project %q is a remote project: shell templates launch a host terminal", proj.ID))
+	}
 	for _, t := range proj.ShellTemplates {
 		if t.ID == req.TemplateID {
 			return bridge.ShellTemplateResponse{
@@ -483,6 +501,29 @@ func (r *appRouter) ResolveProjectTemplate(ctx context.Context, req bridge.Shell
 		}
 	}
 	return bridge.ShellTemplateResponse{}, jsonrpc.NewCodedError(jsonrpc.CodeMethodNotFound, fmt.Errorf("shell template not found: project_id=%q template_id=%q", req.ProjectID, req.TemplateID))
+}
+
+// refuseRemotePty rejects a PTY launch bound to a remote project.
+//
+// This is not merely "a remote project has nothing sensible to run in". Without
+// it the request succeeds: dirWithinProject("", "") returns true, because the
+// empty-dir branch ("no directory to validate") is checked before the empty-
+// project-path branch and short-circuits it. The caller would then receive the
+// project's plaintext token with WorkingDir: "", and Go's exec.Cmd treats an
+// empty Dir as the PARENT process's working directory — so a host shell would
+// come up holding a remote project's credential, rooted wherever relay happens
+// to be running. That is exactly the confused-deputy binding the directory
+// check exists to prevent, arrived at by a different route.
+//
+// Refusing here rather than teaching dirWithinProject about kinds keeps that
+// helper a pure containment predicate, and keeps the reason visible at the
+// place where the token is about to be handed out.
+func refuseRemotePty(proj *Project) error {
+	if !proj.IsRemote() {
+		return nil
+	}
+	return jsonrpc.NewCodedError(jsonrpc.CodeInvalidParams,
+		fmt.Errorf("project %q is a remote project: it has no host directory to launch a terminal in", proj.ID))
 }
 
 // findProjectForPty resolves the project for a PTY launch. Eve's terminal_create

--- a/router_remote_guard_test.go
+++ b/router_remote_guard_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"relaygo/bridge"
+)
+
+// remoteProjectRouter returns a router whose settings hold one remote project.
+// The project is built directly rather than through the create path so these
+// guards are proven independently of validation — the whole point of a second
+// line of defence is that it holds when the first one didn't run.
+func remoteProjectRouter(t *testing.T) (*appRouter, string) {
+	t.Helper()
+	s := makeSettings(nil, nil, nil)
+	s.Projects = append(s.Projects, Project{
+		ID:            "remote-proj",
+		Name:          "remote",
+		Kind:          ProjectKindRemote,
+		AllowedMcpIDs: []string{},
+		Token:         "remote-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TokenHash:     hashToken("remote-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		// Carried from a former life as a local project. Validation would
+		// refuse this today; the guard must not depend on that.
+		ShellTemplates: []ShellTemplate{{ID: "tpl-1", Name: "ssh", Command: "/usr/bin/ssh"}},
+	})
+	r := newTestRouter(t, s, NewExternalMcpManager(nil))
+	svcToken := "service-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	r.serviceTokens.Register(hashToken(svcToken))
+	return r, svcToken
+}
+
+// The hole this closes: dirWithinProject("", "") returns true, because the
+// empty-dir branch is evaluated before the empty-project-path branch and
+// short-circuits it. Without an explicit refusal the call SUCCEEDS and hands
+// back the remote project's plaintext token with WorkingDir: "", which Go's
+// exec.Cmd resolves to relay's own working directory.
+func TestResolvePtyEnv_RefusesRemoteProject(t *testing.T) {
+	r, svcToken := remoteProjectRouter(t)
+
+	resp, err := r.ResolvePtyEnv(context.Background(),
+		bridge.PtyEnvRequest{ProjectID: "remote-proj", Directory: ""}, svcToken)
+	if err == nil {
+		t.Fatalf("remote project PTY launch was permitted, returned working_dir=%q token_len=%d",
+			resp.WorkingDir, len(resp.RelayToken))
+	}
+	if resp.RelayToken != "" {
+		t.Error("a refused PTY launch still returned a project token")
+	}
+	if !strings.Contains(err.Error(), "remote project") {
+		t.Errorf("error should name the reason, got: %v", err)
+	}
+}
+
+// The legacy resolution branch (no ProjectID, matched by name) must refuse too,
+// or the guard is bypassable by using the older request shape.
+func TestResolvePtyEnv_RefusesRemoteProjectViaLegacyPath(t *testing.T) {
+	r, svcToken := remoteProjectRouter(t)
+
+	if _, err := r.ResolvePtyEnv(context.Background(),
+		bridge.PtyEnvRequest{Project: "remote"}, svcToken); err == nil {
+		t.Fatal("legacy project-name resolution let a remote project through")
+	}
+}
+
+// A local project must still resolve normally — the guard must not have
+// tightened the everyday path.
+func TestResolvePtyEnv_LocalProjectStillResolves(t *testing.T) {
+	dir := t.TempDir()
+	s := makeSettings(nil, nil, nil)
+	s.Projects[0].Path = dir
+	r := newTestRouter(t, s, NewExternalMcpManager(nil))
+	svcToken := "service-token-cccccccccccccccccccccccccccccccc"
+	r.serviceTokens.Register(hashToken(svcToken))
+
+	resp, err := r.ResolvePtyEnv(context.Background(),
+		bridge.PtyEnvRequest{ProjectID: "test-project", Directory: dir}, svcToken)
+	if err != nil {
+		t.Fatalf("local project PTY launch was refused: %v", err)
+	}
+	if resp.WorkingDir != dir || resp.RelayToken == "" {
+		t.Errorf("local resolve returned working_dir=%q token_empty=%v", resp.WorkingDir, resp.RelayToken == "")
+	}
+}
+
+func TestResolveProjectTemplate_RefusesRemoteProject(t *testing.T) {
+	r, svcToken := remoteProjectRouter(t)
+
+	// The fixture deliberately carries a shell template, so a missing guard
+	// would resolve it rather than falling through to "not found".
+	resp, err := r.ResolveProjectTemplate(context.Background(),
+		bridge.ShellTemplateRequest{ProjectID: "remote-proj", TemplateID: "tpl-1"}, svcToken)
+	if err == nil {
+		t.Fatalf("remote project resolved a host shell template: command=%q", resp.Command)
+	}
+	if resp.Command != "" {
+		t.Errorf("a refused template resolve still returned a command: %q", resp.Command)
+	}
+}

--- a/settings.go
+++ b/settings.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 )
@@ -234,8 +235,33 @@ func (s *Settings) UpdateProjectPath(id string, path string, schemas map[string]
 	if proj == nil {
 		return
 	}
+	// Belt-and-braces: the real refusal is validateProjectShape at the call
+	// site (applyProjectUpdate validates the full candidate before any
+	// mutation runs), but this mutator is exported on Settings and nothing
+	// stops a future caller from invoking it directly without going through
+	// that guard. A remote project has no filesystem scope, so silently
+	// refuse rather than let one acquire a path no validation pass approved.
+	// Clearing an already-remote project's path back to "" is a no-op and
+	// stays allowed.
+	if proj.IsRemote() && path != "" {
+		return
+	}
 	proj.Path = path
 	s.SyncProjectToken(proj, schemas)
+}
+
+// UpdateProjectKind changes a project's kind. Does not save; use within
+// store.With. Like the other single-field Update* mutators this applies the
+// change unconditionally — the caller (applyProjectCreate / applyProjectUpdate)
+// is responsible for validating the resulting shape with validateProjectShape
+// before this runs.
+func (s *Settings) UpdateProjectKind(id string, kind ProjectKind) {
+	proj, _ := s.findProjectByID(id)
+	if proj == nil {
+		return
+	}
+	// See normalizeProjectKind: local always persists as "", never "local".
+	proj.Kind = normalizeProjectKind(kind)
 }
 
 // UpdateProjectChatTemplates replaces a project's chat_templates list.
@@ -416,6 +442,20 @@ func (s *Settings) SyncProjectToken(proj *Project, schemas map[string]json.RawMe
 			delete(proj.DisabledTools, id)
 		}
 	}
+	// Defence in depth: a remote project has no Path, and BOTH ways to handle
+	// that are unsafe — writing allowed_dirs: [""] hands a downstream MCP an
+	// empty root to interpret (a Node MCP's path.resolve("") resolves to ITS
+	// OWN cwd, which can be far more permissive than intended), and omitting
+	// the field lets the MCP fall back to its own default, which may be
+	// unrestricted. Relay can't see how a given MCP interprets either, so
+	// remote projects skip this derivation entirely — never just when
+	// validation happens to catch it. ValidateProjectGrants is supposed to
+	// refuse granting a path-scoped MCP to a remote project before this ever
+	// runs; this guard is what keeps a bypass of that check from turning into
+	// a silent filesystem-scope widening instead of a loud one.
+	if proj.IsRemote() {
+		return
+	}
 	for _, mcpID := range mcpIDs {
 		if schemaHasField(schemas[mcpID], "allowed_dirs") {
 			ctx, _ := json.Marshal(map[string]interface{}{
@@ -428,6 +468,34 @@ func (s *Settings) SyncProjectToken(proj *Project, schemas map[string]json.RawMe
 			}
 		}
 	}
+}
+
+// ValidateProjectGrants rejects a remote project's MCP grant list if it
+// includes any MCP whose runtime context schema declares allowed_dirs — i.e.
+// an MCP that expects to be scoped to a filesystem path. A remote project has
+// no Path (validateProjectShape enforces that), so granting it a path-scoped
+// MCP would leave SyncProjectToken with no safe way to derive allowed_dirs
+// (see the comment there). The grant itself is refused up front instead,
+// naming the offending MCP so the caller knows what to remove.
+//
+// Local projects are exempt: a path-scoped MCP granted to a local project is
+// exactly the expected case, and SyncProjectToken fills in its real Path.
+//
+// schemas is the same runtime context-schema map SyncProjectToken consumes.
+// A nil/missing entry can't declare allowed_dirs, so passing nil schemas
+// (e.g. a test with no MCP manager wired) is a no-op here, matching
+// SyncProjectToken's "schemas nil => skip filesystem auto-detection" contract
+// rather than failing closed on missing information.
+func (s *Settings) ValidateProjectGrants(proj *Project, schemas map[string]json.RawMessage) error {
+	if !proj.IsRemote() {
+		return nil
+	}
+	for _, mcpID := range proj.AllowedMcpIDs {
+		if schemaHasField(schemas[mcpID], "allowed_dirs") {
+			return fmt.Errorf("remote project cannot be granted %q: it is a filesystem-scoped MCP (declares allowed_dirs) and a remote project has no path to scope it to", mcpID)
+		}
+	}
+	return nil
 }
 
 // schemaHasField checks if a context schema declares a given field.

--- a/settings_projects_test.go
+++ b/settings_projects_test.go
@@ -240,3 +240,57 @@ func TestSyncProjectToken_WildcardPreservesPriorDisabledTools(t *testing.T) {
 		t.Errorf("expected macmcp disabled tools preserved across wildcard switch, got %v", after.DisabledTools)
 	}
 }
+
+// TestSyncProjectToken_LocalStillGetsAllowedDirsAndFsBashDisabled pins the
+// pre-remote behavior for LOCAL projects: this is one of the two existing
+// behaviors (see settings.go SyncProjectToken) that the remote defense-in-
+// depth guard must not disturb.
+func TestSyncProjectToken_LocalStillGetsAllowedDirsAndFsBashDisabled(t *testing.T) {
+	store := newProjectsTestStore(t)
+	dir := t.TempDir()
+	proj := createTestProject(t, store, "Alpha", dir, []string{"fsmcp"})
+
+	after, _ := store.Get().findProjectByID(proj.ID)
+	var ctxMap map[string]interface{}
+	if err := json.Unmarshal(after.Context["fsmcp"], &ctxMap); err != nil {
+		t.Fatalf("expected fsmcp context to be set for a local project: %v", err)
+	}
+	dirs, _ := ctxMap["allowed_dirs"].([]interface{})
+	if len(dirs) != 1 || dirs[0] != dir {
+		t.Errorf("expected allowed_dirs=[%q], got %v", dir, ctxMap["allowed_dirs"])
+	}
+	if !slices.Contains(after.DisabledTools["fsmcp"], "fs_bash") {
+		t.Errorf("expected fs_bash auto-disabled for a local project, got %v", after.DisabledTools["fsmcp"])
+	}
+}
+
+// TestSyncProjectToken_RemoteNeverWritesAllowedDirs proves defence (b): even
+// if validation is somehow bypassed, SyncProjectToken itself refuses to
+// derive allowed_dirs for a remote project. The Project is constructed
+// directly (not through CreateProjectWithTokenKind/ValidateProjectGrants) so
+// this test exercises SyncProjectToken's own guard in isolation, independent
+// of whether validation would have caught the same grant.
+func TestSyncProjectToken_RemoteNeverWritesAllowedDirs(t *testing.T) {
+	store := newProjectsTestStore(t)
+	var proj Project
+	store.With(func(s *Settings) {
+		proj = Project{
+			ID:            "remote-1",
+			Name:          "Bypassed",
+			Kind:          ProjectKindRemote,
+			Path:          "", // remote projects have no path
+			AllowedMcpIDs: []string{"fsmcp"},
+			CreatedAt:     "now",
+		}
+		s.AddProject(proj)
+		p, _ := s.findProjectByID(proj.ID)
+		s.SyncProjectToken(p, fsSchemas())
+	})
+	after, _ := store.Get().findProjectByID(proj.ID)
+	if after == nil {
+		t.Fatal("project not found after SyncProjectToken")
+	}
+	if _, present := after.Context["fsmcp"]; present {
+		t.Errorf("remote project must never get an allowed_dirs context entry, got %v", after.Context["fsmcp"])
+	}
+}

--- a/settings_projects_ui_test.go
+++ b/settings_projects_ui_test.go
@@ -1,0 +1,470 @@
+package main
+
+// Characterization + regression tests for the Projects tab's tri-state MCP
+// picker and (later in this file) the remote-project form behavior added on
+// top of it. Part 1 (characterization) pins CURRENT behavior of projMcpState,
+// setProjMcpState, toggleProjTool, pruneStaleDisabledTool, and
+// harvestProjectForm's payload shape BEFORE the remote-kind changes land, so a
+// regression in the surrounding refactor shows up here. Part 2 covers the new
+// remote-project behavior itself. Uses the same goja harness as
+// settings_bundle_test.go (newAppVM, evalString, domShim).
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Part 1 — characterization tests (pin behavior that predates this change)
+// ---------------------------------------------------------------------------
+
+// TestProjMcpStateThreeStates pins how projMcpState derives each of its three
+// states. The subtle one: 'selected' is signalled by KEY PRESENCE in
+// disabled_tools (even an empty array), not by array length — setProjMcpState
+// deliberately seeds disabled_tools[mcpID] = [] when the user picks "Selected"
+// before unchecking anything, and projMcpState must still read that back as
+// 'selected' rather than falling through to 'all'.
+func TestProjMcpStateThreeStates(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		var wildForm = { allowed_mcp_ids: ['*'], disabled_tools: {} };
+		var noneForm = { allowed_mcp_ids: ['b'], disabled_tools: {} };
+		var allForm = { allowed_mcp_ids: ['a'], disabled_tools: {} };
+		var selectedEmptyForm = { allowed_mcp_ids: ['a'], disabled_tools: { a: [] } };
+		var selectedNonEmptyForm = { allowed_mcp_ids: ['a'], disabled_tools: { a: ['tool1'] } };
+		return JSON.stringify({
+			wild: window.projMcpState(wildForm, 'anything'),
+			none: window.projMcpState(noneForm, 'a'),
+			allNoKey: window.projMcpState(allForm, 'a'),
+			selectedEmptyArray: window.projMcpState(selectedEmptyForm, 'a'),
+			selectedNonEmptyArray: window.projMcpState(selectedNonEmptyForm, 'a')
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"wild":"all"`,
+		`"none":"none"`,
+		`"allNoKey":"all"`,
+		`"selectedEmptyArray":"selected"`,
+		`"selectedNonEmptyArray":"selected"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("projMcpState: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestSetProjMcpStateSelectedSeedsEmptyArray pins the sentinel behavior
+// explicitly: clicking "Selected" writes an EMPTY array into disabled_tools,
+// not no key at all — because key presence (not length) is what projMcpState
+// reads. If this ever regressed to skip seeding, the UI would render as "All
+// tools" immediately after the user clicked "Selected".
+func TestSetProjMcpStateSelectedSeedsEmptyArray(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.externalMcps = [{id:'a'}, {id:'b'}];
+		window.newProject();
+		window.state.projectForm.allowed_mcp_ids = [];
+		window.state.projectForm.disabled_tools = {};
+		window.setProjMcpState('a', 'selected');
+		var f = window.state.projectForm;
+		return JSON.stringify({
+			hasKey: Object.prototype.hasOwnProperty.call(f.disabled_tools, 'a'),
+			isEmptyArray: Array.isArray(f.disabled_tools.a) && f.disabled_tools.a.length === 0,
+			stateReadsSelected: window.projMcpState(f, 'a') === 'selected'
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{`"hasKey":true`, `"isEmptyArray":true`, `"stateReadsSelected":true`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("setProjMcpState('selected') sentinel: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestSetProjMcpStateExpandsWildcard pins that the FIRST per-MCP edit off of
+// the wildcard state expands allowed_mcp_ids into the concrete registered MCP
+// ID set (and resets disabled_tools) before applying the requested state.
+func TestSetProjMcpStateExpandsWildcard(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.externalMcps = [{id:'a'}, {id:'b'}, {id:'c'}];
+		window.newProject(); // blank form starts wildcard
+		var wildBefore = window.isProjMcpWildcard(window.state.projectForm);
+		window.setProjMcpState('b', 'none');
+		var f = window.state.projectForm;
+		return JSON.stringify({
+			wildBefore: wildBefore,
+			wildAfter: window.isProjMcpWildcard(f),
+			ids: f.allowed_mcp_ids.slice().sort(),
+			bState: window.projMcpState(f, 'b')
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"wildBefore":true`, `"wildAfter":false`, `"ids":["a","c"]`, `"bState":"none"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wildcard expansion: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestSetProjMcpStateTransitions pins the 'all' / 'selected' / 'none' button
+// transitions on an already-expanded (non-wildcard) form.
+func TestSetProjMcpStateTransitions(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.externalMcps = [{id:'a'}];
+		window.newProject();
+		var f = window.state.projectForm;
+		f.allowed_mcp_ids = [];
+		f.disabled_tools = {};
+
+		window.setProjMcpState('a', 'all');
+		var afterAll = { ids: f.allowed_mcp_ids.slice(), state: window.projMcpState(f, 'a') };
+
+		window.setProjMcpState('a', 'selected');
+		var afterSelected = { ids: f.allowed_mcp_ids.slice(), state: window.projMcpState(f, 'a'), hasKey: Object.prototype.hasOwnProperty.call(f.disabled_tools, 'a') };
+
+		window.setProjMcpState('a', 'none');
+		var afterNone = { ids: f.allowed_mcp_ids.slice(), state: window.projMcpState(f, 'a'), hasKey: Object.prototype.hasOwnProperty.call(f.disabled_tools, 'a') };
+
+		return JSON.stringify({ afterAll: afterAll, afterSelected: afterSelected, afterNone: afterNone });
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"afterAll":{"ids":["a"],"state":"all"}`,
+		`"afterSelected":{"ids":["a"],"state":"selected","hasKey":true}`,
+		`"afterNone":{"ids":[],"state":"none","hasKey":false}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("setProjMcpState transitions: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestToggleProjToolDenylistPreservesStale pins two things about
+// toggleProjTool: (1) it stores a DENYLIST — unchecking a tool adds it to
+// disabled_tools[mcpID], checking it removes it; (2) it preserves any
+// previously-disabled tool names that are no longer present in the live tool
+// list (e.g. the MCP was renamed/upgraded), regardless of what's being
+// toggled in the same call.
+func TestToggleProjToolDenylistPreservesStale(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.externalMcps = [{id:'m'}];
+		window.newProject();
+		var f = window.state.projectForm;
+		f.allowed_mcp_ids = ['m'];
+		f.disabled_tools = { m: ['stale-tool'] };
+		window.state.mcpToolCache = { m: [{name:'a'}, {name:'b'}] };
+
+		// Uncheck live tool 'a' -> denylist gains 'a', keeps preserving 'stale-tool'.
+		window.toggleProjTool('m', 'a', false);
+		var afterUncheck = f.disabled_tools.m.slice().sort();
+
+		// Re-check 'a' -> denylist loses 'a' but 'stale-tool' survives untouched.
+		window.toggleProjTool('m', 'a', true);
+		var afterRecheck = f.disabled_tools.m.slice().sort();
+
+		return JSON.stringify({ afterUncheck: afterUncheck, afterRecheck: afterRecheck });
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"afterUncheck":["a","stale-tool"]`,
+		`"afterRecheck":["stale-tool"]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("toggleProjTool denylist/stale preservation: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestPruneStaleDisabledTool pins pruneStaleDisabledTool: kept=true is a
+// no-op, kept=false removes exactly that name from the mcp's denylist.
+func TestPruneStaleDisabledTool(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.externalMcps = [{id:'m'}];
+		window.newProject();
+		var f = window.state.projectForm;
+		f.allowed_mcp_ids = ['m'];
+		f.disabled_tools = { m: ['stale-tool', 'other-stale'] };
+
+		window.pruneStaleDisabledTool('m', 'stale-tool', true); // kept=true -> no-op
+		var afterKeep = window.state.projectForm.disabled_tools.m.slice().sort();
+
+		window.pruneStaleDisabledTool('m', 'stale-tool', false); // kept=false -> removed
+		var afterPrune = window.state.projectForm.disabled_tools.m.slice().sort();
+
+		return JSON.stringify({ afterKeep: afterKeep, afterPrune: afterPrune });
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"afterKeep":["other-stale","stale-tool"]`,
+		`"afterPrune":["other-stale"]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("pruneStaleDisabledTool: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestHarvestProjectFormPayloadShape pins the current (pre-remote-kind)
+// harvestProjectForm payload: it carries the form's identity/grant/policy
+// fields, and it deliberately OMITS chat_templates (Eve owns editing them;
+// update_project treats an absent field as "leave unchanged"). This must
+// still hold after the remote-kind form work — the only additive change
+// expected there is a new `kind` field.
+func TestHarvestProjectFormPayloadShape(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.projects = [{
+			id: 'p1', name: 'Proj', path: '/tmp/proj',
+			allowed_mcp_ids: ['a', 'b'], allowed_models: ['*'],
+			disabled_tools: { a: ['x'] },
+			generate_skill: true, allow_cwd_auth: true,
+			chat_templates: [{id:'t1', name:'T', model:'claude-sonnet'}]
+		}];
+		window.editProject('p1');
+		var payload = window.harvestProjectForm();
+		return JSON.stringify({
+			name: payload.name,
+			path: payload.path,
+			allowedMcpIds: payload.allowed_mcp_ids,
+			allowedModels: payload.allowed_models,
+			generateSkill: payload.generate_skill,
+			allowCwdAuth: payload.allow_cwd_auth,
+			disabledTools: payload.disabled_tools,
+			omitsChatTemplates: !('chat_templates' in payload)
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"name":"Proj"`, `"path":"/tmp/proj"`, `"allowedMcpIds":["a","b"]`,
+		`"allowedModels":["*"]`, `"generateSkill":true`, `"allowCwdAuth":true`,
+		`"disabledTools":{"a":["x"]}`, `"omitsChatTemplates":true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("harvestProjectForm payload shape: missing %s in %s", want, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Part 3 — new remote-project form behavior
+// ---------------------------------------------------------------------------
+
+// TestRemoteProjectFormHidesHostControls covers both the edit form for an
+// existing remote project and the new-project form after switching to Remote:
+// the path input, Directory Auth section, Generate Skill section, and the "*"
+// wildcard toggles (MCPs and models) must all be ABSENT from the rendered
+// HTML — not merely disabled — and a short note must explain why.
+func TestRemoteProjectFormHidesHostControls(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.externalMcps = [{id:'a', display_name:'Alpha'}];
+		window.state.projects = [{
+			id: 'p1', name: 'Remote One', kind: 'remote', path: '',
+			allowed_mcp_ids: [], allowed_models: [], disabled_tools: {}
+		}];
+		window.editProject('p1');
+		var editHtml = window.renderProjectForm();
+
+		window.newProject();
+		window.setProjKind('remote');
+		var newHtml = window.renderProjectForm();
+
+		return JSON.stringify({
+			editNoPathInput: editHtml.indexOf('id="projPath"') < 0,
+			editNoDirAuth: editHtml.indexOf('Directory Auth') < 0,
+			editNoSkillSection: editHtml.indexOf('Auto-generate SKILL.md') < 0,
+			editNoMcpWildcard: editHtml.indexOf('Allow all registered MCPs') < 0,
+			editNoModelsWildcard: editHtml.indexOf('Allow all models') < 0,
+			editHasNote: editHtml.indexOf('no host directory') >= 0,
+			editShowsKindLabel: editHtml.indexOf('Remote') >= 0,
+			newNoPathInput: newHtml.indexOf('id="projPath"') < 0,
+			newNoDirAuth: newHtml.indexOf('Directory Auth') < 0,
+			newNoSkillSection: newHtml.indexOf('Auto-generate SKILL.md') < 0,
+			newNoMcpWildcard: newHtml.indexOf('Allow all registered MCPs') < 0,
+			newNoModelsWildcard: newHtml.indexOf('Allow all models') < 0,
+			newHasKindSelector: newHtml.indexOf("setProjKind('local')") >= 0 && newHtml.indexOf("setProjKind('remote')") >= 0
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"editNoPathInput":true`, `"editNoDirAuth":true`, `"editNoSkillSection":true`,
+		`"editNoMcpWildcard":true`, `"editNoModelsWildcard":true`, `"editHasNote":true`,
+		`"editShowsKindLabel":true`,
+		`"newNoPathInput":true`, `"newNoDirAuth":true`, `"newNoSkillSection":true`,
+		`"newNoMcpWildcard":true`, `"newNoModelsWildcard":true`, `"newHasKindSelector":true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("remote form hides host controls: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestRemoteProjectZeroMcpHarvest covers the valid resting state described in
+// project_apply.go: a remote project with zero MCP grants harvests to a
+// payload the server will accept — kind "remote", no path key at all, an
+// empty allowed_models, and an empty (not missing) allowed_mcp_ids. Also
+// checks that saveProjectForm's client-side validation does not block on the
+// (now absent) path.
+func TestRemoteProjectZeroMcpHarvest(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.projects = [{
+			id: 'p2', name: 'Remote Zero', kind: 'remote', path: '',
+			allowed_mcp_ids: [], allowed_models: [], disabled_tools: {},
+			generate_skill: false, allow_cwd_auth: false
+		}];
+		window.editProject('p2');
+		var payload = window.harvestProjectForm();
+
+		window.editProject('p2'); // saveProjectForm mutates state; re-select
+		window.saveProjectForm();
+
+		return JSON.stringify({
+			kind: payload.kind,
+			hasPathKey: ('path' in payload),
+			allowedModels: payload.allowed_models,
+			allowedMcpIds: payload.allowed_mcp_ids,
+			generateSkill: payload.generate_skill,
+			allowCwdAuth: payload.allow_cwd_auth,
+			formErrorAfterSave: window.state.projectFormError
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"kind":"remote"`, `"hasPathKey":false`, `"allowedModels":[]`, `"allowedMcpIds":[]`,
+		`"generateSkill":false`, `"allowCwdAuth":false`, `"formErrorAfterSave":null`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("remote zero-MCP harvest: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestSwitchLocalToRemoteClearsWildcard covers the new-project default: the
+// blank form starts with the "*" MCP wildcard set (matching today's local
+// default), and switching to Remote before first save must clear it to an
+// empty explicit list rather than letting Save send a wildcard the server
+// will reject (validateProjectShape refuses "*" on a remote project).
+func TestSwitchLocalToRemoteClearsWildcard(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.newProject();
+		var wildBefore = window.isProjMcpWildcard(window.state.projectForm);
+		window.setProjKind('remote');
+		var f = window.state.projectForm;
+		return JSON.stringify({
+			wildBefore: wildBefore,
+			kindAfter: f.kind,
+			idsAfter: f.allowed_mcp_ids,
+			modelsAfter: f.allowed_models
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"wildBefore":true`, `"kindAfter":"remote"`, `"idsAfter":[]`, `"modelsAfter":[]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("switch local->remote wildcard clear: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestLocalProjectFormUnchanged is the regression net for the daily-driver
+// path: with kind local (the default, both for a brand-new form and an
+// existing project), every control that existed before the remote-kind work
+// must still render — path input, MCP wildcard toggle, models section +
+// wildcard toggle, chat templates, permission policy, skill section,
+// directory auth section, and (edit-only) the bearer token section. None of
+// the remote-only explanatory text should appear.
+func TestLocalProjectFormUnchanged(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.externalMcps = [{id:'a', display_name:'Alpha'}];
+		window.state.projects = [{
+			id: 'p1', name: 'Local One', path: '/tmp/local', kind: 'local',
+			allowed_mcp_ids: ['*'], allowed_models: ['*'], disabled_tools: {},
+			chat_templates: [], permission_policy: { default_mode: '', allowed_tools: [], denied_tools: [] },
+			generate_skill: false, allow_cwd_auth: false
+		}];
+		window.editProject('p1');
+		var editHtml = window.renderProjectForm();
+
+		window.newProject();
+		var newHtml = window.renderProjectForm();
+		var newFormDefaultsLocal = window.state.projectForm.kind === 'local';
+
+		return JSON.stringify({
+			editHasPathInput: editHtml.indexOf('id="projPath"') >= 0,
+			editHasMcpWildcard: editHtml.indexOf('Allow all registered MCPs') >= 0,
+			editHasModelsSection: editHtml.indexOf('Allowed Models') >= 0,
+			editHasModelsWildcard: editHtml.indexOf('Allow all models') >= 0,
+			editHasChatTemplates: editHtml.indexOf('Chat Templates') >= 0,
+			editHasPermissionPolicy: editHtml.indexOf('Permission Policy') >= 0,
+			editHasSkillSection: editHtml.indexOf('Skill (CLAUDE.md') >= 0,
+			editHasDirAuthSection: editHtml.indexOf('Directory Auth') >= 0,
+			editHasTokenSection: editHtml.indexOf('Bearer Token') >= 0,
+			editHasKindLabel: editHtml.indexOf('Local') >= 0,
+			editNoRemoteNote: editHtml.indexOf('no host directory') < 0,
+			newFormDefaultsLocal: newFormDefaultsLocal,
+			newHasPathInput: newHtml.indexOf('id="projPath"') >= 0,
+			newHasMcpWildcard: newHtml.indexOf('Allow all registered MCPs') >= 0,
+			newHasModelsWildcard: newHtml.indexOf('Allow all models') >= 0,
+			newHasSkillSection: newHtml.indexOf('Skill (CLAUDE.md') >= 0,
+			newHasDirAuthSection: newHtml.indexOf('Directory Auth') >= 0,
+			newHasKindSelector: newHtml.indexOf("setProjKind('local')") >= 0 && newHtml.indexOf("setProjKind('remote')") >= 0
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"editHasPathInput":true`, `"editHasMcpWildcard":true`, `"editHasModelsSection":true`,
+		`"editHasModelsWildcard":true`, `"editHasChatTemplates":true`, `"editHasPermissionPolicy":true`,
+		`"editHasSkillSection":true`, `"editHasDirAuthSection":true`, `"editHasTokenSection":true`,
+		`"editHasKindLabel":true`, `"editNoRemoteNote":true`,
+		`"newFormDefaultsLocal":true`, `"newHasPathInput":true`, `"newHasMcpWildcard":true`,
+		`"newHasModelsWildcard":true`, `"newHasSkillSection":true`, `"newHasDirAuthSection":true`,
+		`"newHasKindSelector":true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("local project form regression: missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestProjectListBadgesRemote covers renderProjects: a remote project gets a
+// visible badge and local projects don't. Also pins that a LOCAL project with
+// zero explicit MCP grants keeps showing the plain "0" count (unchanged),
+// while a REMOTE project with zero grants shows the friendlier "no tools
+// granted" instead of looking broken/empty-by-accident.
+func TestProjectListBadgesRemote(t *testing.T) {
+	vm := newAppVM(t)
+	script := `(function(){
+		window.state.projects = [
+			{id:'r1', name:'Remote Proj', kind:'remote', path:'', allowed_mcp_ids:[], allowed_models:[]},
+			{id:'l1', name:'Local Proj', kind:'local', path:'/tmp/l', allowed_mcp_ids:['*'], allowed_models:['*']},
+			{id:'l2', name:'Local Zero', kind:'local', path:'/tmp/z', allowed_mcp_ids:[], allowed_models:[]}
+		];
+		window.state.editingProjectId = null;
+		var html = window.renderProjects();
+		var badgeCount = (html.match(/proj-badge-remote/g) || []).length;
+		return JSON.stringify({
+			badgeCount: badgeCount,
+			remoteShowsNoTools: html.indexOf('no tools granted') >= 0,
+			localZeroStillShowsPlainZero: /MCPs: <strong>0<\/strong>/.test(html)
+		});
+	})()`
+	got := evalString(t, vm, script)
+	for _, want := range []string{
+		`"badgeCount":1`, `"remoteShowsNoTools":true`, `"localZeroStillShowsPlainZero":true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("project list remote badge: missing %s in %s", want, got)
+		}
+	}
+}

--- a/types.go
+++ b/types.go
@@ -170,12 +170,34 @@ type PermissionPolicy struct {
 	DeniedTools  []string `json:"denied_tools,omitempty"`  // patterns
 }
 
+// ProjectKind distinguishes a project bound to a host directory from one that
+// is purely a capability grant to a remote client.
+type ProjectKind string
+
+const (
+	ProjectKindLocal  ProjectKind = "local"
+	ProjectKindRemote ProjectKind = "remote"
+)
+
 // Project defines an infrastructure boundary: a directory, a set of MCPs,
 // allowed models, chat templates, and a scoped auth token.
 type Project struct {
-	ID            string         `json:"id"`
-	Name          string         `json:"name"`
-	Path          string         `json:"path"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Path string `json:"path"`
+	// Kind distinguishes a host-directory project (default) from a remote
+	// capability grant. omitempty so every project already on disk — which
+	// predates this field — round-trips byte-identical, and the zero value
+	// ("") deserializes into ProjectKindLocal territory. That zero value must
+	// NEVER be readable as remote: an old settings.json, a hand-edited entry
+	// missing the key, or a struct literal in a test all produce "", and
+	// every one of those must behave exactly as a local project always has.
+	// Enforce this by testing IsRemote() everywhere, never
+	// `Kind == ProjectKindLocal` — the latter is false for "" too, but an
+	// equality check invites someone to later write `Kind != ProjectKindRemote`
+	// wrongly, or to compare against the wrong constant. IsRemote() is the one
+	// place that decision is made.
+	Kind          ProjectKind    `json:"kind,omitempty"`
 	AllowedMcpIDs []string       `json:"allowed_mcp_ids"`
 	AllowedModels []string       `json:"allowed_models"`
 	ChatTemplates []ChatTemplate `json:"chat_templates,omitempty"`
@@ -220,6 +242,31 @@ type Project struct {
 	// (settings.json is 0600 and already holds every token in plaintext), but
 	// it does erase the deliberate hand-off, so it stays opt-in per project.
 	AllowCwdAuth bool `json:"allow_cwd_auth,omitempty"`
+}
+
+// IsRemote reports whether this project is a remote capability grant rather
+// than a host-directory project. This is the ONLY place that decision should
+// be made — see the comment on Kind for why the zero value must always read
+// as local.
+func (p *Project) IsRemote() bool {
+	return p.Kind == ProjectKindRemote
+}
+
+// normalizeProjectKind collapses anything that isn't ProjectKindRemote to the
+// zero value, so a local project's stored Kind is always "" — never the
+// literal "local" string — regardless of whether a caller passed
+// ProjectKindLocal explicitly or left it unset. Without this, a freshly
+// created local project would carry "kind":"local" while an old one (or one
+// loaded from a pre-remote settings.json) carries no key at all: two
+// spellings of the same state. Collapsing to one keeps every local project,
+// old or new, serializing identically, and keeps settings.json minimal for
+// the overwhelmingly common case. Mirrors IsRemote()'s pattern of testing
+// for remote rather than for local.
+func normalizeProjectKind(kind ProjectKind) ProjectKind {
+	if kind == ProjectKindRemote {
+		return ProjectKindRemote
+	}
+	return ""
 }
 
 // Validate checks that required fields are present.

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -337,6 +337,8 @@ textarea:focus {
 .proj-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; margin-bottom: 10px; }
 .proj-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
 .proj-card-name { font-weight: 600; font-size: 13px; color: var(--text); }
+.proj-badge-remote { display: inline-block; padding: 1px 6px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; border-radius: 4px; color: var(--accent); border: 1px solid var(--accent); }
+.proj-kind-label { font-size: 13px; color: var(--text); padding: 4px 0; }
 .proj-card-path { color: var(--text-2); font-size: 11px; font-family: var(--mono); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .proj-card-meta { color: var(--text-3); font-size: 11px; margin-top: 4px; display: flex; gap: 10px; flex-wrap: wrap; }
 .proj-card-meta span { white-space: nowrap; }
@@ -1221,14 +1223,18 @@ window.__RELAY_INIT__ = {
       html += '<div class="empty-state">No projects yet. Click <strong>+ New Project</strong> to create one.</div>';
     } else {
       for (const p of state.projects) {
-        const allowedCount = p.allowed_mcp_ids && p.allowed_mcp_ids.length > 0 ? p.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD ? "all" : String(p.allowed_mcp_ids.length) : "0";
+        const remote = isRemoteProject(p);
+        const allowedCount = p.allowed_mcp_ids && p.allowed_mcp_ids.length > 0 ? p.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD ? "all" : String(p.allowed_mcp_ids.length) : remote ? "no tools granted" : "0";
         const modelsCount = p.allowed_models && p.allowed_models.length > 0 ? p.allowed_models[0] === PROJ_MCP_WILDCARD ? "all" : String(p.allowed_models.length) : "0";
         const skillState = p.generate_skill ? "auto" : "off";
         const policy = p.permission_policy && p.permission_policy.default_mode || "\u2014";
         const regen = state.projectSkillRegen[p.id];
         html += '<div class="proj-card">';
         html += '<div class="proj-card-header">';
+        html += '<div style="display:flex;align-items:center;gap:6px">';
         html += '<span class="proj-card-name">' + esc(p.name) + "</span>";
+        if (remote) html += '<span class="proj-badge-remote">Remote</span>';
+        html += "</div>";
         html += '<div style="display:flex;gap:4px">';
         html += `<button class="btn btn-sm" onclick="editProject('` + esc(p.id) + `')">Edit</button>`;
         html += `<button class="btn btn-sm" onclick="regenProjectSkill('` + esc(p.id) + `')" title="Regenerate SKILL.md now">Regen Skill</button>`;
@@ -1254,6 +1260,8 @@ window.__RELAY_INIT__ = {
   function blankProjectForm() {
     return {
       id: null,
+      kind: "local",
+      // 'local' | 'remote' — see setProjKind
       name: "",
       path: "",
       allowed_mcp_ids: [PROJ_MCP_WILDCARD],
@@ -1272,6 +1280,7 @@ window.__RELAY_INIT__ = {
     const policy = p.permission_policy || {};
     return {
       id: p.id,
+      kind: isRemoteProject(p) ? "remote" : "local",
       name: p.name || "",
       path: p.path || "",
       allowed_mcp_ids: (p.allowed_mcp_ids || []).slice(),
@@ -1328,6 +1337,22 @@ window.__RELAY_INIT__ = {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(text);
     }
+  }
+  function isRemoteProject(p) {
+    return !!p && p.kind === "remote";
+  }
+  function isRemoteForm(f) {
+    return !!f && f.kind === "remote";
+  }
+  function setProjKind(kind) {
+    const f = state.projectForm;
+    if (!f) return;
+    f.kind = kind;
+    if (kind === "remote") {
+      if (isProjMcpWildcard(f)) f.allowed_mcp_ids = [];
+      f.allowed_models = [];
+    }
+    render();
   }
   function projMcpState(form, mcpID) {
     if (isProjMcpWildcard(form)) return "all";
@@ -1403,26 +1428,47 @@ window.__RELAY_INIT__ = {
     const f = state.projectForm;
     if (!f) return '<div class="empty-state">No form state.</div>';
     const isNew = !f.id;
+    const isRemote = isRemoteForm(f);
     const title = isNew ? "New Project" : "Edit Project";
     let html = "<h2>" + esc(title) + "</h2>";
     if (state.projectFormError) {
       html += '<div class="proj-error">' + esc(state.projectFormError) + "</div>";
     }
     html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Kind</div>';
+    if (isNew) {
+      html += '<div class="perm-btns">';
+      html += '<button class="perm-btn ' + (!isRemote ? "active" : "") + `" onclick="setProjKind('local')">Local</button>`;
+      html += '<button class="perm-btn ' + (isRemote ? "active" : "") + `" onclick="setProjKind('remote')">Remote</button>`;
+      html += "</div>";
+    } else {
+      html += '<div class="proj-kind-label">' + (isRemote ? "Remote \u2014 capability grant to another machine" : "Local \u2014 bound to a host directory") + "</div>";
+      html += `<p class="proj-section-help">Kind can't be changed here after creation.</p>`;
+    }
+    html += "</div>";
+    html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Identity</div>';
     html += "<label>Project name</label>";
     html += '<input type="text" id="projName" value="' + esc(f.name) + '" placeholder="e.g. Acme Website" />';
-    html += "<label>Project path</label>";
-    html += '<input type="text" id="projPath" value="' + esc(f.path) + '" placeholder="/Users/you/projects/acme" />';
-    html += '<p class="proj-section-help">Absolute path. Filesystem MCPs are auto-scoped to this directory.</p>';
+    if (!isRemote) {
+      html += "<label>Project path</label>";
+      html += '<input type="text" id="projPath" value="' + esc(f.path) + '" placeholder="/Users/you/projects/acme" />';
+      html += '<p class="proj-section-help">Absolute path. Filesystem MCPs are auto-scoped to this directory.</p>';
+    } else {
+      html += `<p class="proj-section-help">Remote projects are capability grants to an agent on another machine \u2014 they have no host directory, so path, directory auth, and skill generation don't apply.</p>`;
+    }
     html += "</div>";
-    const wild = isProjMcpWildcard(f);
+    const wild = !isRemote && isProjMcpWildcard(f);
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Allowed MCPs &amp; Tools</div>';
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += "<span>Allow all registered MCPs (wildcard <code>*</code>)</span>";
-    html += '<label class="switch"><input type="checkbox" ' + (wild ? "checked" : "") + ' onchange="setProjMcpWildcard(this.checked)" /><span class="slider"></span></label>';
-    html += "</div>";
+    if (!isRemote) {
+      html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+      html += "<span>Allow all registered MCPs (wildcard <code>*</code>)</span>";
+      html += '<label class="switch"><input type="checkbox" ' + (wild ? "checked" : "") + ' onchange="setProjMcpWildcard(this.checked)" /><span class="slider"></span></label>';
+      html += "</div>";
+    } else {
+      html += `<p class="proj-section-help">Remote projects can't use the wildcard \u2014 list MCPs explicitly. Zero granted is a valid starting point; widen it deliberately later.</p>`;
+    }
     if (!wild) {
       const registered = state.externalMcps.slice();
       const registeredIds = new Set(registered.map((m) => m.id));
@@ -1452,17 +1498,21 @@ window.__RELAY_INIT__ = {
       }
     }
     html += "</div>";
-    const modelsWild = isProjModelsWildcard(f);
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Allowed Models</div>';
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += "<span>Allow all models (wildcard <code>*</code>)</span>";
-    html += '<label class="switch"><input type="checkbox" ' + (modelsWild ? "checked" : "") + ' onchange="setProjModelsWildcard(this.checked)" /><span class="slider"></span></label>';
-    html += "</div>";
-    if (!modelsWild) {
-      const csv = f.allowed_models.filter((m) => m !== PROJ_MCP_WILDCARD).join(", ");
-      html += "<label>Model IDs (comma-separated)</label>";
-      html += '<input type="text" id="projModels" value="' + esc(csv) + '" placeholder="claude-opus, claude-sonnet, gpt-4" />';
+    if (isRemote) {
+      html += '<p class="proj-section-help">Not applicable to remote projects \u2014 the model allowlist stays empty.</p>';
+    } else {
+      const modelsWild = isProjModelsWildcard(f);
+      html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+      html += "<span>Allow all models (wildcard <code>*</code>)</span>";
+      html += '<label class="switch"><input type="checkbox" ' + (modelsWild ? "checked" : "") + ' onchange="setProjModelsWildcard(this.checked)" /><span class="slider"></span></label>';
+      html += "</div>";
+      if (!modelsWild) {
+        const csv = f.allowed_models.filter((m) => m !== PROJ_MCP_WILDCARD).join(", ");
+        html += "<label>Model IDs (comma-separated)</label>";
+        html += '<input type="text" id="projModels" value="' + esc(csv) + '" placeholder="claude-opus, claude-sonnet, gpt-4" />';
+      }
     }
     html += "</div>";
     html += '<div class="proj-section">';
@@ -1496,30 +1546,34 @@ window.__RELAY_INIT__ = {
     html += "<label>Denied tools (one per line)</label>";
     html += '<textarea id="projDeniedTools" rows="3" placeholder="Bash(rm *)&#10;Write">' + esc(pol.denied_tools.join("\n")) + "</textarea>";
     html += "</div>";
-    html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Skill (CLAUDE.md / SKILL.md)</div>';
-    html += `<p class="proj-section-help">When enabled, relay regenerates <code>&lt;path&gt;/.claude/skills/relay/SKILL.md</code> on project save and MCP changes so Claude Code can discover this project's tools.</p>`;
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += "<span>Auto-generate SKILL.md</span>";
-    html += '<label class="switch"><input type="checkbox" ' + (f.generate_skill ? "checked" : "") + ' onchange="state.projectForm.generate_skill = this.checked" /><span class="slider"></span></label>';
-    html += "</div>";
-    if (!isNew) {
-      html += `<div style="margin-top:8px"><button class="btn btn-sm" onclick="regenProjectSkill('` + esc(f.id) + `')">Regenerate now</button></div>`;
-      const regen = state.projectSkillRegen[f.id];
-      if (regen) {
-        const cls = regen.ok ? "proj-ok" : "proj-error";
-        html += '<div class="' + cls + '">' + (regen.ok ? "\u2713 Regenerated: " : "\u2717 Regen failed: ") + esc(regen.message) + "</div>";
+    if (!isRemote) {
+      html += '<div class="proj-section">';
+      html += '<div class="proj-section-title">Skill (CLAUDE.md / SKILL.md)</div>';
+      html += `<p class="proj-section-help">When enabled, relay regenerates <code>&lt;path&gt;/.claude/skills/relay/SKILL.md</code> on project save and MCP changes so Claude Code can discover this project's tools.</p>`;
+      html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+      html += "<span>Auto-generate SKILL.md</span>";
+      html += '<label class="switch"><input type="checkbox" ' + (f.generate_skill ? "checked" : "") + ' onchange="state.projectForm.generate_skill = this.checked" /><span class="slider"></span></label>';
+      html += "</div>";
+      if (!isNew) {
+        html += `<div style="margin-top:8px"><button class="btn btn-sm" onclick="regenProjectSkill('` + esc(f.id) + `')">Regenerate now</button></div>`;
+        const regen = state.projectSkillRegen[f.id];
+        if (regen) {
+          const cls = regen.ok ? "proj-ok" : "proj-error";
+          html += '<div class="' + cls + '">' + (regen.ok ? "\u2713 Regenerated: " : "\u2717 Regen failed: ") + esc(regen.message) + "</div>";
+        }
       }
+      html += "</div>";
     }
-    html += "</div>";
-    html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Directory Auth</div>';
-    html += `<p class="proj-section-help">Lets <code>relay mcp</code> / <code>relay mcp call</code> run with no token when the working directory is inside this project's path, granting exactly this project's tools. <strong>Any process running as you</strong> gets them by being in the directory \u2014 including agents you started for something else. Leave off unless you want that trade.</p>`;
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += "<span>Allow token-less access from this project's directory</span>";
-    html += '<label class="switch"><input type="checkbox" ' + (f.allow_cwd_auth ? "checked" : "") + ' onchange="state.projectForm.allow_cwd_auth = this.checked" /><span class="slider"></span></label>';
-    html += "</div>";
-    html += "</div>";
+    if (!isRemote) {
+      html += '<div class="proj-section">';
+      html += '<div class="proj-section-title">Directory Auth</div>';
+      html += `<p class="proj-section-help">Lets <code>relay mcp</code> / <code>relay mcp call</code> run with no token when the working directory is inside this project's path, granting exactly this project's tools. <strong>Any process running as you</strong> gets them by being in the directory \u2014 including agents you started for something else. Leave off unless you want that trade.</p>`;
+      html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+      html += "<span>Allow token-less access from this project's directory</span>";
+      html += '<label class="switch"><input type="checkbox" ' + (f.allow_cwd_auth ? "checked" : "") + ' onchange="state.projectForm.allow_cwd_auth = this.checked" /><span class="slider"></span></label>';
+      html += "</div>";
+      html += "</div>";
+    }
     if (!isNew) {
       const visible = !!state.projectTokenVisible[f.id];
       const fresh = state.projectFreshToken[f.id];
@@ -1589,10 +1643,12 @@ window.__RELAY_INIT__ = {
   function harvestProjectForm() {
     const f = state.projectForm;
     if (!f) return null;
+    const isRemote = isRemoteForm(f);
     const name = (document.getElementById("projName") || {}).value || f.name;
-    const path = (document.getElementById("projPath") || {}).value || f.path;
     let allowedModels = f.allowed_models;
-    if (!isProjModelsWildcard(f)) {
+    if (isRemote) {
+      allowedModels = [];
+    } else if (!isProjModelsWildcard(f)) {
       const csv = (document.getElementById("projModels") || {}).value || "";
       allowedModels = csv.split(",").map((s) => s.trim()).filter(Boolean);
     }
@@ -1603,16 +1659,23 @@ window.__RELAY_INIT__ = {
       allowed_tools: allowedToolsTA ? allowedToolsTA.value.split("\n").map((s) => s.trim()).filter(Boolean) : f.permission_policy.allowed_tools,
       denied_tools: deniedToolsTA ? deniedToolsTA.value.split("\n").map((s) => s.trim()).filter(Boolean) : f.permission_policy.denied_tools
     };
-    return {
+    const payload = {
       name: name.trim(),
-      path: path.trim(),
+      kind: isRemote ? "remote" : "local",
       allowed_mcp_ids: f.allowed_mcp_ids,
       allowed_models: allowedModels,
       permission_policy: policy,
-      generate_skill: f.generate_skill,
-      allow_cwd_auth: f.allow_cwd_auth,
+      // Both are directory-flavored and meaningless without a path;
+      // force them off for remote regardless of stale form state.
+      generate_skill: isRemote ? false : f.generate_skill,
+      allow_cwd_auth: isRemote ? false : f.allow_cwd_auth,
       disabled_tools: f.disabled_tools
     };
+    if (!isRemote) {
+      const path = (document.getElementById("projPath") || {}).value || f.path;
+      payload.path = path.trim();
+    }
+    return payload;
   }
   function saveProjectForm() {
     const f = state.projectForm;
@@ -1624,7 +1687,7 @@ window.__RELAY_INIT__ = {
       render();
       return;
     }
-    if (!payload.path) {
+    if (payload.kind !== "remote" && !payload.path) {
       state.projectFormError = "Project path is required";
       render();
       return;
@@ -2515,6 +2578,8 @@ window.__RELAY_INIT__ = {
     isAnyActionPending,
     isProjMcpWildcard,
     isProjModelsWildcard,
+    isRemoteForm,
+    isRemoteProject,
     newMcp,
     newProject,
     newService,
@@ -2558,6 +2623,7 @@ window.__RELAY_INIT__ = {
     serviceBadgeHTML,
     setMcpAddMode,
     setMcpTransport,
+    setProjKind,
     setProjMcpState,
     setProjMcpWildcard,
     setProjModelsWildcard,

--- a/web/shell.html
+++ b/web/shell.html
@@ -337,6 +337,8 @@ textarea:focus {
 .proj-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; margin-bottom: 10px; }
 .proj-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
 .proj-card-name { font-weight: 600; font-size: 13px; color: var(--text); }
+.proj-badge-remote { display: inline-block; padding: 1px 6px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; border-radius: 4px; color: var(--accent); border: 1px solid var(--accent); }
+.proj-kind-label { font-size: 13px; color: var(--text); padding: 4px 0; }
 .proj-card-path { color: var(--text-2); font-size: 11px; font-family: var(--mono); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .proj-card-meta { color: var(--text-3); font-size: 11px; margin-top: 4px; display: flex; gap: 10px; flex-wrap: wrap; }
 .proj-card-meta span { white-space: nowrap; }

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -751,9 +751,10 @@ function renderProjects() {
         html += '<div class="empty-state">No projects yet. Click <strong>+ New Project</strong> to create one.</div>';
     } else {
         for (const p of state.projects) {
+            const remote = isRemoteProject(p);
             const allowedCount = p.allowed_mcp_ids && p.allowed_mcp_ids.length > 0
                 ? (p.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD ? 'all' : String(p.allowed_mcp_ids.length))
-                : '0';
+                : (remote ? 'no tools granted' : '0');
             const modelsCount = p.allowed_models && p.allowed_models.length > 0
                 ? (p.allowed_models[0] === PROJ_MCP_WILDCARD ? 'all' : String(p.allowed_models.length))
                 : '0';
@@ -762,7 +763,10 @@ function renderProjects() {
             const regen = state.projectSkillRegen[p.id];
             html += '<div class="proj-card">';
             html += '<div class="proj-card-header">';
+            html += '<div style="display:flex;align-items:center;gap:6px">';
             html += '<span class="proj-card-name">' + esc(p.name) + '</span>';
+            if (remote) html += '<span class="proj-badge-remote">Remote</span>';
+            html += '</div>';
             html += '<div style="display:flex;gap:4px">';
             html += '<button class="btn btn-sm" onclick="editProject(\'' + esc(p.id) + '\')">Edit</button>';
             html += '<button class="btn btn-sm" onclick="regenProjectSkill(\'' + esc(p.id) + '\')" title="Regenerate SKILL.md now">Regen Skill</button>';
@@ -792,6 +796,7 @@ function renderProjects() {
 function blankProjectForm() {
     return {
         id: null,
+        kind: 'local',                            // 'local' | 'remote' — see setProjKind
         name: '',
         path: '',
         allowed_mcp_ids: [PROJ_MCP_WILDCARD],   // wildcard by default
@@ -809,6 +814,7 @@ function projectFormFromExisting(p) {
     const policy = p.permission_policy || {};
     return {
         id: p.id,
+        kind: isRemoteProject(p) ? 'remote' : 'local',
         name: p.name || '',
         path: p.path || '',
         allowed_mcp_ids: (p.allowed_mcp_ids || []).slice(),
@@ -873,6 +879,43 @@ function copyProjectToken(text) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text);
     }
+}
+
+// ---- Kind helpers ----
+//
+// A remote project (types.go ProjectKind) is a capability grant to an agent
+// on another machine, not a host directory: it carries no path, can't use
+// allow_cwd_auth or generate_skill (both are directory-flavored), can't use
+// the "*" MCP wildcard (a remote grant must be an explicit enumeration —
+// see validateProjectShape in project_apply.go), and always sends an empty
+// allowed_models. Kind is chosen at create time only; the edit form shows it
+// read-only (see renderProjectForm) because converting an existing project
+// has real consequences and isn't something to expose as a casual dropdown.
+
+function isRemoteProject(p) {
+    return !!p && p.kind === 'remote';
+}
+
+function isRemoteForm(f) {
+    return !!f && f.kind === 'remote';
+}
+
+function setProjKind(kind) {
+    const f = state.projectForm;
+    if (!f) return;
+    f.kind = kind;
+    if (kind === 'remote') {
+        // The wildcard means "every MCP relay currently knows about" — on a
+        // remote grant that would let a future MCP registration silently
+        // widen what the remote client can reach, so it's not offered (see
+        // the MCP section below). If the user had it set (the new-project
+        // default), drop to an empty explicit list rather than letting Save
+        // send something the server will reject.
+        if (isProjMcpWildcard(f)) f.allowed_mcp_ids = [];
+        // Remote projects always carry an empty model allowlist.
+        f.allowed_models = [];
+    }
+    render();
 }
 
 // ---- Tri-state helpers ----
@@ -974,6 +1017,7 @@ function renderProjectForm() {
     const f = state.projectForm;
     if (!f) return '<div class="empty-state">No form state.</div>';
     const isNew = !f.id;
+    const isRemote = isRemoteForm(f);
     const title = isNew ? 'New Project' : 'Edit Project';
 
     let html = '<h2>' + esc(title) + '</h2>';
@@ -981,24 +1025,50 @@ function renderProjectForm() {
         html += '<div class="proj-error">' + esc(state.projectFormError) + '</div>';
     }
 
+    // ---- Kind ----
+    // Chosen at create time only. The edit form shows it read-only: converting
+    // an existing project is possible server-side but has real consequences
+    // (see project_convert_test.go / project_apply.go), so it isn't offered
+    // here as a casual dropdown.
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Kind</div>';
+    if (isNew) {
+        html += '<div class="perm-btns">';
+        html += '<button class="perm-btn ' + (!isRemote ? 'active' : '') + '" onclick="setProjKind(\'local\')">Local</button>';
+        html += '<button class="perm-btn ' + (isRemote ? 'active' : '') + '" onclick="setProjKind(\'remote\')">Remote</button>';
+        html += '</div>';
+    } else {
+        html += '<div class="proj-kind-label">' + (isRemote ? 'Remote — capability grant to another machine' : 'Local — bound to a host directory') + '</div>';
+        html += '<p class="proj-section-help">Kind can\'t be changed here after creation.</p>';
+    }
+    html += '</div>';
+
     // ---- Identity ----
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Identity</div>';
     html += '<label>Project name</label>';
     html += '<input type="text" id="projName" value="' + esc(f.name) + '" placeholder="e.g. Acme Website" />';
-    html += '<label>Project path</label>';
-    html += '<input type="text" id="projPath" value="' + esc(f.path) + '" placeholder="/Users/you/projects/acme" />';
-    html += '<p class="proj-section-help">Absolute path. Filesystem MCPs are auto-scoped to this directory.</p>';
+    if (!isRemote) {
+        html += '<label>Project path</label>';
+        html += '<input type="text" id="projPath" value="' + esc(f.path) + '" placeholder="/Users/you/projects/acme" />';
+        html += '<p class="proj-section-help">Absolute path. Filesystem MCPs are auto-scoped to this directory.</p>';
+    } else {
+        html += '<p class="proj-section-help">Remote projects are capability grants to an agent on another machine — they have no host directory, so path, directory auth, and skill generation don\'t apply.</p>';
+    }
     html += '</div>';
 
     // ---- Allowed MCPs + tri-state picker ----
-    const wild = isProjMcpWildcard(f);
+    const wild = !isRemote && isProjMcpWildcard(f);
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Allowed MCPs &amp; Tools</div>';
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += '<span>Allow all registered MCPs (wildcard <code>*</code>)</span>';
-    html += '<label class="switch"><input type="checkbox" ' + (wild ? 'checked' : '') + ' onchange="setProjMcpWildcard(this.checked)" /><span class="slider"></span></label>';
-    html += '</div>';
+    if (!isRemote) {
+        html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+        html += '<span>Allow all registered MCPs (wildcard <code>*</code>)</span>';
+        html += '<label class="switch"><input type="checkbox" ' + (wild ? 'checked' : '') + ' onchange="setProjMcpWildcard(this.checked)" /><span class="slider"></span></label>';
+        html += '</div>';
+    } else {
+        html += '<p class="proj-section-help">Remote projects can\'t use the wildcard — list MCPs explicitly. Zero granted is a valid starting point; widen it deliberately later.</p>';
+    }
 
     if (!wild) {
         const registered = state.externalMcps.slice();
@@ -1032,17 +1102,21 @@ function renderProjectForm() {
     html += '</div>';
 
     // ---- Allowed models ----
-    const modelsWild = isProjModelsWildcard(f);
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Allowed Models</div>';
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += '<span>Allow all models (wildcard <code>*</code>)</span>';
-    html += '<label class="switch"><input type="checkbox" ' + (modelsWild ? 'checked' : '') + ' onchange="setProjModelsWildcard(this.checked)" /><span class="slider"></span></label>';
-    html += '</div>';
-    if (!modelsWild) {
-        const csv = f.allowed_models.filter(m => m !== PROJ_MCP_WILDCARD).join(', ');
-        html += '<label>Model IDs (comma-separated)</label>';
-        html += '<input type="text" id="projModels" value="' + esc(csv) + '" placeholder="claude-opus, claude-sonnet, gpt-4" />';
+    if (isRemote) {
+        html += '<p class="proj-section-help">Not applicable to remote projects — the model allowlist stays empty.</p>';
+    } else {
+        const modelsWild = isProjModelsWildcard(f);
+        html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+        html += '<span>Allow all models (wildcard <code>*</code>)</span>';
+        html += '<label class="switch"><input type="checkbox" ' + (modelsWild ? 'checked' : '') + ' onchange="setProjModelsWildcard(this.checked)" /><span class="slider"></span></label>';
+        html += '</div>';
+        if (!modelsWild) {
+            const csv = f.allowed_models.filter(m => m !== PROJ_MCP_WILDCARD).join(', ');
+            html += '<label>Model IDs (comma-separated)</label>';
+            html += '<input type="text" id="projModels" value="' + esc(csv) + '" placeholder="claude-opus, claude-sonnet, gpt-4" />';
+        }
     }
     html += '</div>';
 
@@ -1082,32 +1156,41 @@ function renderProjectForm() {
     html += '</div>';
 
     // ---- Skill ----
-    html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Skill (CLAUDE.md / SKILL.md)</div>';
-    html += '<p class="proj-section-help">When enabled, relay regenerates <code>&lt;path&gt;/.claude/skills/relay/SKILL.md</code> on project save and MCP changes so Claude Code can discover this project\'s tools.</p>';
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += '<span>Auto-generate SKILL.md</span>';
-    html += '<label class="switch"><input type="checkbox" ' + (f.generate_skill ? 'checked' : '') + ' onchange="state.projectForm.generate_skill = this.checked" /><span class="slider"></span></label>';
-    html += '</div>';
-    if (!isNew) {
-        html += '<div style="margin-top:8px"><button class="btn btn-sm" onclick="regenProjectSkill(\'' + esc(f.id) + '\')">Regenerate now</button></div>';
-        const regen = state.projectSkillRegen[f.id];
-        if (regen) {
-            const cls = regen.ok ? 'proj-ok' : 'proj-error';
-            html += '<div class="' + cls + '">' + (regen.ok ? '✓ Regenerated: ' : '✗ Regen failed: ') + esc(regen.message) + '</div>';
+    // Skills are written under <path>/.claude/skills — no path, no skill, so
+    // the whole section is absent (not disabled) for a remote project rather
+    // than showing a toggle that would lie about what it does.
+    if (!isRemote) {
+        html += '<div class="proj-section">';
+        html += '<div class="proj-section-title">Skill (CLAUDE.md / SKILL.md)</div>';
+        html += '<p class="proj-section-help">When enabled, relay regenerates <code>&lt;path&gt;/.claude/skills/relay/SKILL.md</code> on project save and MCP changes so Claude Code can discover this project\'s tools.</p>';
+        html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+        html += '<span>Auto-generate SKILL.md</span>';
+        html += '<label class="switch"><input type="checkbox" ' + (f.generate_skill ? 'checked' : '') + ' onchange="state.projectForm.generate_skill = this.checked" /><span class="slider"></span></label>';
+        html += '</div>';
+        if (!isNew) {
+            html += '<div style="margin-top:8px"><button class="btn btn-sm" onclick="regenProjectSkill(\'' + esc(f.id) + '\')">Regenerate now</button></div>';
+            const regen = state.projectSkillRegen[f.id];
+            if (regen) {
+                const cls = regen.ok ? 'proj-ok' : 'proj-error';
+                html += '<div class="' + cls + '">' + (regen.ok ? '✓ Regenerated: ' : '✗ Regen failed: ') + esc(regen.message) + '</div>';
+            }
         }
+        html += '</div>';
     }
-    html += '</div>';
 
     // ---- Directory auth ----
-    html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Directory Auth</div>';
-    html += '<p class="proj-section-help">Lets <code>relay mcp</code> / <code>relay mcp call</code> run with no token when the working directory is inside this project\'s path, granting exactly this project\'s tools. <strong>Any process running as you</strong> gets them by being in the directory — including agents you started for something else. Leave off unless you want that trade.</p>';
-    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
-    html += '<span>Allow token-less access from this project\'s directory</span>';
-    html += '<label class="switch"><input type="checkbox" ' + (f.allow_cwd_auth ? 'checked' : '') + ' onchange="state.projectForm.allow_cwd_auth = this.checked" /><span class="slider"></span></label>';
-    html += '</div>';
-    html += '</div>';
+    // Compares a caller's cwd against Path; a remote project has no Path, so
+    // the toggle is absent rather than disabled (see validateProjectShape).
+    if (!isRemote) {
+        html += '<div class="proj-section">';
+        html += '<div class="proj-section-title">Directory Auth</div>';
+        html += '<p class="proj-section-help">Lets <code>relay mcp</code> / <code>relay mcp call</code> run with no token when the working directory is inside this project\'s path, granting exactly this project\'s tools. <strong>Any process running as you</strong> gets them by being in the directory — including agents you started for something else. Leave off unless you want that trade.</p>';
+        html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+        html += '<span>Allow token-less access from this project\'s directory</span>';
+        html += '<label class="switch"><input type="checkbox" ' + (f.allow_cwd_auth ? 'checked' : '') + ' onchange="state.projectForm.allow_cwd_auth = this.checked" /><span class="slider"></span></label>';
+        html += '</div>';
+        html += '</div>';
+    }
 
     // ---- Token (edit only) ----
     if (!isNew) {
@@ -1187,10 +1270,15 @@ function pruneStaleDisabledTool(mcpID, name, kept) {
 function harvestProjectForm() {
     const f = state.projectForm;
     if (!f) return null;
+    const isRemote = isRemoteForm(f);
     const name = (document.getElementById('projName') || {}).value || f.name;
-    const path = (document.getElementById('projPath') || {}).value || f.path;
+    // A remote project has no path control in the form (see renderProjectForm)
+    // and must not send one — validateProjectShape rejects any non-empty path
+    // on a remote project.
     let allowedModels = f.allowed_models;
-    if (!isProjModelsWildcard(f)) {
+    if (isRemote) {
+        allowedModels = [];
+    } else if (!isProjModelsWildcard(f)) {
         const csv = (document.getElementById('projModels') || {}).value || '';
         allowedModels = csv.split(',').map(s => s.trim()).filter(Boolean);
     }
@@ -1204,16 +1292,23 @@ function harvestProjectForm() {
     // chat_templates is intentionally absent: the form is read-only for
     // templates (Eve owns editing), and omitting the field makes
     // update_project leave the stored list untouched.
-    return {
+    const payload = {
         name: name.trim(),
-        path: path.trim(),
+        kind: isRemote ? 'remote' : 'local',
         allowed_mcp_ids: f.allowed_mcp_ids,
         allowed_models: allowedModels,
         permission_policy: policy,
-        generate_skill: f.generate_skill,
-        allow_cwd_auth: f.allow_cwd_auth,
+        // Both are directory-flavored and meaningless without a path;
+        // force them off for remote regardless of stale form state.
+        generate_skill: isRemote ? false : f.generate_skill,
+        allow_cwd_auth: isRemote ? false : f.allow_cwd_auth,
         disabled_tools: f.disabled_tools,
     };
+    if (!isRemote) {
+        const path = (document.getElementById('projPath') || {}).value || f.path;
+        payload.path = path.trim();
+    }
+    return payload;
 }
 
 function saveProjectForm() {
@@ -1226,7 +1321,7 @@ function saveProjectForm() {
         render();
         return;
     }
-    if (!payload.path) {
+    if (payload.kind !== 'remote' && !payload.path) {
         state.projectFormError = 'Project path is required';
         render();
         return;
@@ -2280,6 +2375,6 @@ render();
 // the shared state object) on window — exactly the global surface the original
 // classic <script> had.
 Object.assign(window, {
-    addExternalMcp, addExternalMcpFromJson, addExternalMcpHttp, addService, authenticateMcp, blankProjectForm, cancelMcpEdit, cancelProjectEdit, cancelServiceEdit, cfgArrayAdd, cfgArrayRemove, cfgBind, cfgChevron, cfgDirty, cfgEdit, cfgEditJson, cfgExpandKey, cfgFieldAt, cfgFirstMissingRequired, cfgGetDraft, cfgHasBadJson, cfgIsExpanded, cfgKvAdd, cfgKvRemove, cfgKvRename, cfgKvSetVal, cfgKvState, cfgMapAdd, cfgMapRemove, cfgMapRename, cfgNodeLabel, cfgRefreshChrome, cfgRerender, cfgSetExpanded, cfgToggleExpand, copyProjectToken, dispatchConfigOp, dispatchServiceAction, editProject, editService, harvestProjectForm, ipc, isAnyActionPending, isProjMcpWildcard, isProjModelsWildcard, newMcp, newProject, newService, projMcpState, projectFormFromExisting, pruneStaleDisabledTool, regenProjectSkill, removeExternalMcp, removeProject, removeService, render, renderActionButton, renderArrayBlock, renderConfigArray, renderConfigItem, renderConfigKeyValue, renderConfigLeaf, renderConfigMap, renderConfigNode, renderConfigObject, renderConfigSection, renderMcpForm, renderMcpPush, renderMcpServers, renderObjectFields, renderProjToolPicker, renderProjectForm, renderProjects, renderServiceForm, renderServiceInspector, renderServicePanel, renderServiceStatus, renderServices, renderStatusPayload, resetMcpPermissions, revertConfig, rotateProjectToken, saveConfig, saveProjectForm, saveServiceEdit, serviceBadgeHTML, setMcpAddMode, setMcpTransport, setProjMcpState, setProjMcpWildcard, setProjModelsWildcard, setsEqual, showPage, svcFormValues, toggleConfigSection, toggleProjTool, toggleProjectTokenVisible, toggleServiceRunning, updateServiceAutostart, updateServiceStatusDOM
+    addExternalMcp, addExternalMcpFromJson, addExternalMcpHttp, addService, authenticateMcp, blankProjectForm, cancelMcpEdit, cancelProjectEdit, cancelServiceEdit, cfgArrayAdd, cfgArrayRemove, cfgBind, cfgChevron, cfgDirty, cfgEdit, cfgEditJson, cfgExpandKey, cfgFieldAt, cfgFirstMissingRequired, cfgGetDraft, cfgHasBadJson, cfgIsExpanded, cfgKvAdd, cfgKvRemove, cfgKvRename, cfgKvSetVal, cfgKvState, cfgMapAdd, cfgMapRemove, cfgMapRename, cfgNodeLabel, cfgRefreshChrome, cfgRerender, cfgSetExpanded, cfgToggleExpand, copyProjectToken, dispatchConfigOp, dispatchServiceAction, editProject, editService, harvestProjectForm, ipc, isAnyActionPending, isProjMcpWildcard, isProjModelsWildcard, isRemoteForm, isRemoteProject, newMcp, newProject, newService, projMcpState, projectFormFromExisting, pruneStaleDisabledTool, regenProjectSkill, removeExternalMcp, removeProject, removeService, render, renderActionButton, renderArrayBlock, renderConfigArray, renderConfigItem, renderConfigKeyValue, renderConfigLeaf, renderConfigMap, renderConfigNode, renderConfigObject, renderConfigSection, renderMcpForm, renderMcpPush, renderMcpServers, renderObjectFields, renderProjToolPicker, renderProjectForm, renderProjects, renderServiceForm, renderServiceInspector, renderServicePanel, renderServiceStatus, renderServices, renderStatusPayload, resetMcpPermissions, revertConfig, rotateProjectToken, saveConfig, saveProjectForm, saveServiceEdit, serviceBadgeHTML, setMcpAddMode, setMcpTransport, setProjKind, setProjMcpState, setProjMcpWildcard, setProjModelsWildcard, setsEqual, showPage, svcFormValues, toggleConfigSection, toggleProjTool, toggleProjectTokenVisible, toggleServiceRunning, updateServiceAutostart, updateServiceStatusDOM
 });
 window.state = state;


### PR DESCRIPTION
Second step of the effort to let a semi-trusted LLM agent run on a separate VM and reach relay for tool access, rather than running on the host where it would have the world. Relay becomes a gated control plane for sensitive host resources (mail, iMessage, calendar) and the VM never touches the host filesystem.

This PR makes the project model coherent for that. It does not make a remote project reachable by anything: the listener, client certificates and enrollment are 2b. Branched from `main`, so it is independent of the audit-log PR and reviewable on its own.

## Why a new kind rather than an optional path

`Project.Path` is load-bearing in five places (directory auth, `allowed_dirs` scoping, the PTY containment check, the skill emit directory, PTY cwd). Making it merely optional means each of those either nil-derefs or, worse, silently produces a wrong value. A kind makes each one an explicit answer.

`Kind`'s zero value reads as local, so every project already on disk round-trips untouched and serializes with no `kind` key. Nothing in the codebase compares against `local` directly, only `IsRemote()`, so an unset field can never come to mean remote no matter how a future check is written.

## What a remote project may not have, and why

Refused by `validateProjectShape`: a path, `allow_cwd_auth` (a remote caller's cwd is a path on a different machine), `generate_skill`, shell templates, an `allowed_mcp_ids` wildcard, a model allowlist.

Two of those are worth the reasoning:

**The wildcard.** On a local project `["*"]` is a convenience. On a remote grant it means registering a new MCP on the host silently widens what another machine can reach, with no action against the project and no diff to review. A remote grant has to be an enumeration someone typed.

**`generate_skill`.** `regenProjectSkills` already skips pathless projects silently, so leaving the flag settable would break nothing. It would just make it an inert toggle that lies about what it does. Refusing at the door is more honest than a control that quietly no-ops.

Zero grants is valid. Enrolling a client and granting it tools are separate steps, and "authenticated, granted nothing" is a resting state, not a fault.

## The sharp edge: `allowed_dirs`, defended twice

`SyncProjectToken` writes `allowed_dirs: [proj.Path]` into an MCP's context whenever that MCP's runtime schema declares the field. For a pathless project both available behaviors are unsafe: writing `[""]` hands a downstream MCP an empty root to interpret (a Node MCP's `path.resolve("")` gives its own cwd), and omitting the field lets the MCP fall back to its own default, possibly unrestricted. Relay cannot see how fsMCP resolves either.

So the grant is refused at validation (`ValidateProjectGrants`, naming the offending MCP) **and** the derivation is skipped inside `SyncProjectToken` independently.

The second defence is not redundant. MCP context schemas are discovered at runtime, so an MCP can gain an `allowed_dirs` field after a grant was already validated against an earlier version of that schema. Validation alone would not catch that; the guard inside the function that actually writes the context does. The failure mode here is a silent widening of filesystem scope rather than a loud error, which is what justifies paying for it twice.

The early return is placed after the stale-entry cleanup, so a remote project still gets pruned when its grants change.

## Three guards, one of which closed a live hole

**`ResolvePtyEnv` refuses remote projects**, on both the authoritative and legacy resolution branches. This was not theoretical. `dirWithinProject("", "")` returns `true`, because the empty-directory branch ("nothing to validate") is evaluated before the empty-project-path branch and short-circuits it. Without the guard the call succeeds and returns the project's plaintext token with `WorkingDir: ""`, which Go's `exec.Cmd` resolves to the parent process's directory. That is a host shell holding a remote project's credential, rooted wherever relay happens to be running: the confused-deputy binding that check exists to prevent, reached by another route. Verified by deleting the guard and watching the test report a 45-character token come back.

**`ResolveProjectTemplate` refuses them.** Validation already keeps `ShellTemplates` empty, so this is belt-and-braces for a project constructed by hand or converted from a former life as a local project.

**Session creation refuses them.** This could not live in the model allowlist: `validateProjectShape` requires a remote project's `allowed_models` to be empty, and `modelAllowedForProject` reads an empty allowlist as unrestricted. The most restrictive configuration was producing the most permissive outcome. There is a paired test asserting the allowlist alone would still permit it, so if that ever changes the pair fails and says the guard may have become redundant, rather than letting it quietly turn decorative.

## Conversion

Converting an existing local project to remote is possible through the API but constrained, and it is the subtlest path here. A local project carries `allowed_dirs` context from its former life, and that context is what relay injects into `_meta` on every tool call, so a conversion that kept it would hand a remote client exactly what this change exists to prevent.

It is refused while the project still holds a filesystem-scoped grant, and the stale context is gone when the grant is dropped in the same request. Both directions are pinned in `project_convert_test.go`. The settings UI does not offer conversion, only creation.

## Validation moved

The standalone `validateProjectPath` pre-checks in the HTTP PUT route and the IPC update handler were kind-unaware and would have rejected a remote project's empty path. Validation now happens once inside `applyProjectUpdate`, which merges the patch onto the current project and validates the resulting candidate before mutating anything.

That is stricter than what it replaced, not looser: it validates the final shape, so a request that only flips `allow_cwd_auth` on an already-remote project is caught, where a field-by-field pre-check would have missed it.

## Deliberately not here

**Per-tool tri-state permissions** (`allow` / `prompt` / `deny`) were planned for this PR and pulled out. The `disabled_tools` to `tool_policy` dual-write is the riskiest part of that design, its value is unlocked by the approval work rather than by this, and nothing in 2b depends on it existing first. It gets its own review.

## Testing

Characterization tests were written for the settings-UI tool picker *before* it was modified: `projMcpState`, `setProjMcpState`, `toggleProjTool` and `pruneStaleDisabledTool` had no direct coverage and are exactly what the form change touches.

New coverage: every rejected remote combination; zero-grant remote projects; `SyncProjectToken` called directly on a remote project (constructed to bypass validation, proving the second defence in isolation); local behavior unchanged, with `allowed_dirs` and the `fs_bash` auto-disable still applied; the `Kind` zero value round-tripping as local; the PTY and template guards on both resolution branches; the session refusal and its paired allowlist assertion; local→remote conversion in both directions; and the exact JSON the settings UI builds decoding into the Go struct, since every field there is optional and a mismatched tag would silently create a local project where the user asked for remote.

`go test ./...`, `go test -race ./...`, `go vet ./...` all pass. `web/dist/settings.html` regenerated via `go generate ./...`.

## Note on numbering

This adds ADR-009. ADR-008 is the tool-call audit log, which is on an unmerged branch; the numbers resolve when both land.

https://claude.ai/code/session_01VBnY1fhoZq8XA7puNkf3Vh