### PR TITLE
ADR-010: a remote caller is a certificate on a narrow listener (Proposed)

### DIFF
--- a/docs/decisions/000-readme.md
+++ b/docs/decisions/000-readme.md
@@ -41,6 +41,12 @@ ADR that references the old one. Do not edit accepted ADRs in place.
   filesystem path; validation refuses incoherent local-only features, and
   filesystem scope, sessions, and PTY launches are each refused twice —
   once by validation, once at the point of use.
+- [010 — A remote caller is a certificate on a narrow listener](010-remote-client-transport-and-identity.md)
+  *(Proposed)*: the 2b half ADR-009 deferred — a separate remote listener whose
+  dispatch table holds only `ListTools`/`CallTool`, mTLS where the certificate
+  is the identity and the project token names the grant, directory auth made
+  structurally impossible, fail-closed audit for remote callers, and per-grant
+  rate/volume budgets against exfiltration.
 
 ## Format
 

--- a/docs/decisions/000-readme.md
+++ b/docs/decisions/000-readme.md
@@ -41,12 +41,13 @@ ADR that references the old one. Do not edit accepted ADRs in place.
   filesystem path; validation refuses incoherent local-only features, and
   filesystem scope, sessions, and PTY launches are each refused twice —
   once by validation, once at the point of use.
-- [010 — A remote caller is a certificate on a narrow listener](010-remote-client-transport-and-identity.md)
-  *(Proposed)*: the 2b half ADR-009 deferred — a separate remote listener whose
-  dispatch table holds only `ListTools`/`CallTool`, mTLS where the certificate
-  is the identity and the project token names the grant, directory auth made
-  structurally impossible, fail-closed audit for remote callers, and per-grant
-  rate/volume budgets against exfiltration.
+- [010 — A remote caller is a certificate on a narrow listener](010-remote-client-transport-and-identity.md):
+  the 2b half ADR-009 deferred. A separate `RemoteServer` whose dispatch table
+  holds only `ListTools`/`CallTool`; relay is its own CA and an **enrolment
+  record binds a certificate to its grants**, so there is no bearer token on the
+  remote path at all; directory auth is unrepresentable rather than refused;
+  audit is fail-closed and written *before* the call; and rate/volume budgets
+  live on the enrolment, the unit of compromise.
 
 ## Format
 

--- a/docs/decisions/010-remote-client-transport-and-identity.md
+++ b/docs/decisions/010-remote-client-transport-and-identity.md
@@ -1,6 +1,6 @@
 # ADR-010: A Remote Caller Is a Certificate on a Narrow Listener
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-08-20
 
 ## Context
@@ -75,213 +75,341 @@ This mirrors the belt-and-braces reasoning ADR-009 applied to `allowed_dirs`,
 and for the same stated reason: the failure mode is a *silent* widening of
 scope rather than a loud error.
 
-### 2. The certificate is the identity; the project token names the grant
+### 2. The certificate is the identity; the enrolment record is the grant
 
-A remote connection requires mutual TLS. The client certificate answers *who
-is calling* and the project token answers *which capability grant to apply*.
-Both are required; neither substitutes for the other.
+A remote connection requires mutual TLS, and **relay is its own certificate
+authority** — self-signed, no external CA. A two-machine deployment does not
+warrant the ceremony of anything else.
 
-A bearer token alone cannot carry this weight. Project tokens are long-lived,
-stored in plaintext in `settings.json`, replayable in full by anyone who
-observes one, and carry no expiry — properties that are acceptable when the
-only way to observe one is to already be the local user, and unacceptable
-across a network. The certificate is what makes a call attributable to a
-*machine* rather than to a secret that may have been copied off one.
+The certificate answers *who is calling*. An **enrolment record** on the host
+binds that certificate to the grants it may use. There is no bearer token on
+the remote path at all.
 
-The token is not demoted to a formality. It remains the thing that selects the
-grant, so revoking a grant and revoking a device stay independent operations:
-rotating a project token cuts capability without re-enrolling hardware, and
-revoking a certificate cuts a machine without disturbing any project.
+An earlier draft of this ADR required a project token alongside the
+certificate. That was wrong. Once a certificate is mandatory, the token adds a
+second long-lived plaintext secret to the remote path and buys nothing: a
+leaked token is already useless without a certificate. Removing it means a
+copy of `settings.json` grants an attacker no remote access whatsoever.
 
-`RemoteServer` resolves the certificate to an enrolled client identity before
-the token is examined. A connection whose certificate does not resolve is
-closed without reading a request, so an unenrolled caller cannot probe token
-validity.
+An enrolment holding more than one grant selects among them by sending a
+project **id**, which is not a secret. Relay honours it only if that enrolment
+actually holds the grant.
 
-### 3. Only remote-kind project tokens are accepted, and service tokens never are
+**The enrolment is keyed by certificate, not by machine.** One host may hold
+many enrolments, which is the expected shape: several agents on one VM, each
+with its own certificate and its own grants, audited and revoked
+independently.
 
-The remote listener refuses any token that does not resolve to a project with
-`IsRemote()` true. A service token presented on a remote connection is
-rejected before use, not merely unhelpful.
+    hermes-mail    sha256:9f2a...  [proj_mail]
+    hermes-cal     sha256:41c7...  [proj_calendar]
+    hermes-triage  sha256:8b03...  [proj_mail, proj_calendar]
 
-Both halves matter and neither is redundant. Refusing service tokens closes
-god-mode. Requiring `IsRemote()` means the ADR-009 guards — no filesystem
-scope, no wildcard MCP grants, no sessions, no PTY — are load-bearing for
-every remote call rather than incidental to which token the caller happened to
-present. Without it, a leaked *local* project token would grant a remote
-caller a filesystem-scoped project, and every protection ADR-009 built would
-be bypassed by presenting the wrong credential rather than by defeating any of
-them.
+**The limit of that separation is stated rather than pretended away.** Relay
+distinguishes those agents only by the key each presents. Agents running as
+the same user on the same VM can read each other's private keys, so the
+separation is exactly as strong as the filesystem isolation on the client
+side — different users, containers, or key permissions make it real. This is
+the same reasoning `docs/tokens.md` applies to local processes, reappearing
+one boundary out. Relay cannot enforce it from the host and does not claim to.
 
-### 4. Directory auth is structurally impossible on the remote listener
+Device and capability revocation stay independent: editing an enrolment's
+grants changes what a machine may reach without touching its certificate;
+deleting the enrolment cuts the machine without disturbing any project.
 
-`RemoteServer` never populates the caller-cwd context value, and a remote
-request carrying `Cwd` is rejected rather than ignored.
+`RemoteServer` resolves the certificate to an enrolled client before any
+request is read. A connection whose certificate does not resolve is closed
+without processing, so an unenrolled caller cannot probe for valid grants.
 
-Rejecting rather than ignoring is the whole point. Silently dropping the field
-would leave a client that believes it is authenticating by directory and is
-in fact authenticating by token — the two produce identical success today,
-so the divergence would surface only when the token was removed and the call
-unexpectedly kept working, or stopped. An explicit error at the door makes a
-client that tries this fail immediately and visibly.
+### 3. An enrolment may only grant remote-kind projects
 
-The condition ADR-009 identified for remote projects — "a remote caller's cwd
-is a path on a *different* machine, with nothing on the host to compare it
-against" — is a property of the *connection*, not only of the project. Enforcing
-it at the transport means it holds even for a request that never resolves to a
-project at all.
+Every grant on an enrolment must name a project with `IsRemote()` true.
 
-### 5. Audit is fail-closed for remote callers
+Without this, every protection in ADR-009 — no filesystem scope, no wildcard
+grants, no sessions, no PTY — would be bypassed by *pointing at the wrong
+project* rather than by defeating any of them. Service tokens need no
+equivalent rule here: decision 2 leaves no token field on the remote wire, so
+god-mode is not refused, it is unrepresentable.
 
-`audit.required` (default true for remote, unchanged fail-open for local)
-refuses any remote tool call that cannot be durably recorded. If the audit
-channel is saturated or the log cannot be written, the call returns an error
-instead of proceeding unlogged.
+Enforced at three points, for the reason ADR-009 gave when it defended
+`allowed_dirs` twice — the failure mode is a silent widening of scope, not a
+loud error:
 
-ADR-008 accepted fail-open with a precise consequence: "the log is not
-admissible as proof that something did *not* happen." That is a fair trade for
-a local laptop, where the alternative is your own tooling breaking. It is the
-wrong trade for the one caller whose activity the log exists to establish. The
-cost is real and is accepted here: a remote agent will occasionally see a tool
-call fail because relay could not write a line about it.
+1. **At enrolment.** A grant naming a local project is refused outright.
+2. **At conversion.** Converting a project remote→local is refused while any
+   enrolment references it, naming the offending enrolments. This mirrors
+   ADR-009's constrained local→remote conversion: the project model refuses
+   an edit that would strand a credential, rather than allowing it and
+   cleaning up afterwards.
+3. **At call time.** The resolved project is re-checked. This is what makes a
+   grant that went stale by any route relay did not anticipate fail closed.
 
-Local behaviour does not change. The same drop-and-count path stays exactly as
-ADR-008 specified it, because the reasoning that justified it there is
-untouched by any of this.
+**Remoteness is a property of the grant's shape, not of the caller's
+location.** `validateProjectShape` constrains path, cwd auth, skills,
+templates, wildcards, and models — nothing in it consults a host or address.
+A remote project is reachable from `127.0.0.1` exactly as it is from another
+machine, so the whole model is developed and tested on one box with every
+guard live. No loopback exemption exists, and none is needed: a dev-only
+bypass on the security boundary is the thing most likely to survive into
+production, and it would invert ADR-009's principle of refusing incoherent
+combinations rather than degrading.
+
+One consequence shapes local testing. `ValidateProjectGrants` refuses any MCP
+declaring `allowed_dirs`, so a remote project cannot be granted fsMCP. Testing
+therefore runs against macMCP — mail, calendar, contacts — which is the actual
+target use case rather than a filesystem stand-in.
+
+### 4. The remote wire has no field to authenticate with
+
+`RemoteRequest` is a distinct type carrying `Type`, `Name`, `Arguments`, and
+`ProjectID`. There is no `Token` field and no `Cwd` field.
+
+Directory auth is already unreachable by construction: it fires only when no
+token is present, and identity on this path comes from the certificate before
+a request is read. The separate type is what makes that visible in the code
+rather than emergent from a chain of reasoning.
+
+Decoding uses `DisallowUnknownFields`. Go's default is to ignore unrecognised
+JSON keys silently, which would leave a client sending `cwd` believing it had
+authenticated by directory while it had in fact authenticated by certificate —
+the two succeed identically today, so the divergence would surface only later,
+in the confusing direction. Strict decoding turns that into an error at the
+door. The cost is that adding a wire field requires deploying both ends
+together; both ends are ours, so that is a coordination step rather than a
+compatibility break.
+
+### 5. Audit is fail-closed for remote callers, and written before the call
+
+A remote tool call is recorded in two phases. An **intent** record — actor,
+tool, redacted arguments — is written *and flushed* before the MCP is invoked.
+A **completion** record keyed to the same event `id` follows when the call
+returns. If the intent write fails, the call is refused and the MCP is never
+invoked.
+
+The ordering is the whole point, and an earlier draft of this ADR got it
+wrong. Today's audit event is written *after* the call completes, because
+`doneResult` needs the result bytes. Under that ordering "refuse a call that
+cannot be logged" protects nothing: by the time the write fails the mailbox has
+already been read, and the data has left the MCP. Refusing afterwards is
+theatre.
+
+ADR-008 named exactly what fail-open forfeits — "the log is not admissible as
+proof that something did *not* happen." Buying that back requires writing
+before the side effect, not after. The cost is a second line per remote call,
+which for an agent checking mail on a schedule is nothing.
+
+An intent record with no matching completion is itself a signal: it means relay
+invoked an MCP and never learned the outcome — a crash, a kill, or a hang —
+and it is worth alerting on rather than reconciling away.
+
+This also settles how streaming interacts with fail-closed auditing:
+`RespProgress` frames need no separate guarantee, because the intent record
+already establishes that the call happened before any frame is emitted.
+
+Local behaviour is untouched. The bounded channel, the drop-and-count, and the
+visible drop warning all stay exactly as ADR-008 specified, because the
+reasoning that justified them there is unaffected by any of this.
 
 ### 6. `AuditActor` gains attested remote identity
 
-Three fields, all derived from the connection rather than asserted by the
-caller: the enrolled client identity, the certificate fingerprint that
-authenticated it, and the remote address. A new `AuditAuthMTLS` constant joins
-the existing auth methods.
+A remote call records `kind: "remote"` and `auth: "mtls"`, plus three fields
+derived from the connection and never asserted by the caller: the enrolled
+client id, the full certificate fingerprint, and the remote address.
+`PID` / `Proc` / `Parent` are omitted rather than zero-filled — they are
+`omitempty`, so an absent field reads as "not applicable" instead of "unknown".
 
-This preserves ADR-008's second property — "attributed… from relay's own
+    "actor": {
+      "kind": "remote",
+      "project_id": "proj_mail",
+      "project_name": "Mail",
+      "auth": "mtls",
+      "client_id": "hermes-mail",
+      "fingerprint": "sha256:9f2a...",
+      "remote_addr": "127.0.0.1:52233"
+    }
+
+`kind` is a distinct value rather than a reuse of `project` so that "show me
+everything any VM did" is a first-class filter rather than an inference from
+which fields happen to be populated. `ProjectID` stays populated alongside it:
+the caller is remote *and* is acting as a project grant, and both facts matter.
+
+This preserves ADR-008's second property — attribution "from relay's own
 knowledge, not from anything the caller asserts." `PeerPID` is the local
 expression of that property and is meaningless across a network; the
-certificate fingerprint is its remote equivalent, and is strictly stronger,
+certificate fingerprint is its remote equivalent and is strictly stronger,
 since a pid is reusable and racy while a fingerprint is not.
 
-Recording the fingerprint and not only the resolved identity is what makes
-revocation auditable after the fact: it answers which *key* made a call, so a
-compromised device's history stays legible once its enrolment is deleted.
+The fingerprint is recorded in full, not truncated, and alongside the resolved
+client id rather than instead of it. That is what keeps a revoked device's
+history legible: it answers which *key* made a call, after the enrolment naming
+that key has been deleted.
 
-### 7. Remote grants carry budgets, enforced at the router
+### 7. Budgets live on the enrolment
 
-A remote project may declare a call-rate limit and a cumulative result-volume
-budget per rolling window. Both are enforced in `appRouter.CallTool` — the
-same chokepoint ADR-008 chose, for the same reason: it is the one place every
-transport already funnels through, and the place where the project is known.
+A remote enrolment carries a call-rate limit and a cumulative result-volume
+limit per rolling window. Both are enforced in `appRouter.CallTool` — the
+chokepoint ADR-008 chose, for the same reason: every transport already funnels
+through it, and the actor is known by the time it runs. `ResultBytes` is
+already measured for the audit log, so the accounting exists; only the budget
+did not.
 
-Exceeding a budget is refused with an audit outcome of its own, distinct from
-`denied` (a tool the grant never included) and from `tool_error` (a boundary
-inside the MCP). The distinction is the point: a rate refusal is the only one
-of the three that says *the grant was legitimate and the pattern of use was
-not*, which is precisely the exfiltration signal this ADR exists to surface.
+**The enrolment is the unit of compromise, so it is the unit that carries the
+cap.** If `hermes-mail` is compromised, the attacker holds `hermes-mail`'s key
+and nothing else; its budget is what bounds the damage. A budget on the
+*project* would only bind an attacker who already held several certificates,
+by which point they have broader access anyway — and it would let one noisy
+agent starve its neighbours sharing the same grant.
 
-Volume is budgeted alongside rate because they fail differently. Rate alone
+A project-level ceiling, bounding total drain across every enrolment holding a
+grant, is a coherent later addition. It protects the resource rather than
+bounding any single compromise, and it is not what buys the primary defence.
+
+Exceeding a budget is refused with its own audit outcome, `throttled`, distinct
+from `denied` (a tool the grant never included) and `tool_error` (a boundary
+inside the MCP). The distinction is the signal: `throttled` is the only one of
+the three that says *the grant was legitimate and the pattern of use was not*,
+which is precisely what exfiltration looks like from the host's side.
+
+Rate and volume are budgeted together because they fail differently. Rate alone
 does not stop a slow drain, and a mailbox exfiltrated over six hours is
-exfiltrated. Result bytes are already measured for the audit log
-(`ResultBytes`), so the accounting exists; only the budget does not.
+exfiltrated.
 
-Defaults are conservative and per-project, because there is no meaningful
-global default: a grant that exists to check mail hourly and one that exists
-to answer interactive questions have nothing in common.
+Defaults are conservative and per-enrolment, because there is no meaningful
+global default: an agent that checks mail hourly and one that answers
+interactive questions have nothing in common. The first values will be wrong;
+`throttled` is distinguishable in the log precisely so that tuning is driven by
+evidence rather than by guessing twice.
 
-### 8. Enrolment is an explicit host-side act, and revocation is immediate
+### 8. Enrolment is an explicit host-side act; revocation cuts live connections
 
-A client is enrolled from the host — a deliberate operator action producing a
-certificate bound to one client identity. There is no self-service enrolment
-and no bootstrap token that can be replayed into a new identity: the whole
-value of decision 2 is that a certificate is harder to copy than a token, and
-an enrolment flow reachable by presenting a secret would reintroduce exactly
-the property being designed out.
+Relay is its own CA. An operator creates an enrolment on the host, relay signs
+a client certificate, and relay emits a bundle — client key, client
+certificate, and the CA certificate the client needs to verify the server —
+which is copied to the client machine.
 
-Revocation takes effect on the next connection, not the next restart, and
-enrolments are listed in the Settings UI beside the projects they can reach —
-a credential you cannot see is one you will not revoke.
+There is no self-service enrolment and no bootstrap token. An enrolment
+endpoint reachable by presenting a secret would reintroduce precisely the
+replayable credential decision 2 removed, and would do it at the one point in
+the system where the result is a *new identity* rather than a single call.
+
+The private key is generated on the host and travels to the client once. That
+is a deliberate simplification and the weakest step in this design: a CSR flow,
+where the client generates its key and only a signing request crosses the gap,
+never exposes the key at all. It is the obvious upgrade if these machines ever
+stop being the same person's.
+
+Client certificates are long-lived, and **revocation rather than expiry is the
+control**. Short lifetimes would need an authenticated renewal path, which is
+the replayable-secret problem again wearing a different hat. This is the right
+trade for a handful of enrolments and the wrong one for a fleet; it is the
+first thing to revisit if the number of enrolments grows.
+
+Revocation deletes the enrolment, and **closes any live connection holding that
+certificate**. Taking effect on the next connection is not enough: the wire
+protocol holds persistent connections in a scanner loop, so a compromised agent
+that never reconnects would keep working indefinitely.
+
+Enrolments are listed in the Settings UI beside the grants they reach — a
+credential you cannot see is one you will not revoke.
 
 ### 9. Tunnels are a network path, never an identity
 
 `tunnel` and `wiretunnel` may carry `RemoteServer` traffic. Neither may
-substitute for it, and the existing `BridgeServer` Unix socket must not be
-exposed through one.
+substitute for it, and the `BridgeServer` Unix socket must never be forwarded
+through one.
 
 Forwarding the bridge socket would satisfy reachability while silently
 defeating every decision above: relay would see a local connection, so
 `PeerPID` would attribute calls to the tunnel process, directory auth would
 become reachable from off-host, the full ten-request surface would be exposed,
 and there would be no per-client identity to record or revoke. It is the
-fastest way to build this and it produces the exact system this ADR is written
-to avoid.
+fastest way to build this and it produces the exact system this ADR exists to
+avoid.
+
+`RemoteServer` is **disabled unless configured**, and its listen address
+defaults to `127.0.0.1`:
+
+    "remote": {
+      "enabled": true,
+      "listen": "127.0.0.1:9910"
+    }
+
+An absent block means no listener. The default binds loopback so that
+misconfiguration cannot expose the control plane to a LAN, and so that
+same-machine development needs no configuration at all. Reaching relay from a
+VM is then a deliberate act — widening the bind address, or running a tunnel —
+rather than something that happens by leaving a field unset.
+
+`RemoteServer` sets read and write deadlines on every accepted connection.
+`BridgeServer` sets none, which is harmless on a local socket where the peer is
+same-user and a slowloris vector on a network listener.
 
 ## Consequences
 
-- **A remote client cannot do anything but call tools.** No project listing,
-  no manifest registration, no PTY, no admin. If a future remote client needs
-  one of those, it is a deliberate addition to the remote dispatch table with
-  its own review, not a discovery that it already worked.
+- **A remote client cannot do anything but call tools.** No project listing, no
+  manifest registration, no PTY, no admin. If a future remote client needs one
+  of those, it is a deliberate addition to a two-entry dispatch table with its
+  own review, not a discovery that it already worked.
 
-- **Enrolment is manual, and that is a cost.** Standing up a new VM requires a
-  host-side action. This is accepted: the alternative is an automated flow
-  gated by a replayable secret, which would undo decision 2.
+- **A stolen `settings.json` grants no remote access.** Decision 2 removed the
+  bearer token from this path entirely, so the file that holds every project
+  token in plaintext is not a remote credential. The certificate is, and it
+  lives only where an operator put it.
 
-- **Remote tool calls can fail because auditing failed.** New failure mode,
-  accepted deliberately, and the one place where this ADR knowingly trades
-  availability for evidence.
+- **Enrolment is manual, and that is a cost.** Standing up a new agent requires
+  a host-side action and a file copy. Accepted: the alternative is an automated
+  flow gated by a replayable secret, at the one point in the system where the
+  result is a new identity rather than a single call.
 
-- **Budgets will be tuned by being hit.** A first guess at a mail-checking
-  agent's rate will be wrong. The refusal is audited and distinguishable, so
-  tuning is driven by evidence rather than by guessing twice.
+- **The private key travels once, and that is the weakest step.** A CSR flow
+  would avoid it. This is the first thing to change if these machines stop
+  being the same person's.
 
-- **`relayClient` is taken.** It is the Capacitor iOS wrapper for Eve. The new
-  client needs a different name; `relayRemote` and `relayAgent` are both free.
+- **Remote tool calls can fail because auditing failed.** The one place this
+  ADR knowingly trades availability for evidence. An intent record with no
+  completion is a signal, not noise.
 
-- **Connection deadlines become mandatory.** `BridgeServer` sets no read or
-  write deadlines on accepted connections — harmless on a local socket where
-  the peer is same-user, a slowloris vector on a network listener.
-  `RemoteServer` sets both.
+- **Budgets will be tuned by being hit.** First values will be wrong. That is
+  why `throttled` is a distinct outcome: tuning is driven by evidence rather
+  than by guessing twice.
 
-- **Per-tool tri-state permissions remain out of scope**, as ADR-009 left
-  them. Nothing here depends on that model, and a remote grant's enumerated
-  `allowed_mcp_ids` plus `disabled_tools` is sufficient for 2b.
+- **Agent separation on one VM is only as strong as that VM.** Relay
+  distinguishes co-located agents by the key each presents and cannot enforce
+  that they keep those keys from each other.
 
-### Open questions
+- **`relayClient` is taken** — it is the Capacitor iOS wrapper for Eve. The new
+  client needs its own name; `relayRemote` and `relayAgent` are both free.
 
-These are the parts most likely to change under review, and are called out
-rather than settled so that accepting this ADR does not implicitly accept a
-guess:
+- **Per-tool tri-state permissions remain out of scope**, as ADR-009 left them.
+  A remote grant's enumerated `allowed_mcp_ids` plus `disabled_tools` is
+  sufficient for 2b.
 
-- **Certificate authority shape.** Whether relay acts as its own CA or
-  consumes an external one. Self-signed per-host is simplest and matches how
-  `eve.lan` is already handled in `relayClient`; an external CA is more
-  ceremony than a two-machine deployment warrants.
+### Deferred, deliberately
 
-- **Certificate lifetime and renewal.** Short-lived certificates with
-  automated renewal are stronger but require a renewal path that is itself
-  authenticated — which risks recreating the replayable-secret problem
-  decision 8 avoids.
+Each of these is a decision already taken in a direction, not an unknown:
 
-- **Whether budgets belong on the project or the enrolment.** A project is the
-  capability; an enrolment is the machine. Two VMs sharing one grant is
-  plausible, and it is not obvious which should hold the budget.
-
-- **Streaming under fail-closed audit.** `RespProgress` frames are emitted
-  during a call. Whether a mid-stream audit failure aborts an in-flight call
-  or is recorded and tolerated is unresolved.
+- **A project-level volume ceiling** across every enrolment holding a grant.
+  Protects the resource rather than bounding a single compromise (decision 7).
+- **A CSR enrolment flow**, so a client key never transits (decision 8).
+- **Short-lived certificates with automated renewal**, which need an
+  authenticated renewal path that does not become a replayable secret
+  (decision 8). Revisit when the number of enrolments outgrows manual
+  revocation.
 
 ## See also
 
 - ADR-009 — the remote project model this completes
   (`docs/decisions/009-remote-projects.md`); "the listener, client
-  certificates, and enrollment flow are 2b" is the sentence this ADR answers.
-- ADR-008 — the audit chokepoint and the fail-open trade this narrows for
-  remote callers (`docs/decisions/008-tool-call-audit-log.md`).
-- ADR-007 — the token brokering model the grant half rests on
-  (`docs/decisions/007-project-token-brokering.md`).
-- `docs/tokens.md` — the credential inventory; the directory-auth section
-  states the local-only reasoning that decision 4 inverts.
+  certificates, and enrollment flow are 2b" is the sentence this ADR answers,
+  and `validateProjectShape` is why remoteness is a shape rather than a
+  location.
+- ADR-008 — the audit chokepoint, and the fail-open trade decision 5 reverses
+  for remote callers (`docs/decisions/008-tool-call-audit-log.md`).
+- ADR-007 — the token brokering model that decision 2 deliberately does *not*
+  extend to the remote path (`docs/decisions/007-project-token-brokering.md`).
+- `docs/tokens.md` — the credential inventory. Its directory-auth section
+  states the local-only reasoning that decision 4 makes unrepresentable, and
+  its same-user argument is the one decision 2 relocates to the client machine.
 - `bridge/server.go`, `bridge/client.go` — the Unix-socket listener and dialer
-  that `RemoteServer` sits beside rather than replaces.
-- `bridge/types.go` — `BridgeRequest`, and the ten request-type constants that
+  `RemoteServer` sits beside rather than replaces.
+- `bridge/types.go` — `BridgeRequest`, and the ten request-type constants
   decision 1 narrows to two.

--- a/docs/decisions/010-remote-client-transport-and-identity.md
+++ b/docs/decisions/010-remote-client-transport-and-identity.md
@@ -1,0 +1,287 @@
+# ADR-010: A Remote Caller Is a Certificate on a Narrow Listener
+
+**Status:** Proposed
+**Date:** 2026-08-20
+
+## Context
+
+Step 2b of letting a semi-trusted LLM agent run on a separate VM and reach
+relay for tool access. ADR-009 made the *project model* coherent for that
+client and stopped there, deliberately: "it does not add the listener, client
+certificates, or the enrollment flow that would let one actually connect."
+This ADR is that missing half.
+
+The concrete target is an agent in a VM asking relay to read Apple Mail on the
+host. The threat model is unchanged from ADR-009 — **exfiltration, not
+privilege escalation**. The VM cannot escape to the host, so the risk worth
+designing against is an agent reading an entire mailbox and shipping it
+somewhere, not an agent breaking out of a sandbox.
+
+Everything above the transport is ready. The transport does not exist, and the
+authentication model underneath it assumes it never will. Three properties of
+the current design are correct locally and become wrong the moment a socket is
+reachable from another machine:
+
+1. **Reachability equals authority.** The bridge dispatches ten request types.
+   Two (`ListTools`, `CallTool`) are project-scoped. The other eight —
+   `ResolvePtyEnv`, `RegisterManifest`, `ListProjects`, `GetProject`,
+   `ResolveProjectTemplate`, `ReconcileExternalMcps`, `ReloadExternalMcp`,
+   `ReloadService` — are separated from a tool call only by *which token was
+   presented*, and a service token is documented god-mode ("bypasses all
+   per-project tool filtering"). Locally that separation is sound, because the
+   0600 socket already means same-user. Over a network it makes a single token
+   comparison the only thing between a remote VM and relay's control plane.
+
+2. **The cwd argument inverts.** `docs/tokens.md` justifies trusting a
+   caller-asserted working directory because "anything able to lie here can
+   already read every token out of the 0600 settings.json." That reasoning is
+   airtight for a local process and false for a remote one: a remote caller
+   cannot read `settings.json`, so the thing the argument trades away is no
+   longer already lost. A tokenless remote caller asserting a cwd inside any
+   local project with `allow_cwd_auth` would authenticate as that project.
+
+3. **Fail-open audit stops being harmless.** `docs/audit-log.md` already says
+   so: dropping an event rather than delaying a call is "a deliberate choice
+   for local use… the wrong choice for a remote caller, where the trust
+   boundary justifies refusing a call that cannot be recorded."
+
+A fourth property was never right, and only remote access makes it urgent:
+there is no rate limit, quota, throttle, or volume budget anywhere in the
+codebase. `MaxMessageSize` (10 MiB) bounds a single frame, not a session.
+ADR-008 bought detection; nothing bought interdiction. A remote grant of
+`mail_search` + `mail_get_emails` can drain a mailbox as fast as Mail.app
+answers, fully logged and wholly unimpeded — the exact threat ADR-009 names,
+with the audit log as a faithful record of it happening.
+
+## Decision
+
+### 1. A remote caller gets its own listener, and that listener can only call tools
+
+`RemoteServer` is a second listener, separate from `BridgeServer`, whose
+dispatch table contains exactly `ListTools` and `CallTool`. The other eight
+request types are not refused by a check inside a shared handler — they are
+absent from the remote dispatch table, so there is no code path from a remote
+connection to `ResolvePtyEnv` or `RegisterManifest` at all.
+
+This is deliberately *not* implemented as `if isRemote { … }` guards added to
+`bridge/server.go`. A shared handler with per-request transport checks makes
+every future request type a decision someone must remember to get right, and
+the failure mode of forgetting is silent: a new admin op is reachable from the
+VM the day it is added, with nothing in review to catch it. Two dispatch
+tables make the same mistake loud — a new op is unreachable remotely until
+someone deliberately adds it to a list that is visibly a security boundary.
+
+This mirrors the belt-and-braces reasoning ADR-009 applied to `allowed_dirs`,
+and for the same stated reason: the failure mode is a *silent* widening of
+scope rather than a loud error.
+
+### 2. The certificate is the identity; the project token names the grant
+
+A remote connection requires mutual TLS. The client certificate answers *who
+is calling* and the project token answers *which capability grant to apply*.
+Both are required; neither substitutes for the other.
+
+A bearer token alone cannot carry this weight. Project tokens are long-lived,
+stored in plaintext in `settings.json`, replayable in full by anyone who
+observes one, and carry no expiry — properties that are acceptable when the
+only way to observe one is to already be the local user, and unacceptable
+across a network. The certificate is what makes a call attributable to a
+*machine* rather than to a secret that may have been copied off one.
+
+The token is not demoted to a formality. It remains the thing that selects the
+grant, so revoking a grant and revoking a device stay independent operations:
+rotating a project token cuts capability without re-enrolling hardware, and
+revoking a certificate cuts a machine without disturbing any project.
+
+`RemoteServer` resolves the certificate to an enrolled client identity before
+the token is examined. A connection whose certificate does not resolve is
+closed without reading a request, so an unenrolled caller cannot probe token
+validity.
+
+### 3. Only remote-kind project tokens are accepted, and service tokens never are
+
+The remote listener refuses any token that does not resolve to a project with
+`IsRemote()` true. A service token presented on a remote connection is
+rejected before use, not merely unhelpful.
+
+Both halves matter and neither is redundant. Refusing service tokens closes
+god-mode. Requiring `IsRemote()` means the ADR-009 guards — no filesystem
+scope, no wildcard MCP grants, no sessions, no PTY — are load-bearing for
+every remote call rather than incidental to which token the caller happened to
+present. Without it, a leaked *local* project token would grant a remote
+caller a filesystem-scoped project, and every protection ADR-009 built would
+be bypassed by presenting the wrong credential rather than by defeating any of
+them.
+
+### 4. Directory auth is structurally impossible on the remote listener
+
+`RemoteServer` never populates the caller-cwd context value, and a remote
+request carrying `Cwd` is rejected rather than ignored.
+
+Rejecting rather than ignoring is the whole point. Silently dropping the field
+would leave a client that believes it is authenticating by directory and is
+in fact authenticating by token — the two produce identical success today,
+so the divergence would surface only when the token was removed and the call
+unexpectedly kept working, or stopped. An explicit error at the door makes a
+client that tries this fail immediately and visibly.
+
+The condition ADR-009 identified for remote projects — "a remote caller's cwd
+is a path on a *different* machine, with nothing on the host to compare it
+against" — is a property of the *connection*, not only of the project. Enforcing
+it at the transport means it holds even for a request that never resolves to a
+project at all.
+
+### 5. Audit is fail-closed for remote callers
+
+`audit.required` (default true for remote, unchanged fail-open for local)
+refuses any remote tool call that cannot be durably recorded. If the audit
+channel is saturated or the log cannot be written, the call returns an error
+instead of proceeding unlogged.
+
+ADR-008 accepted fail-open with a precise consequence: "the log is not
+admissible as proof that something did *not* happen." That is a fair trade for
+a local laptop, where the alternative is your own tooling breaking. It is the
+wrong trade for the one caller whose activity the log exists to establish. The
+cost is real and is accepted here: a remote agent will occasionally see a tool
+call fail because relay could not write a line about it.
+
+Local behaviour does not change. The same drop-and-count path stays exactly as
+ADR-008 specified it, because the reasoning that justified it there is
+untouched by any of this.
+
+### 6. `AuditActor` gains attested remote identity
+
+Three fields, all derived from the connection rather than asserted by the
+caller: the enrolled client identity, the certificate fingerprint that
+authenticated it, and the remote address. A new `AuditAuthMTLS` constant joins
+the existing auth methods.
+
+This preserves ADR-008's second property — "attributed… from relay's own
+knowledge, not from anything the caller asserts." `PeerPID` is the local
+expression of that property and is meaningless across a network; the
+certificate fingerprint is its remote equivalent, and is strictly stronger,
+since a pid is reusable and racy while a fingerprint is not.
+
+Recording the fingerprint and not only the resolved identity is what makes
+revocation auditable after the fact: it answers which *key* made a call, so a
+compromised device's history stays legible once its enrolment is deleted.
+
+### 7. Remote grants carry budgets, enforced at the router
+
+A remote project may declare a call-rate limit and a cumulative result-volume
+budget per rolling window. Both are enforced in `appRouter.CallTool` — the
+same chokepoint ADR-008 chose, for the same reason: it is the one place every
+transport already funnels through, and the place where the project is known.
+
+Exceeding a budget is refused with an audit outcome of its own, distinct from
+`denied` (a tool the grant never included) and from `tool_error` (a boundary
+inside the MCP). The distinction is the point: a rate refusal is the only one
+of the three that says *the grant was legitimate and the pattern of use was
+not*, which is precisely the exfiltration signal this ADR exists to surface.
+
+Volume is budgeted alongside rate because they fail differently. Rate alone
+does not stop a slow drain, and a mailbox exfiltrated over six hours is
+exfiltrated. Result bytes are already measured for the audit log
+(`ResultBytes`), so the accounting exists; only the budget does not.
+
+Defaults are conservative and per-project, because there is no meaningful
+global default: a grant that exists to check mail hourly and one that exists
+to answer interactive questions have nothing in common.
+
+### 8. Enrolment is an explicit host-side act, and revocation is immediate
+
+A client is enrolled from the host — a deliberate operator action producing a
+certificate bound to one client identity. There is no self-service enrolment
+and no bootstrap token that can be replayed into a new identity: the whole
+value of decision 2 is that a certificate is harder to copy than a token, and
+an enrolment flow reachable by presenting a secret would reintroduce exactly
+the property being designed out.
+
+Revocation takes effect on the next connection, not the next restart, and
+enrolments are listed in the Settings UI beside the projects they can reach —
+a credential you cannot see is one you will not revoke.
+
+### 9. Tunnels are a network path, never an identity
+
+`tunnel` and `wiretunnel` may carry `RemoteServer` traffic. Neither may
+substitute for it, and the existing `BridgeServer` Unix socket must not be
+exposed through one.
+
+Forwarding the bridge socket would satisfy reachability while silently
+defeating every decision above: relay would see a local connection, so
+`PeerPID` would attribute calls to the tunnel process, directory auth would
+become reachable from off-host, the full ten-request surface would be exposed,
+and there would be no per-client identity to record or revoke. It is the
+fastest way to build this and it produces the exact system this ADR is written
+to avoid.
+
+## Consequences
+
+- **A remote client cannot do anything but call tools.** No project listing,
+  no manifest registration, no PTY, no admin. If a future remote client needs
+  one of those, it is a deliberate addition to the remote dispatch table with
+  its own review, not a discovery that it already worked.
+
+- **Enrolment is manual, and that is a cost.** Standing up a new VM requires a
+  host-side action. This is accepted: the alternative is an automated flow
+  gated by a replayable secret, which would undo decision 2.
+
+- **Remote tool calls can fail because auditing failed.** New failure mode,
+  accepted deliberately, and the one place where this ADR knowingly trades
+  availability for evidence.
+
+- **Budgets will be tuned by being hit.** A first guess at a mail-checking
+  agent's rate will be wrong. The refusal is audited and distinguishable, so
+  tuning is driven by evidence rather than by guessing twice.
+
+- **`relayClient` is taken.** It is the Capacitor iOS wrapper for Eve. The new
+  client needs a different name; `relayRemote` and `relayAgent` are both free.
+
+- **Connection deadlines become mandatory.** `BridgeServer` sets no read or
+  write deadlines on accepted connections — harmless on a local socket where
+  the peer is same-user, a slowloris vector on a network listener.
+  `RemoteServer` sets both.
+
+- **Per-tool tri-state permissions remain out of scope**, as ADR-009 left
+  them. Nothing here depends on that model, and a remote grant's enumerated
+  `allowed_mcp_ids` plus `disabled_tools` is sufficient for 2b.
+
+### Open questions
+
+These are the parts most likely to change under review, and are called out
+rather than settled so that accepting this ADR does not implicitly accept a
+guess:
+
+- **Certificate authority shape.** Whether relay acts as its own CA or
+  consumes an external one. Self-signed per-host is simplest and matches how
+  `eve.lan` is already handled in `relayClient`; an external CA is more
+  ceremony than a two-machine deployment warrants.
+
+- **Certificate lifetime and renewal.** Short-lived certificates with
+  automated renewal are stronger but require a renewal path that is itself
+  authenticated — which risks recreating the replayable-secret problem
+  decision 8 avoids.
+
+- **Whether budgets belong on the project or the enrolment.** A project is the
+  capability; an enrolment is the machine. Two VMs sharing one grant is
+  plausible, and it is not obvious which should hold the budget.
+
+- **Streaming under fail-closed audit.** `RespProgress` frames are emitted
+  during a call. Whether a mid-stream audit failure aborts an in-flight call
+  or is recorded and tolerated is unresolved.
+
+## See also
+
+- ADR-009 — the remote project model this completes
+  (`docs/decisions/009-remote-projects.md`); "the listener, client
+  certificates, and enrollment flow are 2b" is the sentence this ADR answers.
+- ADR-008 — the audit chokepoint and the fail-open trade this narrows for
+  remote callers (`docs/decisions/008-tool-call-audit-log.md`).
+- ADR-007 — the token brokering model the grant half rests on
+  (`docs/decisions/007-project-token-brokering.md`).
+- `docs/tokens.md` — the credential inventory; the directory-auth section
+  states the local-only reasoning that decision 4 inverts.
+- `bridge/server.go`, `bridge/client.go` — the Unix-socket listener and dialer
+  that `RemoteServer` sits beside rather than replaces.
+- `bridge/types.go` — `BridgeRequest`, and the ten request-type constants that
+  decision 1 narrows to two.


### PR DESCRIPTION
Refs #11. **Draft for review — deliberately not merged.**

ADR-009 ends with "the listener, client certificates, and enrollment flow are 2b."
This is 2b, written as a design record before code because the load-bearing choice
isn't the transport — it's **which request types a remote connection may reach and
what attests the caller's identity**. Both are hard to change once a client exists
in the wild.

## Status is `Proposed`, not `Accepted`

`000-readme.md` says ADRs are "immutable once accepted." Four questions are
genuinely open and are listed in the ADR rather than settled, so accepting it
doesn't implicitly accept a guess:

- CA shape — relay as its own CA vs. an external one
- certificate lifetime and renewal (renewal must not recreate the replayable-secret problem)
- whether budgets belong on the project or the enrolment
- streaming under fail-closed audit — does a mid-stream audit failure abort an in-flight call

## The nine decisions

1. **A remote caller gets its own listener with a two-entry dispatch table**
   (`ListTools`, `CallTool`). Not `if isRemote {…}` guards in the shared handler
   — two tables make forgetting *loud*, where a shared handler makes each new
   request type a silent decision someone must remember.
2. **The certificate is the identity; the project token names the grant.** Both
   required. Keeps device revocation and capability revocation independent.
3. **Only `IsRemote()` project tokens accepted; service tokens never.** Both
   halves needed — without the first, a leaked *local* token would bypass every
   ADR-009 guard by presenting the wrong credential rather than defeating any of them.
4. **Directory auth made structurally impossible**, and a `Cwd` field is
   *rejected* rather than ignored, so a client that tries it fails visibly.
5. **Fail-closed audit for remote callers** (`audit.required`). Local behaviour unchanged.
6. **`AuditActor` gains attested remote identity** — client identity, cert
   fingerprint, remote address, plus `AuditAuthMTLS`. The fingerprint is what
   keeps a revoked device's history legible.
7. **Per-grant rate and volume budgets** at `appRouter.CallTool`, with a distinct
   audit outcome — the only one of the three that says *the grant was legitimate
   and the pattern of use was not*.
8. **Enrolment is an explicit host-side act; revocation takes effect next connection.**
9. **Tunnels are a network path, never an identity** — forwarding the bridge socket
   satisfies reachability while silently defeating decisions 1–6.

## What prompted each decision

Every one traces to something in the current tree, not to a hypothetical:

| Finding | Decision |
|---|---|
| 10 request types, 8 gated by token type only; service token is god-mode | 1, 3 |
| `tokens.md` cwd argument is local-only and inverts remotely | 4 |
| `docs/audit-log.md:142` already calls fail-open "the wrong choice for a remote caller" | 5 |
| `AuditActor` is entirely local (PID/Proc/Parent/Cwd) | 6 |
| No rate limit / quota / throttle anywhere; `MaxMessageSize` bounds a frame, not a session | 7 |
| `bridge/server.go` sets no connection deadlines (client does) | Consequences |
| `relayClient` is the Capacitor iOS wrapper for Eve | Consequences |

Claims were verified against the tree rather than asserted: the ten request-type
constants, zero `SetDeadline` calls in `bridge/server.go`, `ResultBytes` already
being measured (so budget accounting exists and only the budget doesn't),
`RespProgress` existing (which is what makes open question 4 real), and
`relayRemote` / `relayAgent` both being free repo names.

## Scope

Docs only — `010-*.md` plus the `000-readme.md` index entry. No Go files touched,
so the pre-commit suite correctly skips. Nothing here is implemented.

## Why I didn't merge it

The point of a design ADR is your review of the design. Merging my own proposal
would skip the only step that matters, and `Accepted` is a claim I can't make on
your behalf. Once you've read it: if the shape is right, flip Status to `Accepted`
and merge; if the open questions resolve differently, they change decisions 2 and
7 and it's cheaper to fix now than after `RemoteServer` exists.
