### PR TITLE
Fix two rendering faults in the Tool Calls tab

### DIFF
--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -379,12 +379,15 @@ textarea:focus {
 .audit-time, .audit-ms { font-variant-numeric: tabular-nums; color: var(--text-2); }
 .audit-tool { font-family: var(--mono); }
 .audit-detail { color: var(--text-2); font-family: var(--mono); }
-.audit-pill { display: inline-block; padding: 1px 7px; border-radius: 9px; font-size: 11px; font-weight: 500; }
+.audit-pill { display: inline-block; padding: 1px 7px; border-radius: 9px; font-size: 11px; font-weight: 500; white-space: nowrap; }
+/* The outcome cell must never ellipsize: a clipped pill reads as a rendering
+   fault, and "unauthorized" is exactly the row a reader is looking for. */
+.audit-table td.audit-outcome-cell { overflow: visible; text-overflow: clip; }
 .audit-ok { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
 .audit-error { background: color-mix(in srgb, var(--danger) 18%, transparent); color: var(--danger); }
 .audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
 .audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
-.audit-expand td { background: var(--bg-card); white-space: normal; }
+.audit-expand td { background: color-mix(in srgb, CanvasText 5%, transparent); white-space: normal; box-shadow: inset 2px 0 0 var(--accent); }
 .audit-kv { display: grid; grid-template-columns: max-content 1fr; gap: 2px 14px; font-size: 12px; }
 .audit-kv dt { color: var(--text-2); }
 .audit-kv dd { margin: 0; font-family: var(--mono); word-break: break-all; }
@@ -2684,7 +2687,7 @@ window.__RELAY_INIT__ = {
       return html;
     }
     html += '<table class="audit-table"><colgroup>';
-    html += '<col style="width:70px"><col style="width:100px"><col style="width:14%"><col style="width:12%">';
+    html += '<col style="width:70px"><col style="width:118px"><col style="width:14%"><col style="width:12%">';
     html += '<col style="width:18%"><col style="width:60px"><col style="width:16%"><col>';
     html += "</colgroup><thead><tr>";
     html += "<th>Time</th><th>Outcome</th><th>Project</th><th>MCP</th><th>Tool</th><th>ms</th><th>Caller</th><th>Detail</th>";
@@ -2698,7 +2701,7 @@ window.__RELAY_INIT__ = {
     const expanded = !!state.auditExpanded[ev.id];
     let html = `<tr class="row" onclick="toggleAuditRow('` + esc(ev.id) + `')">`;
     html += '<td class="audit-time">' + esc(auditFmtTime(ev.ts)) + "</td>";
-    html += '<td><span class="audit-pill audit-' + esc(ev.outcome) + '">' + esc(ev.outcome) + "</span></td>";
+    html += '<td class="audit-outcome-cell"><span class="audit-pill audit-' + esc(ev.outcome) + '">' + esc(ev.outcome) + "</span></td>";
     html += '<td title="' + esc(a.project_name || "") + '">' + esc(a.project_name || "\u2014") + "</td>";
     html += "<td>" + esc(ev.mcp_id || "\u2014") + "</td>";
     html += '<td class="audit-tool" title="' + esc(ev.tool || "") + '">' + esc(ev.tool || ev.event) + "</td>";

--- a/web/shell.html
+++ b/web/shell.html
@@ -379,12 +379,15 @@ textarea:focus {
 .audit-time, .audit-ms { font-variant-numeric: tabular-nums; color: var(--text-2); }
 .audit-tool { font-family: var(--mono); }
 .audit-detail { color: var(--text-2); font-family: var(--mono); }
-.audit-pill { display: inline-block; padding: 1px 7px; border-radius: 9px; font-size: 11px; font-weight: 500; }
+.audit-pill { display: inline-block; padding: 1px 7px; border-radius: 9px; font-size: 11px; font-weight: 500; white-space: nowrap; }
+/* The outcome cell must never ellipsize: a clipped pill reads as a rendering
+   fault, and "unauthorized" is exactly the row a reader is looking for. */
+.audit-table td.audit-outcome-cell { overflow: visible; text-overflow: clip; }
 .audit-ok { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
 .audit-error { background: color-mix(in srgb, var(--danger) 18%, transparent); color: var(--danger); }
 .audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
 .audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
-.audit-expand td { background: var(--bg-card); white-space: normal; }
+.audit-expand td { background: color-mix(in srgb, CanvasText 5%, transparent); white-space: normal; box-shadow: inset 2px 0 0 var(--accent); }
 .audit-kv { display: grid; grid-template-columns: max-content 1fr; gap: 2px 14px; font-size: 12px; }
 .audit-kv dt { color: var(--text-2); }
 .audit-kv dd { margin: 0; font-family: var(--mono); word-break: break-all; }

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -2509,7 +2509,7 @@ function renderAudit() {
     }
 
     html += '<table class="audit-table"><colgroup>';
-    html += '<col style="width:70px"><col style="width:100px"><col style="width:14%"><col style="width:12%">';
+    html += '<col style="width:70px"><col style="width:118px"><col style="width:14%"><col style="width:12%">';
     html += '<col style="width:18%"><col style="width:60px"><col style="width:16%"><col>';
     html += '</colgroup><thead><tr>';
     html += '<th>Time</th><th>Outcome</th><th>Project</th><th>MCP</th><th>Tool</th><th>ms</th><th>Caller</th><th>Detail</th>';
@@ -2524,7 +2524,7 @@ function renderAuditRow(ev) {
     const expanded = !!state.auditExpanded[ev.id];
     let html = '<tr class="row" onclick="toggleAuditRow(\'' + esc(ev.id) + '\')">';
     html += '<td class="audit-time">' + esc(auditFmtTime(ev.ts)) + '</td>';
-    html += '<td><span class="audit-pill audit-' + esc(ev.outcome) + '">' + esc(ev.outcome) + '</span></td>';
+    html += '<td class="audit-outcome-cell"><span class="audit-pill audit-' + esc(ev.outcome) + '">' + esc(ev.outcome) + '</span></td>';
     html += '<td title="' + esc(a.project_name || '') + '">' + esc(a.project_name || '\u2014') + '</td>';
     html += '<td>' + esc(ev.mcp_id || '\u2014') + '</td>';
     html += '<td class="audit-tool" title="' + esc(ev.tool || '') + '">' + esc(ev.tool || ev.event) + '</td>';


### PR DESCRIPTION
Follow-up to the audit log. The browser visual pass had been skipped when that merged; this is what it found.

Neither defect was reachable by the goja tests, which assert structure and content. Both are layout.

## The `unauthorized` pill overflowed its column

The Outcome column was 100px, which fits every outcome except the longest one. The row's `text-overflow: ellipsis` then clipped the pill and leaked a stray `..` fragment into the Project cell.

Widened the column and opted that single cell out of the row-wide ellipsis. A clipped pill reads as a rendering fault, and `unauthorized` is precisely the row someone reviewing this log came to find.

## The expanded detail panel had no visual containment

It used `--bg-card`, which resolves to a real grey in WebKit but collapses to `Canvas` — the page colour — under Blink's system-colour fallbacks. In a browser the panel floated with no boundary against the page.

The tint is now stated explicitly rather than depending on a token that can equal the background it sits on, with an accent rule down the left edge tying the panel to its row. This also matters beyond the browser: a token that can silently equal its own background is fragile regardless of which engine renders it.

## Verification

Rendered in Chrome via `cmd/devui` at 1180x860, both colour schemes, before and after. No JS errors. `go test ./...` green, `web/dist/settings.html` regenerated.

https://claude.ai/code/session_01VBnY1fhoZq8XA7puNkf3Vh