### PR TITLE
Record MCP-refused tool calls as tool_error, not ok

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -31,9 +31,17 @@ const (
 // Audit outcomes. Denied and Unauthorized are deliberately distinct: the first
 // means a known credential was refused a tool it may not use, the second means
 // the credential itself did not resolve. They call for different responses.
+//
+// Error and ToolError are distinct for the same reason. Error means the call
+// did not complete — the transport failed, or the bridge could not reach the
+// MCP. ToolError means the call completed and the MCP answered "no": it
+// returned a normal result carrying isError, which is how a server reports an
+// application-level refusal such as a path outside allowed_dirs. Both are
+// failures, but only the second tells you a boundary was probed and held.
 const (
 	AuditOutcomeOK           = "ok"
 	AuditOutcomeError        = "error"
+	AuditOutcomeToolError    = "tool_error"
 	AuditOutcomeDenied       = "denied"
 	AuditOutcomeUnauthorized = "unauthorized"
 )

--- a/audit_call.go
+++ b/audit_call.go
@@ -150,6 +150,15 @@ func (a *auditCall) doneResult(result json.RawMessage, err error) {
 	if n := a.rec.cfg.MaxResultPreviewBytes; n > 0 && len(result) > 0 {
 		a.ev.ResultPreview = truncateRunes(string(result), n)
 	}
+	// A tool that refuses in-protocol returns a normal result with isError set.
+	// The call completed, so this is not AuditOutcomeError, but it is not a
+	// success either — recording it as "ok" would hide every application-level
+	// refusal (an fsMCP read outside allowed_dirs, say) from `relay audit
+	// --outcome ...` and from the Tool Calls filter.
+	if a.ev.ResultIsError {
+		a.done(AuditOutcomeToolError, nil)
+		return
+	}
 	a.done(AuditOutcomeOK, nil)
 }
 

--- a/audit_cmd.go
+++ b/audit_cmd.go
@@ -21,7 +21,7 @@ func runAuditCommand(args []string) {
 	tail := fs.Int("tail", 50, "show the most recent N events")
 	project := fs.String("project", "", "filter by project id")
 	mcpID := fs.String("mcp", "", "filter by MCP id")
-	outcome := fs.String("outcome", "", "filter by outcome: ok, error, denied, unauthorized")
+	outcome := fs.String("outcome", "", "filter by outcome: ok, error, tool_error, denied, unauthorized")
 	event := fs.String("event", "", "filter by event kind: call_tool, list_tools, list_skills")
 	text := fs.String("grep", "", "substring match over tool, MCP, error, project, caller, args")
 	asJSON := fs.Bool("json", false, "emit raw JSONL instead of a table")

--- a/audit_test.go
+++ b/audit_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -230,6 +231,56 @@ func TestAudit_RecordsProtocolLevelToolError(t *testing.T) {
 	ev := onlyEvent(t, readLoggedEvents(t, rec))
 	if !ev.ResultIsError {
 		t.Error("result_is_error = false, want true for an isError result")
+	}
+	// The flag alone is not enough: the outcome is what `relay audit --outcome`
+	// and the Tool Calls filter select on, so a refusal recorded as "ok" is
+	// invisible to every query an operator would actually run.
+	if ev.Outcome != AuditOutcomeToolError {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, AuditOutcomeToolError)
+	}
+}
+
+// An in-protocol refusal must be reachable by the query an operator runs, not
+// merely recoverable by post-processing raw JSONL for result_is_error.
+func TestAudit_ToolErrorIsFilterable(t *testing.T) {
+	// Branch on the tool named in the request params: read_file refuses
+	// in-protocol, list_dir succeeds, so one call of each lands in the log.
+	mock := newMockConn("fsmcp", simpleTools("read_file", "list_dir"),
+		func(_ context.Context, _ string, params interface{}) (json.RawMessage, error) {
+			raw, err := json.Marshal(params)
+			if err != nil {
+				return nil, err
+			}
+			if bytes.Contains(raw, []byte(`"read_file"`)) {
+				return json.RawMessage(`{"isError":true,"content":[{"type":"text","text":"path /etc/shadow is outside allowed directories"}]}`), nil
+			}
+			return json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`), nil
+		})
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	if _, err := r.CallTool(context.Background(), "list_dir", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("CallTool(list_dir): %v", err)
+	}
+	if _, err := r.CallTool(context.Background(), "read_file", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("CallTool(read_file): %v", err)
+	}
+
+	// Record is asynchronous; drain the queue before querying the ring.
+	rec.Flush()
+
+	got := rec.Query(AuditQuery{Outcome: AuditOutcomeToolError})
+	if len(got) != 1 {
+		t.Fatalf("outcome=tool_error matched %d events, want 1", len(got))
+	}
+	if got[0].Tool != "read_file" {
+		t.Errorf("matched tool = %q, want read_file", got[0].Tool)
+	}
+
+	// The successful call must not be swept up by the new outcome.
+	if ok := rec.Query(AuditQuery{Outcome: AuditOutcomeOK}); len(ok) != 1 || ok[0].Tool != "list_dir" {
+		t.Errorf("outcome=ok matched %v, want exactly list_dir", ok)
 	}
 }
 

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -385,6 +385,7 @@ textarea:focus {
 .audit-table td.audit-outcome-cell { overflow: visible; text-overflow: clip; }
 .audit-ok { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
 .audit-error { background: color-mix(in srgb, var(--danger) 18%, transparent); color: var(--danger); }
+.audit-tool_error { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
 .audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
 .audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
 .audit-expand td { background: color-mix(in srgb, CanvasText 5%, transparent); white-space: normal; box-shadow: inset 2px 0 0 var(--accent); }
@@ -2540,7 +2541,7 @@ window.__RELAY_INIT__ = {
       row: row || void 0
     }));
   }
-  var AUDIT_OUTCOMES = ["ok", "error", "denied", "unauthorized"];
+  var AUDIT_OUTCOMES = ["ok", "error", "tool_error", "denied", "unauthorized"];
   var AUDIT_EVENT_KINDS = [
     ["call_tool", "Tool calls"],
     ["list_tools", "Tool lists"],

--- a/web/shell.html
+++ b/web/shell.html
@@ -385,6 +385,7 @@ textarea:focus {
 .audit-table td.audit-outcome-cell { overflow: visible; text-overflow: clip; }
 .audit-ok { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
 .audit-error { background: color-mix(in srgb, var(--danger) 18%, transparent); color: var(--danger); }
+.audit-tool_error { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
 .audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
 .audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
 .audit-expand td { background: color-mix(in srgb, CanvasText 5%, transparent); white-space: normal; box-shadow: inset 2px 0 0 var(--accent); }

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -2343,7 +2343,7 @@ function dispatchServiceAction(serviceId, actionId, row) {
 // older than the ring holds.
 // ---------------------------------------------------------------------------
 
-const AUDIT_OUTCOMES = ['ok', 'error', 'denied', 'unauthorized'];
+const AUDIT_OUTCOMES = ['ok', 'error', 'tool_error', 'denied', 'unauthorized'];
 const AUDIT_EVENT_KINDS = [
     ['call_tool', 'Tool calls'],
     ['list_tools', 'Tool lists'],


### PR DESCRIPTION
Closes #9.

## The bug

`audit_call.go:doneResult` computed `a.ev.ResultIsError` and then called
`a.done(AuditOutcomeOK, nil)` unconditionally — the flag was recorded but never reached the
`outcome` field. So every in-protocol refusal was logged as a success.

Concretely, an fsMCP read blocked by `allowed_dirs`:

```json
{"tool":"fs_read","args":{"file_path":"/Users/admin/.ssh/id_rsa"},
 "outcome":"ok","result_is_error":true}
```

`relay audit --outcome denied` returned only the bridge-level `fs_bash` denial and silently
omitted the blocked read.

## The fix

A distinct `tool_error` outcome, rather than folding into the existing `error`.

`error` means *the call did not complete* — transport or bridge failure. A tool returning
`isError: true` **did** complete and answered "no": a boundary was probed and held. Those
warrant different responses, which is the same reasoning the existing constants already
apply to `denied` vs `unauthorized`.

| refusal | enforced at | before | after |
|---|---|---|---|
| `fs_bash` disabled for token | bridge | `denied` | `denied` |
| path outside `allowed_dirs` | inside the MCP | `ok` ❌ | `tool_error` ✅ |
| transport/bridge failure | bridge | `error` | `error` |
| successful call | — | `ok` | `ok` |

## Verified on a live build

Reproducing the exact scenario from #9 after `./build.sh --test`:

```
$ relay audit --tail 3
TIME      OUTCOME     PROJECT  MCP    TOOL     MS  CALLER     DETAIL
22:20:38  ok          Relay    fsmcp  fs_read  0   zsh→relay  {"file_path":".../relay/go.mod"}
22:20:38  tool_error  Relay    fsmcp  fs_read  0   zsh→relay  {"file_path":"/Users/admin/.ssh/id_rsa"}
22:20:38  denied      Relay    fsmcp  fs_bash  0   zsh→relay  access denied: tool 'fs_bash' is disabled for this token

$ relay audit --outcome tool_error
22:20:38  tool_error  Relay    fsmcp  fs_read  0   zsh→relay  {"file_path":"/Users/admin/.ssh/id_rsa"}
```

`--outcome denied` and `--outcome ok` still return exactly what they did before.

Tool Calls tab renders the three outcomes as distinct pills (`denied` amber, `tool_error`
red, `ok` green) and `tool_error` is selectable in the outcome filter.

- `go vet ./...` clean
- `go test ./...` — full suite passes
- `gofmt` clean on all changed Go files
- `web/dist/settings.html` regenerated (committed artifact; contains both the new
  `AUDIT_OUTCOMES` entry and the `.audit-tool_error` rule)

## Tests

`TestAudit_RecordsProtocolLevelToolError` already covered this code path but asserted only
`ResultIsError`, never `Outcome` — that assertion gap is why the bug survived. It now
asserts both.

`TestAudit_ToolErrorIsFilterable` is new and covers what actually broke: that the refusal is
reachable by the query an operator runs, and that a successful call is not swept up by the
new outcome.

## Compatibility

This adds a new *value* to `outcome`, not a new field, so the JSONL shape is unchanged.
Anything treating `outcome == "ok"` as "the call succeeded" will see a behaviour change —
which is the point. Historical records are not rewritten; entries logged before this change
keep `ok`.
