### PR TITLE
ADR-010 part 1: relay CA, enrolments, and two-phase remote audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,14 @@ brokering rationale: ADR-007):
 `appRouter.CallTool`, the single chokepoint every transport funnels through.
 Attribution comes from relay's own auth resolution (project id) and the kernel
 (peer pid off the bridge socket), never from the caller. Arguments are redacted
-and capped; results are metadata-only unless explicitly opted in. The sink fails
-open and shows its drop count rather than stalling a tool call. Viewer:
-Settings → Tool Calls, or `relay audit`. Full reference:
-[`docs/audit-log.md`](docs/audit-log.md); rationale: ADR-008.
+and capped; results are metadata-only unless explicitly opted in. For a local
+caller the sink fails open and shows its drop count rather than stalling a tool
+call; for a remote one it is fail-closed — an `intent` record is written and
+flushed before the MCP runs, a `completion` record with the same `id` follows,
+and a call whose intent cannot be recorded is refused (ADR-010 decision 5).
+Viewer: Settings → Tool Calls, or `relay audit` (`--kind remote` for anything a
+VM did). Full reference: [`docs/audit-log.md`](docs/audit-log.md); rationale:
+ADR-008, narrowed for remote callers by ADR-010.
 
 **TCC permissions** — relay holds the personal-information entitlements
 (`Relay.entitlements`) and fires the prompts from its own process; MCPs declare

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ service management.
 - `relay mcp register|unregister|list` — external MCP management.
 - `relay service register|unregister|restart|list` — service self-registration. `restart` sends `ReloadService`; the tray does Stop → Start in place.
 - `relay audit [--tail N] [--project ID] [--outcome denied] [--grep TEXT] [--json]` — tail the tool-call audit log. Reads the file directly, so it works with the tray stopped.
+- `relay enrol create --client-id ID --grant PROJECT_ID [--grant ...] | list | revoke --client-id ID` — remote-client enrolment. Signs a client certificate off relay's own CA and emits a bundle to copy to the client machine. Host-side operator act only: no self-service enrolment, no bootstrap token.
 
 ## Architecture
 
@@ -42,6 +43,9 @@ router.go                Bridge auth (service vs project tokens), tool filtering
 audit.go                 Tool-call audit log: event model, async writer, ring, redaction, query
 audit_call.go            Nil-safe per-call event builder used by the router instrumentation
 audit_cmd.go             `relay audit` CLI
+enrolment.go             Enrolment CRUD, grant validation, revocation + its live-connection hook
+enrolment_ca.go          Relay's self-signed CA: lazy generation, client/server cert issuance, fingerprints
+enrol_cmd.go             `relay enrol` CLI
 external_mcp.go          stdio/HTTP MCP clients + runtime schema storage (McpConnection iface)
 http_mcp.go, oauth.go    HTTP transport + OAuth 2.1 (PKCE, dynamic registration, refresh)
 mcp_cmd.go, exec_cmd.go, service_cmd.go   CLI subcommands
@@ -103,10 +107,34 @@ MCP's schema is discovered at runtime and could gain that field after a
 grant was already validated. Sessions (`refuseRemoteSession`) and PTY
 launches (`refuseRemotePty`) are refused at the point of use too, not just
 at validation — see ADR-009 for why each of these is defended twice rather
-than once. As of this writing a remote project cannot yet be *reached* by
-anything; only the model and its invariants exist so far.
+than once.
 
 See [ADR-009](docs/decisions/009-remote-projects.md) for the full reasoning.
+
+### Remote client enrolment
+
+An **enrolment** (`enrolment.go`, `settings.json` → `enrolments`) binds one
+client certificate to the remote projects it may use. It is keyed by
+*certificate, not by machine* — several agents on one VM each hold their own
+enrolment, granted, audited, and revoked independently, and nothing may assume
+one per machine. There is **no bearer token anywhere on this path**: a stolen
+`settings.json` grants no remote access at all.
+
+Relay is its own CA (`enrolment_ca.go`), generated lazily on first use and
+persisted as `ca.key` / `ca.crt` (0600) in the config dir — not in
+`settings.json`, which is rewritten in full on every mutation. Client certs are
+long-lived because *revocation, not expiry, is the control*; revoking deletes
+the record and fires `SetEnrolmentRevocationHook` so the listener can close
+live connections.
+
+Grants are validated at enrolment (`ValidateEnrolmentGrants` — every grant must
+name a project with `IsRemote()` true) and at conversion
+(`ValidateProjectEnrolments` — remote→local is refused while any enrolment
+grants the project, naming the offenders). Call-time re-checking belongs to the
+listener. As of this writing there is still no listener, so a remote project
+cannot yet be *reached*; the model, the CA, and the enrolment flow exist.
+
+See [ADR-010](docs/decisions/010-remote-client-transport-and-identity.md).
 
 ## Service manifest (enhanced services)
 

--- a/audit.go
+++ b/audit.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -38,18 +39,51 @@ const (
 // returned a normal result carrying isError, which is how a server reports an
 // application-level refusal such as a path outside allowed_dirs. Both are
 // failures, but only the second tells you a boundary was probed and held.
+//
+// Throttled is distinct from both, and from ToolError. It means the grant was
+// legitimate and the tool was allowed, and the *pattern of use* was refused — a
+// rate or volume budget on the enrolment was exceeded (ADR-010 decision 7).
+// That is precisely what exfiltration looks like from the host's side, which is
+// why it must not be flattened into denied.
+//
+// Pending is the outcome-so-far of an intent record, whose result is by
+// definition not known yet (see AuditPhaseIntent). It is a real value rather
+// than an empty string because "outcome" is a non-omitempty on-disk field that
+// every consumer already reads: the CLI table, the UI pill, and the --outcome
+// filter would each render or match "" as nothing at all, whereas "pending"
+// names the state truthfully and is what an alert on orphaned intents selects
+// on.
 const (
 	AuditOutcomeOK           = "ok"
 	AuditOutcomeError        = "error"
 	AuditOutcomeToolError    = "tool_error"
 	AuditOutcomeDenied       = "denied"
 	AuditOutcomeUnauthorized = "unauthorized"
+	AuditOutcomeThrottled    = "throttled"
+	AuditOutcomePending      = "pending"
 )
 
-// Actor kinds.
+// Record phases. A local call is one record and carries no phase at all, which
+// keeps every line written before ADR-010 — and every line written for a local
+// caller after it — exactly the shape ADR-008 specified.
+//
+// A remote call is two records sharing one event id: an intent written and
+// flushed before the MCP is invoked, and a completion written when the call
+// returns. Correlate them by id.
+const (
+	AuditPhaseIntent     = "intent"
+	AuditPhaseCompletion = "completion"
+)
+
+// Actor kinds. Remote is a distinct value rather than a reuse of Project so
+// that "show me everything any VM did" is a first-class filter rather than an
+// inference from which fields happen to be populated — a remote caller is
+// remote *and* acting as a project grant, and both facts are recorded
+// (ADR-010 decision 6).
 const (
 	AuditActorProject = "project"
 	AuditActorService = "service"
+	AuditActorRemote  = "remote"
 	AuditActorUnknown = "unknown"
 )
 
@@ -58,6 +92,7 @@ const (
 	AuditAuthToken   = "token"
 	AuditAuthCwd     = "cwd"
 	AuditAuthService = "service"
+	AuditAuthMTLS    = "mtls"
 	AuditAuthNone    = "none"
 )
 
@@ -71,9 +106,23 @@ type AuditActor struct {
 	ProjectName string `json:"project_name,omitempty"`
 	Auth        string `json:"auth"`
 	Cwd         string `json:"cwd,omitempty"`
-	PID         int    `json:"pid,omitempty"`
-	Proc        string `json:"proc,omitempty"`
-	Parent      string `json:"parent,omitempty"`
+
+	// PID / Proc / Parent describe a local caller and are omitted entirely for
+	// a remote one rather than zero-filled: they are omitempty, so an absent
+	// field reads as "not applicable" instead of "unknown".
+	PID    int    `json:"pid,omitempty"`
+	Proc   string `json:"proc,omitempty"`
+	Parent string `json:"parent,omitempty"`
+
+	// ClientID, Fingerprint and RemoteAddr are the remote equivalent, all three
+	// derived from the TLS connection and never asserted by the caller. The
+	// fingerprint is recorded in full and alongside the resolved client id
+	// rather than instead of it: that is what keeps a revoked device's history
+	// legible, by answering which *key* made a call after the enrolment naming
+	// that key has been deleted (ADR-010 decision 6).
+	ClientID    string `json:"client_id,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	RemoteAddr  string `json:"remote_addr,omitempty"`
 }
 
 // AuditEvent is one record in the tool-call log, serialized as a single JSONL
@@ -84,6 +133,12 @@ type AuditEvent struct {
 	DurMs int64      `json:"dur_ms"`
 	Event string     `json:"event"`
 	Actor AuditActor `json:"actor"`
+
+	// Phase is empty for the single record a local call produces, and is
+	// "intent" or "completion" for the two records a remote call produces,
+	// which share this event's ID. Absent-means-single is what keeps the local
+	// on-disk shape unchanged.
+	Phase string `json:"phase,omitempty"`
 
 	McpID string `json:"mcp_id,omitempty"`
 	Tool  string `json:"tool,omitempty"`
@@ -374,6 +429,7 @@ type AuditRecorder struct {
 
 	ch      chan AuditEvent
 	flushCh chan chan struct{}
+	syncCh  chan auditDurableWrite
 	ring    *auditRing
 	w       io.WriteCloser
 
@@ -416,6 +472,7 @@ func NewAuditRecorder(cfg *AuditConfig, path string) (*AuditRecorder, error) {
 		path:    path,
 		ch:      make(chan AuditEvent, auditQueueSize),
 		flushCh: make(chan chan struct{}),
+		syncCh:  make(chan auditDurableWrite),
 		ring:    newAuditRing(resolved.RingSize),
 		w:       w,
 		done:    make(chan struct{}),
@@ -459,6 +516,47 @@ func (r *AuditRecorder) SetSink(fn func(AuditEvent)) {
 	r.sinkMu.Unlock()
 }
 
+// auditDurableWrite is a synchronous write request handed to the writer
+// goroutine. The reply channel is buffered so the writer never blocks on a
+// caller that has given up waiting.
+type auditDurableWrite struct {
+	ev    AuditEvent
+	reply chan error
+}
+
+// errAuditUnavailable is returned by RecordDurable when there is no live sink
+// to write to. It is an error rather than a silent success because the only
+// caller is the fail-closed path: "I could not record this" and "I recorded
+// this" must never be indistinguishable there.
+var errAuditUnavailable = errors.New("audit recorder unavailable")
+
+// RecordDurable writes an event and blocks until it is on disk, returning any
+// error rather than swallowing it. This is the fail-closed half of the sink,
+// used for a remote caller's intent record (ADR-010 decision 5): the call is
+// refused when this fails, so the caller has to be able to tell.
+//
+// It does not use the bounded queue. The queue exists so that a slow sink can
+// never delay a *local* tool call, and delaying the call is exactly the point
+// here — but the file still belongs to the writer goroutine, so the event is
+// handed over rather than written from the caller's goroutine.
+func (r *AuditRecorder) RecordDurable(ev AuditEvent) error {
+	if r == nil || !r.cfg.Enabled {
+		return errAuditUnavailable
+	}
+	req := auditDurableWrite{ev: ev, reply: make(chan error, 1)}
+	select {
+	case r.syncCh <- req:
+	case <-r.done:
+		return errAuditUnavailable
+	}
+	select {
+	case err := <-req.reply:
+		return err
+	case <-r.done:
+		return errAuditUnavailable
+	}
+}
+
 // Record enqueues an event. Never blocks: a full queue drops the event and
 // increments the drop counter.
 func (r *AuditRecorder) Record(ev AuditEvent) {
@@ -487,6 +585,8 @@ func (r *AuditRecorder) run() {
 				return // Close() closed the queue; buffered events already drained
 			}
 			r.write(enc, ev)
+		case req := <-r.syncCh:
+			req.reply <- r.writeDurable(enc, req.ev)
 		case ack := <-r.flushCh:
 			// select gives no ordering guarantee between the two channels, so
 			// drain everything already queued before acknowledging. By the time
@@ -520,6 +620,49 @@ func (r *AuditRecorder) write(enc *json.Encoder, ev AuditEvent) {
 	if sink != nil {
 		sink(ev)
 	}
+}
+
+// writeDurable persists one event synchronously and reports whether it made it
+// to stable storage.
+//
+// Unlike write, the ring and the live UI sink are updated only *after* the
+// bytes are down. A record relay refused to stand behind must not show up in
+// the Tool Calls tab as though it had been logged — that would recreate, in the
+// one place that is supposed to be fail-closed, exactly the "incomplete log
+// that looks complete" ADR-008 called worse than no log at all.
+func (r *AuditRecorder) writeDurable(enc *json.Encoder, ev AuditEvent) error {
+	if err := enc.Encode(ev); err != nil {
+		slog.Warn("audit durable write failed", "path", r.path, "error", err)
+		return fmt.Errorf("audit write: %w", err)
+	}
+	if err := syncAuditWriter(r.w); err != nil {
+		slog.Warn("audit durable sync failed", "path", r.path, "error", err)
+		return fmt.Errorf("audit sync: %w", err)
+	}
+	r.ring.add(ev)
+	r.wrote.Add(1)
+
+	r.sinkMu.RLock()
+	sink := r.sink
+	r.sinkMu.RUnlock()
+	if sink != nil {
+		sink(ev)
+	}
+	return nil
+}
+
+// auditSyncer is the durable half of the log sink. rotatingWriter implements
+// it; an in-memory writer used by a test may not, and a sink with no notion of
+// stable storage is not something to refuse a tool call over — the bytes still
+// reached it.
+type auditSyncer interface{ Sync() error }
+
+func syncAuditWriter(w io.Writer) error {
+	s, ok := w.(auditSyncer)
+	if !ok {
+		return nil
+	}
+	return s.Sync()
 }
 
 // Close drains the queue and closes the file. Safe to call more than once.
@@ -572,8 +715,12 @@ type AuditQuery struct {
 	McpID     string `json:"mcp_id,omitempty"`
 	Outcome   string `json:"outcome,omitempty"`
 	Event     string `json:"event,omitempty"`
-	Text      string `json:"text,omitempty"` // substring over tool, args, error, project name
-	Limit     int    `json:"limit,omitempty"`
+	// Kind filters on the actor kind, which is how "everything any VM did"
+	// (kind=remote) is asked as one question rather than reconstructed from
+	// which actor fields happen to be set.
+	Kind  string `json:"kind,omitempty"`
+	Text  string `json:"text,omitempty"` // substring over tool, args, error, project name
+	Limit int    `json:"limit,omitempty"`
 	// Deep searches the log file rather than the in-memory ring, for history
 	// older than the ring holds. Bounded by auditTailBudget.
 	Deep bool `json:"deep,omitempty"`
@@ -590,6 +737,9 @@ func (q AuditQuery) matches(ev *AuditEvent) bool {
 		return false
 	}
 	if q.Event != "" && ev.Event != q.Event {
+		return false
+	}
+	if q.Kind != "" && ev.Actor.Kind != q.Kind {
 		return false
 	}
 	if q.Text != "" {

--- a/audit_call.go
+++ b/audit_call.go
@@ -19,6 +19,18 @@ type auditCall struct {
 	rec   *AuditRecorder
 	start time.Time
 	ev    AuditEvent
+
+	// remote marks a caller that arrived over the remote listener, which is the
+	// only thing that switches this event from ADR-008's one fail-open record
+	// to ADR-010's fail-closed intent + completion pair. It is set from the
+	// connection-attested identity in the context and from nothing else.
+	remote bool
+
+	// intentWritten records that the pre-call half is already on disk, so the
+	// final record is labelled as its completion rather than as a standalone
+	// event. A refusal that happens before the intent is written (an unknown
+	// tool, a denied grant) never reaches an MCP, so it stays a single record.
+	intentWritten bool
 }
 
 // beginAudit starts an event, capturing the caller's kernel-attested pid.
@@ -39,6 +51,22 @@ func (r *appRouter) beginAudit(ctx context.Context, event string) *auditCall {
 			Event: event,
 			Actor: AuditActor{Kind: AuditActorUnknown, Auth: AuditAuthNone},
 		},
+	}
+	// A remote caller's identity is attested by its certificate, which is the
+	// network equivalent of the peer pid and strictly stronger: a pid is
+	// reusable and racy, a fingerprint is neither. The two are mutually
+	// exclusive by construction — pid attribution means nothing across a
+	// network — so this is an either/or rather than two independent lookups,
+	// which is also what guarantees PID/Proc/Parent stay *absent* for a remote
+	// call instead of being filled with a locally-meaningless number.
+	if rc, ok := bridge.RemoteCallerFromContext(ctx); ok {
+		a.remote = true
+		a.ev.Actor.Kind = AuditActorRemote
+		a.ev.Actor.Auth = AuditAuthMTLS
+		a.ev.Actor.ClientID = rc.ClientID
+		a.ev.Actor.Fingerprint = rc.Fingerprint
+		a.ev.Actor.RemoteAddr = rc.RemoteAddr
+		return a
 	}
 	// Resolve the caller's process now, while it is certainly still alive: a
 	// `relay mcp call` child exits as soon as it has its answer, so resolving
@@ -80,6 +108,15 @@ func (a *auditCall) setActor(ctx context.Context, stored *StoredToken, settings 
 	if a == nil || stored == nil {
 		return
 	}
+	// A remote caller's kind and auth come from the connection, not from what
+	// auth resolution found, so they are left alone here — but the project
+	// fields below are still filled in. The caller is remote *and* acting as a
+	// project grant, and a record that dropped either half would answer only
+	// one of the two questions worth asking of it.
+	if a.remote {
+		a.setProject(stored, settings)
+		return
+	}
 	switch {
 	case stored.Name == serviceTokenName:
 		a.ev.Actor.Kind = AuditActorService
@@ -92,6 +129,13 @@ func (a *auditCall) setActor(ctx context.Context, stored *StoredToken, settings 
 		a.ev.Actor.Kind = AuditActorProject
 		a.ev.Actor.Auth = AuditAuthToken
 	}
+	a.setProject(stored, settings)
+}
+
+// setProject records the resolved grant. Shared by every actor kind: whichever
+// way a caller was identified, the project it is acting as comes from relay's
+// own auth resolution.
+func (a *auditCall) setProject(stored *StoredToken, settings *Settings) {
 	a.ev.Actor.ProjectID = stored.ProjectID
 	a.ev.Actor.ProjectName = projectNameFor(stored, settings)
 }
@@ -101,6 +145,13 @@ func (a *auditCall) setActor(ctx context.Context, stored *StoredToken, settings 
 // what directory — is exactly what a review of failed calls needs.
 func (a *auditCall) setUnauthenticated(ctx context.Context, token string) {
 	if a == nil {
+		return
+	}
+	// A remote caller that failed to resolve a grant is still a known
+	// certificate on a known connection: downgrading it to "unknown" would
+	// discard the only attribution the record has, and a refused remote call is
+	// exactly the record worth keeping attributable.
+	if a.remote {
 		return
 	}
 	a.ev.Actor.Kind = AuditActorUnknown
@@ -120,11 +171,53 @@ func (a *auditCall) setToolCount(n int) {
 	a.ev.ToolCount = n
 }
 
+// intent writes the pre-call record for a remote caller and blocks until it is
+// on disk, returning an error when it could not be written. The router turns
+// that error into a refusal, and the MCP is never invoked.
+//
+// The ordering is the whole point (ADR-010 decision 5). An event written after
+// the call — which is what every local call still does, because doneResult
+// needs the result bytes — makes "refuse a call that cannot be logged" mean
+// nothing: by the time the write fails the mailbox has been read and the data
+// has left the MCP. Refusing afterwards is theatre.
+//
+// An intent with no matching completion is a signal worth alerting on, not
+// noise to reconcile away: it means relay invoked an MCP and never learned the
+// outcome — a crash, a kill, or a hang. Deleting or pairing those away would
+// discard the only evidence that a call went in and nothing came back.
+//
+// A local caller returns nil immediately, and so does a nil *auditCall — which
+// is the case when auditing is switched off entirely. That is a deliberate
+// limit on this guarantee: an operator who turns the audit log off has turned
+// off the thing the refusal was protecting, and the Tool Calls tab says so
+// rather than pretending otherwise.
+func (a *auditCall) intent() error {
+	if a == nil || !a.remote {
+		return nil
+	}
+	ev := a.ev
+	ev.Phase = AuditPhaseIntent
+	ev.TS = a.start.UTC()
+	// The result is not knowable yet; "pending" says so in the field every
+	// reader of this log already looks at.
+	ev.Outcome = AuditOutcomePending
+	if err := a.rec.RecordDurable(ev); err != nil {
+		return err
+	}
+	a.intentWritten = true
+	return nil
+}
+
 // done finalizes the event with an outcome and optional error, then hands it to
 // the recorder.
 func (a *auditCall) done(outcome string, err error) {
 	if a == nil {
 		return
+	}
+	if a.intentWritten {
+		// Same id as the intent: that pairing is what makes the two lines one
+		// call rather than two events that happen to look alike.
+		a.ev.Phase = AuditPhaseCompletion
 	}
 	a.ev.DurMs = time.Since(a.start).Milliseconds()
 	a.ev.TS = a.start.UTC()

--- a/audit_cmd.go
+++ b/audit_cmd.go
@@ -21,7 +21,8 @@ func runAuditCommand(args []string) {
 	tail := fs.Int("tail", 50, "show the most recent N events")
 	project := fs.String("project", "", "filter by project id")
 	mcpID := fs.String("mcp", "", "filter by MCP id")
-	outcome := fs.String("outcome", "", "filter by outcome: ok, error, tool_error, denied, unauthorized")
+	outcome := fs.String("outcome", "", "filter by outcome: ok, error, tool_error, denied, unauthorized, throttled, pending")
+	kind := fs.String("kind", "", "filter by actor kind: project, service, remote, unknown")
 	event := fs.String("event", "", "filter by event kind: call_tool, list_tools, list_skills")
 	text := fs.String("grep", "", "substring match over tool, MCP, error, project, caller, args")
 	asJSON := fs.Bool("json", false, "emit raw JSONL instead of a table")
@@ -44,6 +45,7 @@ func runAuditCommand(args []string) {
 		ProjectID: *project,
 		McpID:     *mcpID,
 		Outcome:   *outcome,
+		Kind:      *kind,
 		Event:     *event,
 		Text:      *text,
 		Limit:     *tail,
@@ -97,7 +99,14 @@ func runAuditCommand(args []string) {
 // auditCallerLabel renders the actor as "parent→proc", falling back to whatever
 // half is known. The parent is listed first because it's the agent that asked;
 // the process is often just a short-lived `relay mcp` child.
+//
+// A remote caller has no process to name, so it is labelled by the enrolled
+// client instead — otherwise every row of `relay audit --kind remote` would
+// show a dash in the column that is supposed to say who called.
 func auditCallerLabel(a AuditActor) string {
+	if a.ClientID != "" {
+		return a.ClientID
+	}
 	switch {
 	case a.Parent != "" && a.Proc != "":
 		return a.Parent + "→" + a.Proc

--- a/audit_remote_test.go
+++ b/audit_remote_test.go
@@ -1,0 +1,504 @@
+package main
+
+// Fail-closed, two-phase auditing for remote callers (ADR-010 decisions 5 and
+// 6), and the local behaviour that must be provably unchanged by it.
+//
+// The tests that matter here are about *ordering*, not about content: a record
+// written after the MCP has run cannot make "refuse a call that cannot be
+// logged" mean anything, so the interesting assertions are made from inside the
+// MCP handler and from the fact that the handler never ran at all.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"relaygo/bridge"
+)
+
+// A full, untruncated fingerprint. Recorded whole so a revoked device's history
+// still says which key made the call.
+const testFingerprint = "sha256:9f2a41c78b0355ee1d6a4c2f8e0b7a93d5c14e6f8a2b0d9c3e7f15a8b46c2d90"
+
+// remoteCtx returns a context carrying the identity the remote listener
+// attests from the TLS connection. Nothing here is caller-asserted; the test
+// stands in for the listener, which another change owns.
+func remoteCtx(clientID string) context.Context {
+	return bridge.WithRemoteCaller(context.Background(), bridge.RemoteCaller{
+		ClientID:    clientID,
+		Fingerprint: testFingerprint,
+		RemoteAddr:  "127.0.0.1:52233",
+	})
+}
+
+// readLogFile parses the audit log without flushing. Used from inside an MCP
+// handler, where the point is what is *already* durably on disk at the moment
+// the tool is invoked — flushing first would destroy the thing being measured.
+func readLogFile(t *testing.T, rec *AuditRecorder) []AuditEvent {
+	t.Helper()
+	data, err := os.ReadFile(rec.Path())
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	var out []AuditEvent
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev AuditEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("audit log line is not valid JSON: %v\nline: %s", err, line)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Ordering: the intent record exists before the MCP is invoked
+// ---------------------------------------------------------------------------
+
+func TestAuditRemote_IntentIsOnDiskBeforeTheMcpRuns(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	// The recorder has to exist before the mock, because the mock reads its log.
+	var rec *AuditRecorder
+	var seen []AuditEvent
+	mock := newMockConn("macmcp", simpleTools("mail_search"),
+		func(context.Context, string, interface{}) (json.RawMessage, error) {
+			// Read the log from inside the tool call: whatever is here now was
+			// written before the MCP was reached.
+			seen = readLogFile(t, rec)
+			return json.RawMessage(`{"content":[{"type":"text","text":"3 messages"}]}`), nil
+		})
+
+	r := setupRouter(t, map[string]Permission{"macmcp": PermOn}, nil, nil,
+		map[string]*mockMcpConn{"macmcp": mock})
+	rec = newTestAudit(t, nil)
+	r.audit = rec
+
+	ctx := remoteCtx("hermes-mail")
+	if _, err := r.CallTool(ctx, "mail_search", json.RawMessage(`{"q":"invoice"}`), testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	if len(seen) != 1 {
+		t.Fatalf("log held %d records when the MCP ran, want exactly the intent: %+v", len(seen), seen)
+	}
+	ev := seen[0]
+	if ev.Phase != AuditPhaseIntent {
+		t.Errorf("phase = %q, want %q", ev.Phase, AuditPhaseIntent)
+	}
+	if ev.Outcome != AuditOutcomePending {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, AuditOutcomePending)
+	}
+	if ev.Tool != "mail_search" || ev.Actor.ClientID != "hermes-mail" {
+		t.Errorf("intent record is missing attribution: tool=%q client=%q", ev.Tool, ev.Actor.ClientID)
+	}
+	// Actor, tool and redacted arguments, per decision 5.
+	if string(ev.Args) != `{"q":"invoice"}` {
+		t.Errorf("intent args = %s, want the redacted call arguments", ev.Args)
+	}
+}
+
+// The refusal is the entire trade decision 5 makes: availability for evidence.
+// If the intent cannot be written the MCP must never be reached — asserting the
+// call returned an error is not enough, because a call that failed *after* the
+// mailbox was read is exactly the failure this design rejects.
+func TestAuditRemote_FailedIntentRefusesTheCallAndTheMcpNeverRuns(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	called := false
+	mock := newMockConn("macmcp", simpleTools("mail_search"),
+		func(context.Context, string, interface{}) (json.RawMessage, error) {
+			called = true
+			return json.RawMessage(`{"content":[]}`), nil
+		})
+	r, rec := auditedRouter(t,
+		map[string]Permission{"macmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"macmcp": mock}, nil)
+
+	// Break the sink the way a full or unwritable disk would: the file handle
+	// goes away underneath the writer, so the encode fails for real rather than
+	// through a test-only switch in production code.
+	if err := rec.w.Close(); err != nil {
+		t.Fatalf("close audit sink: %v", err)
+	}
+
+	_, err := r.CallTool(remoteCtx("hermes-mail"), "mail_search", json.RawMessage(`{}`), testToken)
+	if err == nil {
+		t.Fatal("remote call succeeded despite an unwritable audit log")
+	}
+	if !strings.Contains(err.Error(), "audit") {
+		t.Errorf("error = %v, want it to name auditing as the reason", err)
+	}
+	if called {
+		t.Error("the MCP was invoked for a call whose intent record could not be written")
+	}
+}
+
+// A local call keeps ADR-008's fail-open path exactly: the sink can be entirely
+// broken and the tool call still succeeds.
+func TestAuditLocal_UnwritableSinkStillCompletesTheCall(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	called := false
+	mock := newMockConn("fsmcp", simpleTools("read_file"),
+		func(context.Context, string, interface{}) (json.RawMessage, error) {
+			called = true
+			return json.RawMessage(`{"content":[]}`), nil
+		})
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	if err := rec.w.Close(); err != nil {
+		t.Fatalf("close audit sink: %v", err)
+	}
+
+	if _, err := r.CallTool(context.Background(), "read_file", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("a broken audit sink must not fail a local tool call: %v", err)
+	}
+	if !called {
+		t.Error("the MCP was not invoked for a local call")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Correlation
+// ---------------------------------------------------------------------------
+
+func TestAuditRemote_IntentAndCompletionShareOneEventID(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	mock := newMockConn("macmcp", simpleTools("mail_search"),
+		okHandler(`{"content":[{"type":"text","text":"3 messages"}]}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"macmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"macmcp": mock}, nil)
+
+	if _, err := r.CallTool(remoteCtx("hermes-mail"), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	events := readLoggedEvents(t, rec)
+	if len(events) != 2 {
+		t.Fatalf("a remote call wrote %d records, want intent + completion: %+v", len(events), events)
+	}
+	// readLoggedEvents preserves file order: intent first, completion second.
+	intent, completion := events[0], events[1]
+	if intent.Phase != AuditPhaseIntent || completion.Phase != AuditPhaseCompletion {
+		t.Fatalf("phases = %q then %q, want intent then completion", intent.Phase, completion.Phase)
+	}
+	if intent.ID == "" || intent.ID != completion.ID {
+		t.Errorf("ids = %q and %q, want one shared id", intent.ID, completion.ID)
+	}
+	if completion.Outcome != AuditOutcomeOK {
+		t.Errorf("completion outcome = %q, want ok (error=%q)", completion.Outcome, completion.Error)
+	}
+	if completion.ResultBytes == 0 {
+		t.Error("completion recorded no result size")
+	}
+	if intent.ResultBytes != 0 {
+		t.Error("intent recorded a result size, which it cannot possibly know")
+	}
+}
+
+// A refusal that happens before the MCP could be reached is a single record:
+// there is no side effect to have written a promise about.
+func TestAuditRemote_DeniedCallIsOneRecordWithNoIntent(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	mock := newMockConn("macmcp", simpleTools("mail_search", "send_mail"), okHandler(`{}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"macmcp": PermOn},
+		map[string][]string{"macmcp": {"send_mail"}},
+		map[string]*mockMcpConn{"macmcp": mock}, nil)
+
+	if _, err := r.CallTool(remoteCtx("hermes-mail"), "send_mail", nil, testToken); err == nil {
+		t.Fatal("disabled tool was not denied")
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Outcome != AuditOutcomeDenied {
+		t.Errorf("outcome = %q, want denied", ev.Outcome)
+	}
+	if ev.Phase != "" {
+		t.Errorf("phase = %q, want empty for a call that never reached an MCP", ev.Phase)
+	}
+	// The refusal is still attributable to the certificate that made it.
+	if ev.Actor.Kind != AuditActorRemote || ev.Actor.ClientID != "hermes-mail" {
+		t.Errorf("denied remote call lost its attestation: %+v", ev.Actor)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Remote actor identity (decision 6)
+// ---------------------------------------------------------------------------
+
+func TestAuditRemote_ActorIsAttestedAndProcessFieldsAreAbsent(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	mock := newMockConn("macmcp", simpleTools("mail_search"), okHandler(`{"content":[]}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"macmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"macmcp": mock}, nil)
+
+	// A peer pid in the context as well: even if one somehow rides along, a
+	// remote record must not be attributed to a local process.
+	ctx := bridge.WithCallerPID(remoteCtx("hermes-mail"), os.Getpid())
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	events := readLoggedEvents(t, rec)
+	if len(events) != 2 {
+		t.Fatalf("want intent + completion, got %d: %+v", len(events), events)
+	}
+	for _, ev := range events {
+		a := ev.Actor
+		if a.Kind != AuditActorRemote {
+			t.Errorf("actor kind = %q, want %q", a.Kind, AuditActorRemote)
+		}
+		if a.Auth != AuditAuthMTLS {
+			t.Errorf("actor auth = %q, want %q", a.Auth, AuditAuthMTLS)
+		}
+		if a.ClientID != "hermes-mail" {
+			t.Errorf("client_id = %q, want hermes-mail", a.ClientID)
+		}
+		if a.Fingerprint != testFingerprint {
+			t.Errorf("fingerprint = %q, want the full value %q", a.Fingerprint, testFingerprint)
+		}
+		if a.RemoteAddr != "127.0.0.1:52233" {
+			t.Errorf("remote_addr = %q", a.RemoteAddr)
+		}
+		// Remote *and* acting as a project grant: both facts matter.
+		if a.ProjectID != "test-project" || a.ProjectName != "test" {
+			t.Errorf("project attribution = %q/%q, want test-project/test", a.ProjectID, a.ProjectName)
+		}
+		if a.PID != 0 || a.Proc != "" || a.Parent != "" {
+			t.Errorf("local process fields set on a remote actor: %+v", a)
+		}
+	}
+
+	// Omitted, not zero-filled: an absent field reads as "not applicable", a
+	// present-but-zero one reads as "unknown", and those are different claims.
+	data, err := os.ReadFile(rec.Path())
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var raw struct {
+			Actor map[string]json.RawMessage `json:"actor"`
+		}
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			t.Fatalf("bad log line: %v", err)
+		}
+		for _, key := range []string{"pid", "proc", "parent"} {
+			if _, ok := raw.Actor[key]; ok {
+				t.Errorf("actor.%s present on a remote record: %s", key, line)
+			}
+		}
+	}
+}
+
+// An unresolved grant on a remote connection is still a known certificate.
+func TestAuditRemote_UnauthorizedKeepsTheAttestedIdentity(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	mock := newMockConn("macmcp", simpleTools("mail_search"), okHandler(`{}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"macmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"macmcp": mock}, nil)
+
+	if _, err := r.CallTool(remoteCtx("hermes-mail"), "mail_search", nil, "not-a-real-token"); err == nil {
+		t.Fatal("a bogus credential was accepted")
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Outcome != AuditOutcomeUnauthorized {
+		t.Errorf("outcome = %q, want unauthorized", ev.Outcome)
+	}
+	if ev.Actor.Kind != AuditActorRemote || ev.Actor.Fingerprint != testFingerprint {
+		t.Errorf("unauthorized remote call lost its attestation: %+v", ev.Actor)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Local behaviour is untouched (decision 5, last paragraph)
+// ---------------------------------------------------------------------------
+
+func TestAuditLocal_StillWritesExactlyOneRecordWithNoPhase(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	mock := newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{"content":[]}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	ctx := bridge.WithCallerPID(context.Background(), os.Getpid())
+	if _, err := r.CallTool(ctx, "read_file", json.RawMessage(`{"path":"/tmp/x"}`), testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	ev := onlyEvent(t, readLoggedEvents(t, rec))
+	if ev.Phase != "" {
+		t.Errorf("phase = %q, want absent: a local call is one record, exactly as before", ev.Phase)
+	}
+	if ev.Actor.Kind != AuditActorProject || ev.Actor.Auth != AuditAuthToken {
+		t.Errorf("actor = %q/%q, want project/token", ev.Actor.Kind, ev.Actor.Auth)
+	}
+	if ev.Actor.ClientID != "" || ev.Actor.Fingerprint != "" || ev.Actor.RemoteAddr != "" {
+		t.Errorf("remote fields leaked onto a local record: %+v", ev.Actor)
+	}
+	if ev.Actor.PID != os.Getpid() {
+		t.Errorf("actor pid = %d, want %d", ev.Actor.PID, os.Getpid())
+	}
+}
+
+// The bounded channel, the drop-and-count, and the refusal to stall a tool call
+// are unchanged for local callers: with the writer wedged and the queue full, a
+// local call still completes rather than waiting for the sink.
+func TestAuditLocal_DropsRatherThanBlockingWhenTheQueueIsFull(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	mock := newMockConn("fsmcp", simpleTools("read_file"), okHandler(`{"content":[]}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"fsmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"fsmcp": mock}, nil)
+
+	// Wedge the writer goroutine, then fill the queue behind it.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	blocked := make(chan struct{})
+	rec.SetSink(func(AuditEvent) {
+		close(blocked)
+		wg.Wait()
+	})
+	rec.Record(AuditEvent{ID: "wedge"})
+	<-blocked
+	for i := 0; i < auditQueueSize+50; i++ {
+		rec.Record(AuditEvent{ID: "flood"})
+	}
+	defer func() {
+		rec.SetSink(nil)
+		wg.Done()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.CallTool(context.Background(), "read_file", nil, testToken)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("local CallTool failed with the audit queue full: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("local CallTool blocked on the audit sink; it must drop and continue")
+	}
+	if rec.Dropped() == 0 {
+		t.Error("a full queue did not drop any events")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+func TestAuditQuery_KindAndThrottledFilters(t *testing.T) {
+	rec := newTestAudit(t, nil)
+	rec.Record(AuditEvent{ID: "local", Event: AuditEventCallTool, Tool: "read_file", Outcome: AuditOutcomeOK,
+		Actor: AuditActor{Kind: AuditActorProject, ProjectID: "p1"}})
+	rec.Record(AuditEvent{ID: "remote-ok", Event: AuditEventCallTool, Tool: "mail_search", Outcome: AuditOutcomeOK,
+		Phase: AuditPhaseCompletion,
+		Actor: AuditActor{Kind: AuditActorRemote, ProjectID: "p1", ClientID: "hermes-mail"}})
+	rec.Record(AuditEvent{ID: "remote-throttled", Event: AuditEventCallTool, Tool: "mail_get_emails",
+		Outcome: AuditOutcomeThrottled,
+		Actor:   AuditActor{Kind: AuditActorRemote, ProjectID: "p1", ClientID: "hermes-mail"}})
+	rec.Flush()
+
+	got := rec.Query(AuditQuery{Kind: AuditActorRemote})
+	if len(got) != 2 {
+		t.Fatalf("kind=remote returned %d events, want 2: %+v", len(got), got)
+	}
+	for _, ev := range got {
+		if ev.Actor.Kind != AuditActorRemote {
+			t.Errorf("kind filter let a %q actor through", ev.Actor.Kind)
+		}
+	}
+
+	if got := rec.Query(AuditQuery{Outcome: AuditOutcomeThrottled}); len(got) != 1 || got[0].ID != "remote-throttled" {
+		t.Errorf("outcome=throttled returned %+v", got)
+	}
+	// Combined, the way an operator asks "what did that VM get cut off for".
+	if got := rec.Query(AuditQuery{Kind: AuditActorRemote, Outcome: AuditOutcomeThrottled}); len(got) != 1 {
+		t.Errorf("kind+outcome returned %+v", got)
+	}
+	if got := rec.Query(AuditQuery{Kind: AuditActorProject}); len(got) != 1 || got[0].ID != "local" {
+		t.Errorf("kind=project returned %+v", got)
+	}
+}
+
+// `relay audit --kind remote` filters the file, not the ring, so the same
+// predicate has to hold over parsed JSONL.
+func TestAuditCmd_KindFilterMatchesLoggedRecords(t *testing.T) {
+	mkSandboxRelayHome(t)
+
+	mock := newMockConn("macmcp", simpleTools("mail_search"), okHandler(`{"content":[]}`))
+	r, rec := auditedRouter(t,
+		map[string]Permission{"macmcp": PermOn}, nil,
+		map[string]*mockMcpConn{"macmcp": mock}, nil)
+
+	if _, err := r.CallTool(context.Background(), "mail_search", nil, testToken); err != nil {
+		t.Fatalf("local CallTool: %v", err)
+	}
+	if _, err := r.CallTool(remoteCtx("hermes-mail"), "mail_search", nil, testToken); err != nil {
+		t.Fatalf("remote CallTool: %v", err)
+	}
+
+	events := readLoggedEvents(t, rec)
+	q := AuditQuery{Kind: AuditActorRemote}
+	matched := 0
+	for i := range events {
+		if q.matches(&events[i]) {
+			matched++
+		}
+	}
+	// One local record, two remote ones.
+	if len(events) != 3 {
+		t.Fatalf("log holds %d records, want 3: %+v", len(events), events)
+	}
+	if matched != 2 {
+		t.Errorf("--kind remote matched %d of %d records, want 2", matched, len(events))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The context carrier
+// ---------------------------------------------------------------------------
+
+// Remote identity is admitted only when the certificate attested it. An
+// identity with no fingerprint is not a remote caller, and must not be able to
+// switch a call onto the fail-closed path.
+func TestRemoteCallerContext_RequiresAFingerprint(t *testing.T) {
+	if _, ok := bridge.RemoteCallerFromContext(context.Background()); ok {
+		t.Error("a bare context reported a remote caller")
+	}
+	ctx := bridge.WithRemoteCaller(context.Background(), bridge.RemoteCaller{ClientID: "hermes-mail"})
+	if _, ok := bridge.RemoteCallerFromContext(ctx); ok {
+		t.Error("an identity with no certificate fingerprint was admitted as remote")
+	}
+	ctx = bridge.WithRemoteCaller(context.Background(), bridge.RemoteCaller{
+		ClientID: "hermes-mail", Fingerprint: testFingerprint, RemoteAddr: "127.0.0.1:1",
+	})
+	got, ok := bridge.RemoteCallerFromContext(ctx)
+	if !ok || got.ClientID != "hermes-mail" || got.Fingerprint != testFingerprint {
+		t.Errorf("round trip lost the identity: %+v ok=%v", got, ok)
+	}
+}

--- a/bridge/remote_caller.go
+++ b/bridge/remote_caller.go
@@ -1,0 +1,55 @@
+package bridge
+
+import "context"
+
+// RemoteCaller is the connection-attested identity of a client that reached
+// relay over the remote listener (ADR-010): the enrolled client the certificate
+// resolved to, that certificate's fingerprint, and the peer address.
+//
+// Every field is derived from the connection. None of it is ever read out of a
+// request body, and there is deliberately no constructor that takes one — the
+// whole point of decision 6 is that a remote caller's identity is attested the
+// same way a local caller's pid is, rather than asserted.
+//
+// The fingerprint is carried in full. Truncating it would save nothing and cost
+// the one question the log has to answer after an enrolment is deleted: which
+// *key* made this call, when the record naming that key is gone.
+type RemoteCaller struct {
+	ClientID    string
+	Fingerprint string
+	RemoteAddr  string
+}
+
+// attested reports whether this identity actually came from a verified
+// certificate. The fingerprint is the attestation — a client id on its own is
+// just a string someone chose — so an identity without one is not admitted to
+// the context at all. This is what keeps "is this caller remote?" a question
+// about the connection rather than about which fields happen to be populated.
+func (c RemoteCaller) attested() bool { return c.Fingerprint != "" }
+
+type remoteCallerCtxKey struct{}
+
+// WithRemoteCaller returns ctx carrying the identity behind a remote (mTLS)
+// connection. Carried in the context for the same reason as the peer pid and
+// the caller-asserted cwd: ToolRouter is implemented across repos and must not
+// grow a parameter for every piece of caller metadata (ADR-008 Consequences).
+//
+// An unattested identity returns ctx unchanged, mirroring WithCallerPID's
+// treatment of a zero pid. A caller that is not on the remote listener must
+// never be able to acquire remote identity by any route, because that identity
+// is what switches auditing from ADR-008's fail-open path to ADR-010's
+// fail-closed one.
+func WithRemoteCaller(ctx context.Context, c RemoteCaller) context.Context {
+	if !c.attested() {
+		return ctx
+	}
+	return context.WithValue(ctx, remoteCallerCtxKey{}, c)
+}
+
+// RemoteCallerFromContext returns the identity set by WithRemoteCaller. The
+// bool reports whether the call arrived over the remote listener at all, which
+// is a different question from whether any particular field is populated.
+func RemoteCallerFromContext(ctx context.Context) (RemoteCaller, bool) {
+	c, ok := ctx.Value(remoteCallerCtxKey{}).(RemoteCaller)
+	return c, ok
+}

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -8,15 +8,22 @@ Read it in the tray under **Settings → Tool Calls**, or from a terminal with
 
 ## What is recorded
 
-All three of these produce a record, because a refusal is usually the more
+Every one of these produces a record, because a refusal is usually the more
 interesting event:
 
 | Outcome | Meaning |
 |---|---|
 | `ok` | The call reached the MCP and returned |
 | `error` | The call failed (transport error, unknown tool, or the MCP errored) |
+| `tool_error` | The call completed and the MCP answered `isError` |
 | `denied` | A resolved credential was refused a tool it may not use |
 | `unauthorized` | The credential itself did not resolve |
+| `throttled` | A remote enrolment's rate or volume budget was exceeded |
+| `pending` | An intent record, written before the call ran and awaiting its completion |
+
+`throttled` is deliberately distinct from `denied` and `tool_error`: it is the
+only one of the three that says the grant was legitimate and the *pattern of
+use* was not, which is what exfiltration looks like from the host's side.
 
 One JSONL line per event:
 
@@ -53,12 +60,29 @@ from anything the caller asserted:
   the same value relay injects into `_meta.project_id`.
 - `auth` is how the caller was identified: `token` (a project token was
   presented), `cwd` ([directory auth](tokens.md#directory-auth-allow_cwd_auth)),
-  or `service` (a full-access service token).
+  `service` (a full-access service token), or `mtls` (a client certificate on
+  the remote listener).
 - `cwd` appears only for directory auth. That grant has no deliberate credential
   hand-off to point at afterwards, so the log is its audit trail.
 - `pid` is read off the bridge socket with `getsockopt(LOCAL_PEERPID)`, so it
   cannot be forged by the caller. `proc` and `parent` are resolved from it via
   `proc_pidinfo`.
+
+For a caller on the remote listener the actor looks different, because a pid
+means nothing across a network:
+
+- `kind` is `remote` and `auth` is `mtls`.
+- `client_id` names the enrolment the client certificate resolved to,
+  `fingerprint` is that certificate's fingerprint **in full**, and
+  `remote_addr` is the peer address. All three come from the connection and
+  none of them can be asserted by the caller.
+- `pid` / `proc` / `parent` are **absent**, not zero — an omitted field reads
+  as "not applicable" rather than "unknown".
+- `project_id` / `project_name` are still populated: the caller is remote *and*
+  is acting as a project grant, and both facts matter.
+
+Filter on it with `relay audit --kind remote`, or the caller dropdown in the
+Tool Calls tab.
 
 `parent` is usually the field you want. `relay mcp` opens a fresh connection —
 and often a fresh process — per call, so `proc` names a throwaway subprocess
@@ -130,6 +154,23 @@ A bounded in-memory ring of the most recent `ring_size` events backs the Tool
 Calls tab's first paint and its live tail, so opening the tab never re-reads the
 file.
 
+## Two records for a remote call
+
+A local call is one record, written after the call completes. A call from the
+remote listener is two, sharing one event `id`:
+
+| `phase` | When | Holds |
+|---|---|---|
+| `intent` | before the MCP is invoked | actor, tool, redacted arguments, `outcome: "pending"` |
+| `completion` | when the call returns | the same, plus outcome, duration and result metadata |
+
+A record with no `phase` at all is a single-record (local) event, which is
+every line written before this existed.
+
+**An intent with no matching completion is a signal, not noise.** It means relay
+invoked an MCP and never learned the outcome — a crash, a kill, or a hang. It is
+worth alerting on rather than reconciling away.
+
 ## Fail-open, visibly
 
 Events are handed to a single writer goroutine over a bounded channel. If that
@@ -140,8 +181,19 @@ complete is worse than no log.
 
 This is a deliberate choice for local use: logging must not be able to break
 your tooling. It is the wrong choice for a remote caller, where the trust
-boundary justifies refusing a call that cannot be recorded; a fail-closed mode
-is planned alongside remote access.
+boundary justifies refusing a call that cannot be recorded.
+
+**Remote callers are therefore fail-closed.** The intent record is written and
+flushed to disk before the MCP is invoked, and if that write fails the call is
+refused and the MCP never runs. Writing *after* the call, as the local path
+does, would make the refusal meaningless: by the time the write fails the
+mailbox has already been read. The cost is that a remote tool call can fail
+because auditing failed — the one place this design knowingly trades
+availability for evidence (ADR-010 decision 5).
+
+The guarantee ends where auditing does: with `audit.enabled` set to false there
+is no sink to fail, and remote calls proceed unrecorded. The Tool Calls tab says
+so outright rather than showing an empty table.
 
 If the log file itself can't be opened at startup, relay logs the error and runs
 with auditing off. The Tool Calls tab says so rather than showing an empty table.
@@ -151,6 +203,7 @@ with auditing off. The Tool Calls tab says so rather than showing an empty table
 ```
 relay audit                          # 50 most recent, as a table
 relay audit --tail 200 --outcome denied
+relay audit --kind remote                 # everything any VM did
 relay audit --project proj_7f2a --mcp fsmcp
 relay audit --grep read_file --json  # JSONL, oldest first, for piping
 relay audit --path                   # print the log path and exit

--- a/enrol_cmd.go
+++ b/enrol_cmd.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+// `relay enrol` — the host-side operator act that creates a remote client's
+// identity (ADR-010 decision 8). Follows the mcp_cmd.go / service_cmd.go
+// shape: a verb with subcommands over the same SettingsStore.
+//
+// There is no self-service enrolment subcommand and no bootstrap token by
+// design. Everything here runs on the host, as the user who owns the config
+// dir; nothing in this file is reachable over a socket.
+func runEnrolCommand(args []string) {
+	store := NewSettingsStore()
+	runSubcommands("enrol", []cliSubcommand{
+		{"create", func(a []string) { enrolCreate(store, a) }},
+		{"list", func(_ []string) { enrolList(store) }},
+		{"revoke", func(a []string) { enrolRevoke(store, a) }},
+	}, args)
+}
+
+func enrolCreate(store SettingsStore, args []string) {
+	fs := flag.NewFlagSet("enrol create", flag.ExitOnError)
+	clientID := fs.String("client-id", "", "human-readable id for this enrolment (required, unique)")
+	var grants stringSlice
+	fs.Var(&grants, "grant", "project id this certificate may use (repeatable); every grant must name a remote-kind project")
+	windowSeconds := fs.Int("window-seconds", defaultEnrolmentWindowSeconds, "budget window in seconds")
+	maxCalls := fs.Int("max-calls", defaultEnrolmentMaxCalls, "max tool calls per window")
+	maxResultBytes := fs.Int64("max-result-bytes", defaultEnrolmentMaxResultBytes, "max cumulative result bytes per window")
+	fs.Parse(args)
+
+	if *clientID == "" {
+		exitError("--client-id is required")
+	}
+	// An enrolment with no grants is legal and is the expected resting state
+	// for "enrol now, widen deliberately later" — the same stance ADR-009
+	// takes on an empty allowed_mcp_ids. Say so rather than silently emitting
+	// a certificate that can reach nothing.
+	if len(grants) == 0 {
+		fmt.Println("note: no --grant given; this client is enrolled but can reach no project until one is added")
+	}
+
+	bundle, err := createEnrolment(store, enrolmentRequest{
+		ClientID:   *clientID,
+		ProjectIDs: []string(grants),
+		Budget: EnrolmentBudget{
+			WindowSeconds:  *windowSeconds,
+			MaxCalls:       *maxCalls,
+			MaxResultBytes: *maxResultBytes,
+		},
+	})
+	if err != nil {
+		exitError("%v", err)
+	}
+
+	e := bundle.Enrolment
+	fmt.Printf("enrolled %q\n", e.ClientID)
+	fmt.Printf("  fingerprint: %s\n", e.Fingerprint)
+	fmt.Printf("  grants:      %s\n", formatGrants(e.ProjectIDs))
+	fmt.Printf("  budget:      %d calls / %d bytes per %ds\n", e.Budget.MaxCalls, e.Budget.MaxResultBytes, e.Budget.WindowSeconds)
+	fmt.Printf("  bundle:      %s\n", bundle.Dir)
+	fmt.Println("    client.key  client private key (0600)")
+	fmt.Println("    client.crt  client certificate")
+	fmt.Println("    ca.crt      relay's CA certificate, for verifying the server")
+	// The private key travels to the client exactly once and this is that
+	// moment — decision 8 names it the weakest step in the design. Telling
+	// the operator to move rather than copy is the only mitigation available
+	// short of a CSR flow.
+	fmt.Println("  move (don't copy) this directory to the client machine")
+}
+
+func enrolList(store SettingsStore) {
+	s := store.Get()
+
+	if len(s.Enrolments) == 0 {
+		fmt.Println("no enrolments")
+		return
+	}
+
+	w := newTabWriter()
+	fmt.Fprintln(w, "CLIENT ID\tGRANTS\tCALLS/WINDOW\tBYTES/WINDOW\tCREATED\tFINGERPRINT")
+	for _, e := range s.Enrolments {
+		// The fingerprint prints in full. It is the last column precisely so
+		// that showing all 64 hex characters costs nothing in readability —
+		// decision 6 keeps it untruncated so a revoked client's audit history
+		// stays legible after its enrolment is gone, and a listing that
+		// shortened it would be the obvious place for someone to copy the
+		// short form from.
+		fmt.Fprintf(w, "%s\t%s\t%d/%ds\t%d\t%s\t%s\n",
+			e.ClientID, formatGrants(e.ProjectIDs),
+			e.Budget.MaxCalls, e.Budget.WindowSeconds, e.Budget.MaxResultBytes,
+			e.CreatedAt, e.Fingerprint)
+	}
+	w.Flush()
+}
+
+func enrolRevoke(store SettingsStore, args []string) {
+	fs := flag.NewFlagSet("enrol revoke", flag.ExitOnError)
+	clientID := fs.String("client-id", "", "client id to revoke")
+	fs.Parse(args)
+
+	if *clientID == "" {
+		exitError("--client-id is required")
+	}
+
+	removed, err := revokeEnrolment(store, *clientID)
+	if err != nil {
+		exitError("%v", err)
+	}
+
+	fmt.Printf("revoked enrolment %q\n", removed.ClientID)
+	fmt.Printf("  fingerprint: %s\n", removed.Fingerprint)
+	fmt.Println("  the certificate itself is unchanged and no project was touched; the record is what granted it access")
+}
+
+// formatGrants renders a grant list for CLI output, distinguishing "enrolled
+// with nothing" from a missing column.
+func formatGrants(ids []string) string {
+	if len(ids) == 0 {
+		return "-"
+	}
+	return strings.Join(ids, ",")
+}

--- a/enrolment.go
+++ b/enrolment.go
@@ -1,0 +1,438 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"relaygo/bridge"
+)
+
+// Enrolment lifecycle: creation (host-side operator act), grant validation,
+// persistence in settings.json, bundle emission, and revocation. ADR-010
+// decisions 2, 3 and 8. The listener that consumes all of this lives
+// elsewhere; nothing here opens a socket.
+
+// Conservative per-enrolment defaults. There is no meaningful global default —
+// an agent that checks mail hourly and one that answers interactive questions
+// have nothing in common — so these are a starting point to be tuned per
+// enrolment, not a considered ceiling. The first values will be wrong; the
+// audit log's `throttled` outcome is distinguishable precisely so tuning is
+// driven by evidence rather than by guessing twice (ADR-010 decision 7).
+const (
+	defaultEnrolmentWindowSeconds  = 60
+	defaultEnrolmentMaxCalls       = 60
+	defaultEnrolmentMaxResultBytes = 8 << 20 // 8 MiB per window
+)
+
+// enrolmentBundleDir is the config-dir subdirectory holding emitted bundles,
+// one directory per client id.
+const enrolmentBundleDir = "enrolments"
+
+// normalizeEnrolmentBudget fills unset fields with the conservative defaults.
+// Zero never means "unlimited" — see the EnrolmentBudget doc comment.
+func normalizeEnrolmentBudget(b EnrolmentBudget) EnrolmentBudget {
+	if b.WindowSeconds <= 0 {
+		b.WindowSeconds = defaultEnrolmentWindowSeconds
+	}
+	if b.MaxCalls <= 0 {
+		b.MaxCalls = defaultEnrolmentMaxCalls
+	}
+	if b.MaxResultBytes <= 0 {
+		b.MaxResultBytes = defaultEnrolmentMaxResultBytes
+	}
+	return b
+}
+
+// ---------------------------------------------------------------------------
+// Enrolment CRUD — mirrors the Project CRUD in settings.go: plain mutators
+// that do not save, called within store.With.
+// ---------------------------------------------------------------------------
+
+// AddEnrolment appends an enrolment. Validate with ValidateEnrolment first —
+// this mutator applies unconditionally, like the Project mutators.
+// Does not save; use within store.With.
+func (s *Settings) AddEnrolment(e Enrolment) {
+	e.Budget = normalizeEnrolmentBudget(e.Budget)
+	s.Enrolments = append(s.Enrolments, e)
+}
+
+// RemoveEnrolment deletes the enrolment with the given client id and returns
+// it, so the caller can hand its fingerprint to CloseRevokedEnrolment (the
+// record is the only place that fingerprint is still written down). Returns
+// false if no enrolment has that id.
+//
+// Deleting the enrolment is the whole of revocation on the persistence side:
+// nothing about the certificate itself changes, and no project is touched.
+// Does not save; use within store.With.
+func (s *Settings) RemoveEnrolment(clientID string) (Enrolment, bool) {
+	e, idx := s.findEnrolmentByClientID(clientID)
+	if idx < 0 {
+		return Enrolment{}, false
+	}
+	removed := *e
+	s.Enrolments = slices.Delete(s.Enrolments, idx, idx+1)
+	return removed, true
+}
+
+// UpdateEnrolmentGrants replaces an enrolment's grant list. Validate the
+// resulting list with ValidateEnrolmentGrants first. Does not save; use within
+// store.With.
+func (s *Settings) UpdateEnrolmentGrants(clientID string, projectIDs []string) {
+	e, idx := s.findEnrolmentByClientID(clientID)
+	if idx < 0 {
+		return
+	}
+	e.ProjectIDs = projectIDs
+}
+
+// FindEnrolmentByFingerprint resolves a presented client certificate to an
+// enrolment. This is the listener's entry point: RemoteServer fingerprints the
+// peer certificate (FingerprintCert) and calls this before reading a request,
+// closing the connection when it returns nil so an unenrolled caller cannot
+// probe for valid grants.
+//
+// Matching is on the full fingerprint string, exact — see FingerprintDER for
+// why a prefix match would be the wrong shape here.
+func (s *Settings) FindEnrolmentByFingerprint(fingerprint string) *Enrolment {
+	if fingerprint == "" {
+		return nil
+	}
+	for i := range s.Enrolments {
+		if s.Enrolments[i].Fingerprint == fingerprint {
+			return &s.Enrolments[i]
+		}
+	}
+	return nil
+}
+
+// FindEnrolment returns the enrolment with the given client id, or nil.
+func (s *Settings) FindEnrolment(clientID string) *Enrolment {
+	e, _ := s.findEnrolmentByClientID(clientID)
+	return e
+}
+
+// findEnrolmentByClientID returns the enrolment with the given client id and
+// its index, or nil, -1. Mirrors findProjectByID.
+func (s *Settings) findEnrolmentByClientID(clientID string) (*Enrolment, int) {
+	for i := range s.Enrolments {
+		if s.Enrolments[i].ClientID == clientID {
+			return &s.Enrolments[i], i
+		}
+	}
+	return nil, -1
+}
+
+// EnrolmentsGrantingProject returns the client ids of every enrolment holding
+// a grant for projectID. Feeds the conversion refusal below, and gives the
+// Settings UI the "which clients can reach this project" answer — a credential
+// you cannot see is one you will not revoke (ADR-010 decision 8).
+func (s *Settings) EnrolmentsGrantingProject(projectID string) []string {
+	var ids []string
+	for i := range s.Enrolments {
+		if s.Enrolments[i].GrantsProject(projectID) {
+			ids = append(ids, s.Enrolments[i].ClientID)
+		}
+	}
+	return ids
+}
+
+// ---------------------------------------------------------------------------
+// Validation — ADR-010 decision 3, enforced at the two points this file owns.
+// The third point (call time, in the router) belongs to the listener.
+// ---------------------------------------------------------------------------
+
+// ValidateEnrolment checks a candidate enrolment's shape and uniqueness
+// against the current settings, then its grants. Call before AddEnrolment,
+// inside the same store.With, so two concurrent creates cannot both pass.
+func (s *Settings) ValidateEnrolment(e *Enrolment) error {
+	if e.ClientID == "" {
+		return fmt.Errorf("enrolment client id is required")
+	}
+	// The client id names the bundle directory under <config>/enrolments/ and
+	// is the certificate's Common Name, so the same filename-safe restriction
+	// service ids carry applies: a value with a path separator or ".." would
+	// escape the bundle directory.
+	if !isSafeID(e.ClientID) {
+		return fmt.Errorf("enrolment client id %q is invalid: use only letters, digits, '.', '_', '-' (no path separators)", e.ClientID)
+	}
+	if existing, _ := s.findEnrolmentByClientID(e.ClientID); existing != nil {
+		return fmt.Errorf("enrolment %q already exists: revoke it first, or choose another client id", e.ClientID)
+	}
+	if e.Fingerprint == "" {
+		return fmt.Errorf("enrolment %q has no certificate fingerprint: the certificate IS the identity, so an enrolment without one could never resolve a connection", e.ClientID)
+	}
+	// A second enrolment on the same certificate would make identity
+	// ambiguous at exactly the point relay resolves it, and the two rows
+	// would diverge in grants — the resolved authority would then depend on
+	// scan order. Refuse rather than pick.
+	if other := s.FindEnrolmentByFingerprint(e.Fingerprint); other != nil {
+		return fmt.Errorf("certificate %s is already enrolled as %q", e.Fingerprint, other.ClientID)
+	}
+	return s.ValidateEnrolmentGrants(e)
+}
+
+// ValidateEnrolmentGrants refuses an enrolment whose grants do not all name
+// remote-kind projects (ADR-010 decision 3, point 1).
+//
+// Without this rule, every protection ADR-009 built — no filesystem scope, no
+// wildcard grants, no sessions, no PTY — would be bypassed by POINTING AT THE
+// WRONG PROJECT rather than by defeating any of them: a grant naming a local
+// project would hand a remote client that project's full host-directory tool
+// surface, `allowed_dirs` and all.
+//
+// Tests IsRemote(), never Kind == ProjectKindLocal: the zero value is local,
+// so an equality check invites a future bug where an unset field reads as
+// remote (see the Project.Kind comment). An unknown project id is refused too
+// — a grant relay cannot resolve is not a grant to keep, and silently
+// dropping it would let a later project reusing that id inherit the grant.
+func (s *Settings) ValidateEnrolmentGrants(e *Enrolment) error {
+	for _, id := range e.ProjectIDs {
+		proj, _ := s.findProjectByID(id)
+		if proj == nil {
+			return fmt.Errorf("enrolment %q cannot grant unknown project %q", e.ClientID, id)
+		}
+		if !proj.IsRemote() {
+			return fmt.Errorf("enrolment %q cannot grant project %q (%s): it is a local project, and a remote client granted one would inherit its host directory scope — only remote-kind projects may be enrolled", e.ClientID, id, proj.Name)
+		}
+	}
+	return nil
+}
+
+// ValidateProjectEnrolments refuses converting a project remote→local while
+// any enrolment still grants it (ADR-010 decision 3, point 2), naming the
+// offending enrolments so the operator knows what to revoke or re-grant.
+//
+// This mirrors the constrained conversion ADR-009 already applies in the other
+// direction (ValidateProjectGrants, refusing local→remote while a
+// filesystem-scoped MCP is granted): the project model refuses an edit that
+// would strand a credential rather than allowing it and cleaning up
+// afterwards. Cleaning up afterwards would mean silently dropping grants from
+// records the operator never touched — the same silent widening/narrowing of
+// scope both ADRs refuse to do.
+//
+// A remote project is unaffected, and so is a local project no enrolment
+// mentions, so the common case costs one loop over a list that is empty on
+// every install that has never enrolled a client.
+func (s *Settings) ValidateProjectEnrolments(proj *Project) error {
+	if proj.IsRemote() {
+		return nil
+	}
+	holders := s.EnrolmentsGrantingProject(proj.ID)
+	if len(holders) == 0 {
+		return nil
+	}
+	return fmt.Errorf("project %q cannot become a local project while enrolled clients grant it: %s — revoke those enrolments or drop the grant first", proj.ID, strings.Join(holders, ", "))
+}
+
+// ---------------------------------------------------------------------------
+// Revocation hook — the seam RemoteServer fills in.
+// ---------------------------------------------------------------------------
+
+// EnrolmentRevocationHook is called after an enrolment is deleted, with the
+// deleted client id and its full certificate fingerprint.
+//
+// Revocation must CLOSE LIVE CONNECTIONS, not merely take effect on the next
+// one: the wire protocol holds persistent connections in a scanner loop, so a
+// compromised agent that never reconnects would keep working indefinitely
+// (ADR-010 decision 8). Deleting the record is all this package does; severing
+// the socket is the listener's job, and this is where it registers to do it.
+type EnrolmentRevocationHook func(clientID, fingerprint string)
+
+var (
+	revocationMu   sync.Mutex
+	revocationHook EnrolmentRevocationHook
+)
+
+// SetEnrolmentRevocationHook installs the callback invoked by
+// CloseRevokedEnrolment. RemoteServer calls this once at startup with a
+// closure that closes every live connection presenting the given fingerprint.
+// Passing nil clears it (which is also the state in the CLI process, where
+// there is no listener to notify — see revokeEnrolment).
+func SetEnrolmentRevocationHook(fn EnrolmentRevocationHook) {
+	revocationMu.Lock()
+	defer revocationMu.Unlock()
+	revocationHook = fn
+}
+
+// CloseRevokedEnrolment notifies the installed hook that an enrolment is gone.
+// Safe to call with no hook installed: a revocation performed from the CLI
+// while the tray is not running has no live connections to sever, and one
+// performed while it IS running still needs the tray's own listener to be told
+// — see the note in revokeEnrolment about that gap.
+func CloseRevokedEnrolment(clientID, fingerprint string) {
+	revocationMu.Lock()
+	hook := revocationHook
+	revocationMu.Unlock()
+	if hook != nil {
+		hook(clientID, fingerprint)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Creation — the host-side operator act.
+// ---------------------------------------------------------------------------
+
+// enrolmentRequest is the transport-agnostic body for creating an enrolment,
+// in the shape of projectCreateFields: the CLI fills it today, a Settings-UI
+// IPC handler could fill it tomorrow without duplicating the orchestration.
+type enrolmentRequest struct {
+	ClientID   string
+	ProjectIDs []string
+	Budget     EnrolmentBudget
+}
+
+// enrolmentBundle is what an operator copies to the client machine: the paths
+// of the emitted files plus the persisted record.
+type enrolmentBundle struct {
+	Enrolment  Enrolment
+	Dir        string
+	KeyPath    string
+	CertPath   string
+	CACertPath string
+}
+
+// createEnrolment is the whole enrolment act: ensure the CA exists, sign a
+// client certificate, persist the record, and emit the bundle.
+//
+// There is no self-service enrolment and no bootstrap token, deliberately. An
+// enrolment endpoint reachable by presenting a secret would reintroduce
+// precisely the replayable credential decision 2 removed, and would do it at
+// the one point in the system where the result is a NEW IDENTITY rather than a
+// single call. Creating an enrolment is a host-side act or it is nothing.
+//
+// Ordering matters: validation happens inside store.With, so two concurrent
+// creates cannot both claim a client id, and a rejected request has written
+// nothing anywhere — the signed key exists only in memory until the record is
+// safely persisted. The bundle is written last, for the same reason: a key on
+// disk that no enrolment references is a credential nobody knows to revoke.
+func createEnrolment(store SettingsStore, req enrolmentRequest) (*enrolmentBundle, error) {
+	ca, err := LoadOrCreateCA()
+	if err != nil {
+		return nil, err
+	}
+	keyPEM, certPEM, fingerprint, err := ca.IssueClientCert(req.ClientID)
+	if err != nil {
+		return nil, err
+	}
+
+	enrolment := Enrolment{
+		ClientID:    req.ClientID,
+		Fingerprint: fingerprint,
+		ProjectIDs:  req.ProjectIDs,
+		Budget:      normalizeEnrolmentBudget(req.Budget),
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	if enrolment.ProjectIDs == nil {
+		enrolment.ProjectIDs = []string{}
+	}
+
+	var validationErr error
+	if err := store.With(func(s *Settings) {
+		if validationErr = s.ValidateEnrolment(&enrolment); validationErr != nil {
+			return // no-op write; nothing is added
+		}
+		s.AddEnrolment(enrolment)
+	}); err != nil {
+		return nil, fmt.Errorf("failed to save settings: %w", err)
+	}
+	if validationErr != nil {
+		return nil, validationErr
+	}
+
+	bundle, err := writeEnrolmentBundle(enrolment, keyPEM, certPEM, ca.CertPEM())
+	if err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// writeEnrolmentBundle emits the three files a client needs — its key, its
+// certificate, and the CA certificate it verifies the server with — into
+// <config>/enrolments/<client-id>/, 0700 dir and 0600 files.
+//
+// The private key is generated on the host and travels to the client once.
+// That is the weakest step in this design and it is deliberate: a CSR flow,
+// where the client generates its key and only a signing request crosses the
+// gap, never exposes the key at all, and is the obvious upgrade if these
+// machines ever stop being the same person's (ADR-010 decision 8). Until then
+// the mitigation is that the key sits in a 0600 file under a 0700 directory
+// inside the config dir, and the operator is expected to move rather than copy
+// it.
+func writeEnrolmentBundle(e Enrolment, keyPEM, certPEM, caPEM []byte) (*enrolmentBundle, error) {
+	dir := filepath.Join(bridge.ConfigDir(), enrolmentBundleDir, e.ClientID)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create bundle dir: %w", err)
+	}
+	b := &enrolmentBundle{
+		Enrolment:  e,
+		Dir:        dir,
+		KeyPath:    filepath.Join(dir, "client.key"),
+		CertPath:   filepath.Join(dir, "client.crt"),
+		CACertPath: filepath.Join(dir, "ca.crt"),
+	}
+	for path, data := range map[string][]byte{
+		b.KeyPath:    keyPEM,
+		b.CertPath:   certPEM,
+		b.CACertPath: caPEM,
+	} {
+		if err := atomicWriteFile(path, data, 0600); err != nil {
+			return nil, fmt.Errorf("write %s: %w", filepath.Base(path), err)
+		}
+	}
+	return b, nil
+}
+
+// revokeEnrolment deletes an enrolment, notifies the revocation hook so the
+// listener can sever live connections, and removes the emitted bundle.
+// Returns the deleted record so the caller can report the fingerprint that no
+// longer resolves.
+//
+// Deleting the record cuts the client without disturbing any project, and
+// leaves the certificate itself untouched — there is nothing to un-sign.
+// Revocation, not expiry, is the control (decision 8), so this is the only
+// mechanism there is.
+func revokeEnrolment(store SettingsStore, clientID string) (Enrolment, error) {
+	// Resolution and removal happen inside one With() call, matching
+	// resolveAndRemove's reason for doing the same: no TOCTOU window between
+	// reading the record and deleting it.
+	var removed Enrolment
+	var found bool
+	if err := store.With(func(s *Settings) {
+		removed, found = s.RemoveEnrolment(clientID)
+	}); err != nil {
+		return Enrolment{}, fmt.Errorf("failed to save settings: %w", err)
+	}
+	if !found {
+		return Enrolment{}, fmt.Errorf("no enrolment found with client id %q", clientID)
+	}
+	// Severing live connections is the half of revocation the record cannot
+	// do: taking effect on the next connection is not enough, because the
+	// wire protocol holds persistent connections in a scanner loop and a
+	// compromised agent that never reconnects would keep working. In a CLI
+	// process no hook is installed and this is a no-op — a CLI revocation
+	// reaches a running tray only through its settings poll
+	// (App.ReloadIfChanged), which changes what the NEXT connection resolves
+	// to but does not by itself close an established one. Closing that gap
+	// belongs to RemoteServer, which owns both the connection table and the
+	// reload path; it is said plainly here rather than left to be discovered.
+	CloseRevokedEnrolment(removed.ClientID, removed.Fingerprint)
+	removeEnrolmentBundle(removed.ClientID)
+	return removed, nil
+}
+
+// removeEnrolmentBundle deletes an emitted bundle directory. Best-effort: the
+// operator may well have moved the bundle to the client and deleted it here,
+// and a revocation must not fail because the copy on the host is already gone.
+// Revocation's teeth are the deleted record and the closed connection, not
+// this.
+func removeEnrolmentBundle(clientID string) {
+	if !isSafeID(clientID) {
+		return // never join an unvalidated id into a path we then remove
+	}
+	_ = os.RemoveAll(filepath.Join(bridge.ConfigDir(), enrolmentBundleDir, clientID))
+}

--- a/enrolment_ca.go
+++ b/enrolment_ca.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"relaygo/bridge"
+)
+
+// Relay is its own certificate authority for remote clients (ADR-010
+// decision 8). A two-machine deployment does not warrant the ceremony of an
+// external CA, and the CA never leaves the host: only the certificates it
+// signs travel.
+//
+// The CA material lives as PEM files in the config dir rather than inline in
+// settings.json. settings.json is rewritten atomically in full on every
+// mutation (see FileSettingsStore.save) — a key and a certificate embedded
+// there would be re-serialized on every project rename, and would ride along
+// in every deepCopySettings round-trip and every settings DTO that forgets to
+// strip them. A file the CA code opens by name is both smaller and harder to
+// leak by accident.
+const (
+	caKeyFile  = "ca.key"
+	caCertFile = "ca.crt"
+
+	// The CA outlives the certificates it signs by a wide margin: renewing it
+	// means re-enrolling every client, which is exactly the manual ceremony
+	// decision 8 accepts once and does not want to repeat on a timer.
+	caValidity = 20 * 365 * 24 * time.Hour
+
+	// Client certificates are deliberately long-lived. Decision 8:
+	// "revocation rather than expiry is the control". A short lifetime would
+	// need an authenticated renewal path, and any credential that can be
+	// replayed to obtain a fresh certificate reintroduces precisely the
+	// bearer secret decision 2 removed — at the one point in the system where
+	// the result is a new identity rather than a single call. Ten years is
+	// long enough that expiry never silently cuts a working agent, which
+	// keeps revocation the only mechanism anyone has to reason about.
+	clientCertValidity = 10 * 365 * 24 * time.Hour
+
+	// Server certificates are issued on demand by the listener rather than
+	// persisted, so their lifetime only has to cover a single relay process's
+	// uptime with room to spare. The client verifies them against the CA, so
+	// rotating one costs nothing on the client side.
+	serverCertValidity = 5 * 365 * 24 * time.Hour
+)
+
+// RelayCA is relay's self-signed certificate authority: the private key, the
+// self-signed certificate, and the PEM encoding of that certificate (which is
+// what ships to a client so it can verify the server).
+//
+// Obtain one with LoadOrCreateCA. A RelayCA is immutable after construction
+// and safe for concurrent use.
+type RelayCA struct {
+	key     *ecdsa.PrivateKey
+	cert    *x509.Certificate
+	certPEM []byte
+}
+
+// caMu serializes LoadOrCreateCA so two callers racing on first use cannot
+// each generate a CA and have the loser's certificate silently overwrite the
+// winner's — which would invalidate every certificate signed in between.
+var caMu sync.Mutex
+
+// caPaths returns the on-disk locations of the CA key and certificate. Both
+// live in bridge.ConfigDir(), so --config-dir and the test sandbox reroute
+// them together with settings.json.
+func caPaths() (keyPath, certPath string) {
+	dir := bridge.ConfigDir()
+	return filepath.Join(dir, caKeyFile), filepath.Join(dir, caCertFile)
+}
+
+// LoadOrCreateCA returns relay's CA, generating and persisting it on first
+// use. Generation is lazy rather than part of startup: an install that never
+// enrols a remote client never grows a signing key it has no use for.
+//
+// Idempotent — a second call reads the persisted PEM back rather than signing
+// a new CA, so certificates issued by an earlier call keep verifying.
+func LoadOrCreateCA() (*RelayCA, error) {
+	caMu.Lock()
+	defer caMu.Unlock()
+
+	keyPath, certPath := caPaths()
+	ca, err := loadCA(keyPath, certPath)
+	if err == nil {
+		return ca, nil
+	}
+	if !os.IsNotExist(err) {
+		// A present-but-unreadable CA is not something to paper over by
+		// minting a new one: that would silently invalidate every enrolment
+		// on the host. Surface it and let the operator decide.
+		return nil, err
+	}
+	return generateCA(keyPath, certPath)
+}
+
+// loadCA reads an existing CA from disk. Returns an os.IsNotExist error when
+// either file is missing, which is LoadOrCreateCA's signal to generate.
+func loadCA(keyPath, certPath string) (*RelayCA, error) {
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("ca key %s is not valid PEM", keyPath)
+	}
+	key, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse ca key %s: %w", keyPath, err)
+	}
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return nil, fmt.Errorf("ca certificate %s is not valid PEM", certPath)
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse ca certificate %s: %w", certPath, err)
+	}
+	return &RelayCA{key: key, cert: cert, certPEM: certPEM}, nil
+}
+
+// generateCA mints a fresh self-signed CA and writes it to disk 0600.
+func generateCA(keyPath, certPath string) (*RelayCA, error) {
+	// ECDSA P-256 rather than Ed25519: both ends are ours today, but a CA is
+	// the one artifact here that has to keep verifying for as long as any
+	// certificate it signed, and P-256 is accepted by every TLS stack a
+	// future client might be written in.
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ca key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "relay local CA", Organization: []string{"relay"}},
+		NotBefore:             now.Add(-5 * time.Minute), // tolerate a client clock a few minutes behind
+		NotAfter:              now.Add(caValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true, // this CA signs leaves only; it never delegates
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("self-sign ca certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse generated ca certificate: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("marshal ca key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0700); err != nil {
+		return nil, fmt.Errorf("create config dir: %w", err)
+	}
+	// The key goes down first and durably: a certificate on disk whose key is
+	// missing would make LoadOrCreateCA fail every subsequent call rather
+	// than regenerate, since a half-written CA is not os.IsNotExist.
+	if err := atomicWriteFile(keyPath, keyPEM, 0600); err != nil {
+		return nil, fmt.Errorf("write ca key: %w", err)
+	}
+	if err := atomicWriteFile(certPath, certPEM, 0600); err != nil {
+		return nil, fmt.Errorf("write ca certificate: %w", err)
+	}
+	return &RelayCA{key: key, cert: cert, certPEM: certPEM}, nil
+}
+
+// CertPEM returns the PEM-encoded CA certificate. This is the copy that ships
+// in an enrolment bundle so the client can verify relay's server certificate.
+func (ca *RelayCA) CertPEM() []byte {
+	out := make([]byte, len(ca.certPEM))
+	copy(out, ca.certPEM)
+	return out
+}
+
+// Pool returns a x509.CertPool containing only relay's CA — the value a
+// RemoteServer hands to tls.Config.ClientCAs so that no certificate signed by
+// anything else can complete a handshake.
+func (ca *RelayCA) Pool() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.cert)
+	return pool
+}
+
+// IssueClientCert signs a client certificate for an enrolment's client id and
+// returns its PEM key, PEM certificate, and full fingerprint.
+//
+// The client id is the certificate's Common Name, so the identity relay
+// records is bound into the credential itself rather than sitting only in a
+// settings.json row beside it. Resolution at connection time still goes
+// through the fingerprint (FindEnrolmentByFingerprint) — a CN is chosen by
+// whoever signs, and only relay signs, but the fingerprint is what cannot be
+// re-used by a second certificate claiming the same name.
+func (ca *RelayCA) IssueClientCert(clientID string) (keyPEM, certPEM []byte, fingerprint string, err error) {
+	if clientID == "" {
+		return nil, nil, "", fmt.Errorf("client id is required")
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("generate client key: %w", err)
+	}
+	der, err := ca.signLeaf(&key.PublicKey, pkix.Name{
+		CommonName:         clientID,
+		Organization:       []string{"relay"},
+		OrganizationalUnit: []string{"relay-enrolment"},
+	}, clientCertValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("marshal client key: %w", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return keyPEM, certPEM, FingerprintDER(der), nil
+}
+
+// IssueServerCert signs a short-chain server certificate for the given hosts,
+// ready to drop into tls.Config.Certificates. Deliberately not persisted: the
+// client verifies it against the CA cert in its bundle, so a fresh one per
+// process start costs the client nothing and gives the host one fewer private
+// key sitting on disk.
+//
+// hosts may name IPs or DNS names; an empty list defaults to loopback, which
+// matches RemoteServer's default bind (decision 9).
+func (ca *RelayCA) IssueServerCert(hosts ...string) (tls.Certificate, error) {
+	if len(hosts) == 0 {
+		hosts = []string{"127.0.0.1", "::1", "localhost"}
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate server key: %w", err)
+	}
+	der, err := ca.signLeaf(&key.PublicKey, pkix.Name{
+		CommonName:   "relay",
+		Organization: []string{"relay"},
+	}, serverCertValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, hosts)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("parse server certificate: %w", err)
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}, nil
+}
+
+// signLeaf is the one place a leaf certificate is created, so client and
+// server certs cannot drift in serial generation, clock skew tolerance, or
+// basic-constraints handling. hosts, when non-empty, become IP/DNS SANs.
+func (ca *RelayCA) signLeaf(pub *ecdsa.PublicKey, subject pkix.Name, validity time.Duration, eku []x509.ExtKeyUsage, hosts []string) ([]byte, error) {
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               subject,
+		NotBefore:             now.Add(-5 * time.Minute),
+		NotAfter:              now.Add(validity),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           eku,
+		BasicConstraintsValid: true,
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+			continue
+		}
+		tmpl.DNSNames = append(tmpl.DNSNames, h)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, pub, ca.key)
+	if err != nil {
+		return nil, fmt.Errorf("sign certificate: %w", err)
+	}
+	return der, nil
+}
+
+// randomSerial returns a 128-bit positive certificate serial number.
+func randomSerial() (*big.Int, error) {
+	max := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return nil, fmt.Errorf("generate certificate serial: %w", err)
+	}
+	// A zero serial is legal-ish but universally disliked by TLS stacks.
+	return serial.Add(serial, big.NewInt(1)), nil
+}
+
+// FingerprintDER returns the canonical fingerprint of a DER-encoded
+// certificate: "sha256:" followed by the FULL 64 hex characters.
+//
+// Never truncate this. Decision 6 records the fingerprint in full precisely so
+// a revoked device's history stays legible after the enrolment naming it has
+// been deleted — a shortened fingerprint answers "probably that key" where the
+// whole point is answering "that key". It is also the value the listener
+// resolves against an enrolment, and a prefix match on identity is a match on
+// something an attacker gets to grind.
+func FingerprintDER(der []byte) string {
+	sum := sha256.Sum256(der)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// FingerprintCert is FingerprintDER for an already-parsed certificate — what
+// RemoteServer calls on the peer certificate of an accepted connection.
+func FingerprintCert(cert *x509.Certificate) string {
+	if cert == nil {
+		return ""
+	}
+	return FingerprintDER(cert.Raw)
+}

--- a/enrolment_ca_test.go
+++ b/enrolment_ca_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// parseCertPEM decodes a single PEM certificate for assertions.
+func parseCertPEM(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatalf("not valid PEM: %q", certPEM)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assertNoErr(t, err, "parse certificate")
+	return cert
+}
+
+// The CA is generated lazily on first use and persisted. A second call MUST
+// reuse it: minting a fresh CA would silently invalidate every certificate
+// issued so far, which — since revocation rather than expiry is the control —
+// is the one failure that would cut every enrolled client at once with no
+// operator action to point at.
+func TestLoadOrCreateCA_ReusesPersistedCA(t *testing.T) {
+	dir := mkEmptySandboxRelayHome(t)
+
+	first, err := LoadOrCreateCA()
+	assertNoErr(t, err, "first LoadOrCreateCA")
+
+	for _, name := range []string{caKeyFile, caCertFile} {
+		info, err := os.Stat(filepath.Join(dir, name))
+		assertNoErr(t, err, "stat %s", name)
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Fatalf("%s mode = %#o, want 0600", name, perm)
+		}
+	}
+
+	second, err := LoadOrCreateCA()
+	assertNoErr(t, err, "second LoadOrCreateCA")
+	if !bytes.Equal(first.CertPEM(), second.CertPEM()) {
+		t.Fatal("second LoadOrCreateCA returned a different CA certificate — the persisted CA was not reused")
+	}
+
+	// The real property, stated in the terms that matter: a certificate the
+	// first call signed still verifies against the second call's pool.
+	_, certPEM, _, err := first.IssueClientCert("hermes-mail")
+	assertNoErr(t, err, "issue client cert")
+	cert := parseCertPEM(t, certPEM)
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:     second.Pool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Fatalf("client cert from the first CA does not verify against the reloaded CA: %v", err)
+	}
+}
+
+// The certificate's identity is tied to the enrolment's client id, and the
+// certificate is usable for client auth and nothing else.
+func TestIssueClientCert_BindsClientIDAndClientAuth(t *testing.T) {
+	mkEmptySandboxRelayHome(t)
+	ca, err := LoadOrCreateCA()
+	assertNoErr(t, err, "LoadOrCreateCA")
+
+	keyPEM, certPEM, fingerprint, err := ca.IssueClientCert("hermes-mail")
+	assertNoErr(t, err, "IssueClientCert")
+
+	cert := parseCertPEM(t, certPEM)
+	if cert.Subject.CommonName != "hermes-mail" {
+		t.Fatalf("certificate CN = %q, want %q", cert.Subject.CommonName, "hermes-mail")
+	}
+	if cert.IsCA {
+		t.Fatal("client certificate must not be a CA")
+	}
+	wantEKU := []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	if len(cert.ExtKeyUsage) != 1 || cert.ExtKeyUsage[0] != wantEKU[0] {
+		t.Fatalf("certificate ExtKeyUsage = %v, want client auth only", cert.ExtKeyUsage)
+	}
+	if fingerprint != FingerprintCert(cert) {
+		t.Fatalf("returned fingerprint %q does not match the certificate's own %q", fingerprint, FingerprintCert(cert))
+	}
+	if block, _ := pem.Decode(keyPEM); block == nil {
+		t.Fatal("client key is not valid PEM")
+	}
+
+	// Client certs are long-lived on purpose: revocation, not expiry, is the
+	// control. A cert that expires inside a couple of years would quietly
+	// reintroduce the renewal path decision 8 refuses.
+	if years := cert.NotAfter.Sub(cert.NotBefore).Hours() / 24 / 365; years < 5 {
+		t.Fatalf("client certificate validity = %.1f years, want a multi-year lifetime (revocation is the control, not expiry)", years)
+	}
+}
+
+// Fingerprints are the identity the listener resolves and the value the audit
+// log keeps after an enrolment is deleted, so they are never truncated.
+func TestFingerprint_IsFullLengthSHA256(t *testing.T) {
+	mkEmptySandboxRelayHome(t)
+	ca, err := LoadOrCreateCA()
+	assertNoErr(t, err, "LoadOrCreateCA")
+
+	_, _, fpA, err := ca.IssueClientCert("hermes-mail")
+	assertNoErr(t, err, "issue A")
+	_, _, fpB, err := ca.IssueClientCert("hermes-cal")
+	assertNoErr(t, err, "issue B")
+
+	for _, fp := range []string{fpA, fpB} {
+		if !strings.HasPrefix(fp, "sha256:") {
+			t.Fatalf("fingerprint %q missing sha256: prefix", fp)
+		}
+		if hexPart := strings.TrimPrefix(fp, "sha256:"); len(hexPart) != 64 {
+			t.Fatalf("fingerprint hex length = %d, want the full 64 (never truncate — see FingerprintDER)", len(hexPart))
+		}
+	}
+	if fpA == fpB {
+		t.Fatal("two certificates produced the same fingerprint")
+	}
+	if FingerprintCert(nil) != "" {
+		t.Fatal("FingerprintCert(nil) must be empty, not a hash of nothing")
+	}
+}
+
+// The listener needs a server certificate the client can verify with the
+// ca.crt in its bundle; issuing one is the CA's job, not the listener's.
+func TestIssueServerCert_VerifiesAgainstCAForLoopback(t *testing.T) {
+	mkEmptySandboxRelayHome(t)
+	ca, err := LoadOrCreateCA()
+	assertNoErr(t, err, "LoadOrCreateCA")
+
+	tlsCert, err := ca.IssueServerCert()
+	assertNoErr(t, err, "IssueServerCert")
+	if tlsCert.Leaf == nil {
+		t.Fatal("server certificate has no parsed Leaf")
+	}
+	if _, err := tlsCert.Leaf.Verify(x509.VerifyOptions{
+		Roots:     ca.Pool(),
+		DNSName:   "localhost",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("default server certificate does not verify for localhost: %v", err)
+	}
+}

--- a/enrolment_test.go
+++ b/enrolment_test.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newEnrolmentSandbox returns a sandboxed store whose config dir also holds
+// the CA and the emitted bundles, so nothing here can touch the real
+// ~/Library/Application Support/relay.
+func newEnrolmentSandbox(t *testing.T) (string, SettingsStore) {
+	t.Helper()
+	dir := mkEmptySandboxRelayHome(t)
+	store := NewSettingsStoreAt(dir)
+	assertNoErr(t, store.EnsureInitialized(), "EnsureInitialized")
+	return dir, store
+}
+
+// mkStoreProject creates a project of the given kind in the store and returns
+// it. path must be empty for a remote project (validateProjectShape).
+func mkStoreProject(t *testing.T, store SettingsStore, kind ProjectKind, name, path string) Project {
+	t.Helper()
+	var proj Project
+	var createErr error
+	assertNoErr(t, store.With(func(s *Settings) {
+		proj, createErr = s.CreateProjectWithTokenKind(kind, name, path, []string{}, []string{}, nil, nil)
+	}), "create %s project", kind)
+	assertNoErr(t, createErr, "create %s project", kind)
+	return proj
+}
+
+// A grant naming a local project is refused outright. Without this rule every
+// protection ADR-009 built is bypassed by pointing at the wrong project rather
+// than by defeating any of them.
+func TestCreateEnrolment_RefusesLocalProjectGrant(t *testing.T) {
+	dir, store := newEnrolmentSandbox(t)
+	local := mkStoreProject(t, store, ProjectKindLocal, "Workspace", dir)
+
+	_, err := createEnrolment(store, enrolmentRequest{
+		ClientID:   "hermes-mail",
+		ProjectIDs: []string{local.ID},
+	})
+	if err == nil {
+		t.Fatal("enrolling a grant that names a local project must be refused")
+	}
+	if !strings.Contains(err.Error(), local.ID) || !strings.Contains(err.Error(), "Workspace") {
+		t.Fatalf("refusal must name the offending project, got: %v", err)
+	}
+
+	// A refused enrolment persists nothing and emits no credential — a key on
+	// disk that no enrolment references is one nobody knows to revoke.
+	if got := store.Get().Enrolments; len(got) != 0 {
+		t.Fatalf("refused enrolment was persisted anyway: %+v", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, enrolmentBundleDir, "hermes-mail")); !os.IsNotExist(err) {
+		t.Fatalf("refused enrolment left a bundle behind: %v", err)
+	}
+}
+
+// The happy path: a remote-kind grant enrols, persists, and emits the three
+// files that get copied to the client machine.
+func TestCreateEnrolment_RemoteProjectGrantSucceedsAndEmitsBundle(t *testing.T) {
+	dir, store := newEnrolmentSandbox(t)
+	mail := mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+
+	bundle, err := createEnrolment(store, enrolmentRequest{
+		ClientID:   "hermes-mail",
+		ProjectIDs: []string{mail.ID},
+	})
+	assertNoErr(t, err, "createEnrolment")
+
+	stored := store.Get().Enrolments
+	if len(stored) != 1 {
+		t.Fatalf("want 1 enrolment persisted, got %d", len(stored))
+	}
+	e := stored[0]
+	if e.ClientID != "hermes-mail" || !e.GrantsProject(mail.ID) {
+		t.Fatalf("persisted enrolment does not match the request: %+v", e)
+	}
+	if e.CreatedAt == "" {
+		t.Fatal("enrolment has no created-at")
+	}
+	// Budgets are stored even though enforcement lives elsewhere, and an
+	// unset budget must never read as "unlimited".
+	if e.Budget.MaxCalls != defaultEnrolmentMaxCalls || e.Budget.MaxResultBytes != defaultEnrolmentMaxResultBytes || e.Budget.WindowSeconds != defaultEnrolmentWindowSeconds {
+		t.Fatalf("unset budget did not take the conservative defaults: %+v", e.Budget)
+	}
+
+	// The bundle is key + cert + CA cert, tight permissions, and the
+	// fingerprint on record is the fingerprint of the cert that shipped.
+	for _, path := range []string{bundle.KeyPath, bundle.CertPath, bundle.CACertPath} {
+		info, err := os.Stat(path)
+		assertNoErr(t, err, "stat %s", path)
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Fatalf("%s mode = %#o, want 0600", path, perm)
+		}
+	}
+	if info, err := os.Stat(bundle.Dir); err != nil || info.Mode().Perm() != 0700 {
+		t.Fatalf("bundle dir %s: err=%v mode=%v, want 0700", bundle.Dir, err, info.Mode().Perm())
+	}
+	certPEM, err := os.ReadFile(bundle.CertPath)
+	assertNoErr(t, err, "read client cert")
+	if got := FingerprintCert(parseCertPEM(t, certPEM)); got != e.Fingerprint {
+		t.Fatalf("recorded fingerprint %q != emitted certificate's %q", e.Fingerprint, got)
+	}
+	caPEM, err := os.ReadFile(filepath.Join(dir, caCertFile))
+	assertNoErr(t, err, "read ca cert")
+	bundledCA, err := os.ReadFile(bundle.CACertPath)
+	assertNoErr(t, err, "read bundled ca cert")
+	if string(caPEM) != string(bundledCA) {
+		t.Fatal("bundle's ca.crt is not relay's CA certificate — the client could not verify the server with it")
+	}
+
+	// Resolution at connection time is by certificate, and it is the
+	// certificate that carries the grant.
+	s := store.Get()
+	resolved := s.FindEnrolmentByFingerprint(e.Fingerprint)
+	if resolved == nil || resolved.ClientID != "hermes-mail" {
+		t.Fatalf("FindEnrolmentByFingerprint did not resolve the enrolment: %+v", resolved)
+	}
+	if s.FindEnrolmentByFingerprint("sha256:"+strings.Repeat("0", 64)) != nil {
+		t.Fatal("an unknown fingerprint must resolve to nothing")
+	}
+	if resolved.GrantsProject("proj-nobody-granted") {
+		t.Fatal("enrolment claims a grant it does not hold")
+	}
+}
+
+// A grant relay cannot resolve is not a grant to keep: silently dropping it
+// would let a later project reusing that id inherit it.
+func TestCreateEnrolment_RefusesUnknownProjectGrant(t *testing.T) {
+	_, store := newEnrolmentSandbox(t)
+	_, err := createEnrolment(store, enrolmentRequest{
+		ClientID:   "hermes-mail",
+		ProjectIDs: []string{"proj_does_not_exist"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "proj_does_not_exist") {
+		t.Fatalf("want a refusal naming the unknown project, got: %v", err)
+	}
+}
+
+// Client ids are unique and filesystem-safe: the id names the bundle
+// directory, and a duplicate would make two certificates answer to one name.
+func TestCreateEnrolment_RefusesDuplicateAndUnsafeClientIDs(t *testing.T) {
+	_, store := newEnrolmentSandbox(t)
+	_, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail"})
+	assertNoErr(t, err, "first enrolment")
+
+	if _, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail"}); err == nil {
+		t.Fatal("a duplicate client id must be refused")
+	}
+	if _, err := createEnrolment(store, enrolmentRequest{ClientID: "../escape"}); err == nil {
+		t.Fatal("a client id with path separators must be refused")
+	}
+	if got := len(store.Get().Enrolments); got != 1 {
+		t.Fatalf("want 1 enrolment after two refusals, got %d", got)
+	}
+}
+
+// An enrolment is keyed by certificate, NOT by machine: several agents on one
+// host each hold their own enrolment, granted and revoked independently.
+// Nothing may assume one-per-machine.
+func TestEnrolments_AreKeyedByCertificateNotByMachine(t *testing.T) {
+	_, store := newEnrolmentSandbox(t)
+	mail := mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+	cal := mkStoreProject(t, store, ProjectKindRemote, "Calendar", "")
+
+	a, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail", ProjectIDs: []string{mail.ID}})
+	assertNoErr(t, err, "enrol hermes-mail")
+	b, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-cal", ProjectIDs: []string{cal.ID}})
+	assertNoErr(t, err, "enrol hermes-cal")
+	c, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-triage", ProjectIDs: []string{mail.ID, cal.ID}})
+	assertNoErr(t, err, "enrol hermes-triage")
+
+	if a.Enrolment.Fingerprint == b.Enrolment.Fingerprint || b.Enrolment.Fingerprint == c.Enrolment.Fingerprint {
+		t.Fatal("co-located enrolments share a fingerprint — they must be distinct identities")
+	}
+	s := store.Get()
+	if len(s.Enrolments) != 3 {
+		t.Fatalf("want 3 co-existing enrolments, got %d", len(s.Enrolments))
+	}
+	holders := s.EnrolmentsGrantingProject(mail.ID)
+	if len(holders) != 2 {
+		t.Fatalf("want 2 enrolments granting Mail, got %v", holders)
+	}
+
+	// Revoking one leaves its neighbours untouched.
+	_, err = revokeEnrolment(store, "hermes-mail")
+	assertNoErr(t, err, "revoke hermes-mail")
+	after := store.Get()
+	if len(after.Enrolments) != 2 || after.FindEnrolment("hermes-cal") == nil || after.FindEnrolment("hermes-triage") == nil {
+		t.Fatalf("revoking one enrolment disturbed the others: %+v", after.Enrolments)
+	}
+	if after.FindEnrolmentByFingerprint(c.Enrolment.Fingerprint) == nil {
+		t.Fatal("a surviving enrolment stopped resolving by certificate")
+	}
+}
+
+// The full fingerprint must survive the settings.json round trip: it is what
+// keeps a revoked device's history legible, and a value truncated on write
+// would be unrecoverable.
+func TestEnrolmentFingerprint_RoundTripsThroughSettingsAtFullLength(t *testing.T) {
+	dir, store := newEnrolmentSandbox(t)
+	bundle, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail"})
+	assertNoErr(t, err, "createEnrolment")
+
+	// Read settings.json off disk rather than through the cache, so a store
+	// that only kept the value in memory cannot pass.
+	raw, err := os.ReadFile(filepath.Join(dir, "settings.json"))
+	assertNoErr(t, err, "read settings.json")
+	var onDisk Settings
+	assertNoErr(t, json.Unmarshal(raw, &onDisk), "parse settings.json")
+
+	if len(onDisk.Enrolments) != 1 {
+		t.Fatalf("want 1 enrolment on disk, got %d", len(onDisk.Enrolments))
+	}
+	got := onDisk.Enrolments[0].Fingerprint
+	if got != bundle.Enrolment.Fingerprint {
+		t.Fatalf("fingerprint changed on the way to disk: %q != %q", got, bundle.Enrolment.Fingerprint)
+	}
+	if len(strings.TrimPrefix(got, "sha256:")) != 64 {
+		t.Fatalf("persisted fingerprint is not full length: %q", got)
+	}
+
+	// There is no bearer token anywhere on this path — a stolen settings.json
+	// must grant no remote access. Guard the serialized form, since that is
+	// the artifact an attacker would read.
+	for _, forbidden := range []string{"\"token\"", "\"secret\"", "\"bearer\""} {
+		if strings.Contains(strings.ToLower(string(mustMarshal(t, onDisk.Enrolments[0]))), forbidden) {
+			t.Fatalf("enrolment serialized a %s field — decision 2 leaves no bearer credential on the remote path", forbidden)
+		}
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	assertNoErr(t, err, "marshal")
+	return data
+}
+
+// Converting a project remote→local is refused while any enrolment grants it,
+// and the refusal names the offending enrolments. Mirrors ADR-009's
+// constrained local→remote conversion: refuse the edit that would strand a
+// credential rather than allowing it and cleaning up afterwards.
+func TestProjectConvertRemoteToLocal_RefusedWhileEnrolled(t *testing.T) {
+	s := &Settings{}
+	mail, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Mail", "", []string{}, []string{}, nil, nil)
+	assertNoErr(t, err, "create remote project")
+	s.AddEnrolment(Enrolment{
+		ClientID:    "hermes-mail",
+		Fingerprint: "sha256:" + strings.Repeat("a", 64),
+		ProjectIDs:  []string{mail.ID},
+	})
+	schemas := func() map[string]json.RawMessage { return nil }
+
+	local := ProjectKindLocal
+	path := t.TempDir()
+	_, _, err = applyProjectUpdate(s, mail.ID, projectUpdateFields{Kind: &local, Path: &path}, schemas)
+	if err == nil {
+		t.Fatal("converting a remote project to local must be refused while an enrolment grants it")
+	}
+	if !strings.Contains(err.Error(), "hermes-mail") {
+		t.Fatalf("refusal must name the offending enrolment, got: %v", err)
+	}
+
+	// The refusal must have changed nothing.
+	after, _ := s.findProjectByID(mail.ID)
+	if !after.IsRemote() || after.Path != "" {
+		t.Fatalf("refused conversion mutated the project: kind=%q path=%q", after.Kind, after.Path)
+	}
+
+	// Revoking the enrolment makes the conversion legal — capability and
+	// device revocation stay independent, and neither strands the other.
+	if _, ok := s.RemoveEnrolment("hermes-mail"); !ok {
+		t.Fatal("RemoveEnrolment did not find the enrolment it just stored")
+	}
+	if _, _, err := applyProjectUpdate(s, mail.ID, projectUpdateFields{Kind: &local, Path: &path}, schemas); err != nil {
+		t.Fatalf("conversion should be legal once no enrolment grants the project: %v", err)
+	}
+	converted, _ := s.findProjectByID(mail.ID)
+	if converted.IsRemote() {
+		t.Fatal("project did not convert to local after the enrolment was revoked")
+	}
+}
+
+// Belt-and-braces, in the shape UpdateProjectPath already uses: the exported
+// mutator refuses the same conversion on its own, so a caller that skips
+// applyProjectUpdate cannot produce the silent widening.
+func TestUpdateProjectKind_RefusesRemoteToLocalWhileEnrolled(t *testing.T) {
+	s := &Settings{}
+	mail, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Mail", "", []string{}, []string{}, nil, nil)
+	assertNoErr(t, err, "create remote project")
+	s.AddEnrolment(Enrolment{
+		ClientID:    "hermes-mail",
+		Fingerprint: "sha256:" + strings.Repeat("b", 64),
+		ProjectIDs:  []string{mail.ID},
+	})
+
+	s.UpdateProjectKind(mail.ID, ProjectKindLocal)
+	if proj, _ := s.findProjectByID(mail.ID); !proj.IsRemote() {
+		t.Fatal("UpdateProjectKind converted an enrolled remote project to local")
+	}
+
+	// Unrelated projects, and remote→remote no-ops, stay unaffected.
+	other, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Calendar", "", []string{}, []string{}, nil, nil)
+	assertNoErr(t, err, "create second remote project")
+	s.UpdateProjectKind(other.ID, ProjectKindLocal)
+	if proj, _ := s.findProjectByID(other.ID); proj.IsRemote() {
+		t.Fatal("an unenrolled remote project must still be convertible")
+	}
+}
+
+// Revocation deletes the record, hands the fingerprint to the hook the
+// listener installs (its cue to close live connections), and removes the
+// host's copy of the bundle.
+func TestRevokeEnrolment_RemovesRecordFiresHookAndDeletesBundle(t *testing.T) {
+	_, store := newEnrolmentSandbox(t)
+	bundle, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail"})
+	assertNoErr(t, err, "createEnrolment")
+
+	var gotClientID, gotFingerprint string
+	SetEnrolmentRevocationHook(func(clientID, fingerprint string) {
+		gotClientID, gotFingerprint = clientID, fingerprint
+	})
+	t.Cleanup(func() { SetEnrolmentRevocationHook(nil) })
+
+	removed, err := revokeEnrolment(store, "hermes-mail")
+	assertNoErr(t, err, "revokeEnrolment")
+
+	if removed.Fingerprint != bundle.Enrolment.Fingerprint {
+		t.Fatalf("revoked record %q is not the one created %q", removed.Fingerprint, bundle.Enrolment.Fingerprint)
+	}
+	if gotClientID != "hermes-mail" || gotFingerprint != bundle.Enrolment.Fingerprint {
+		t.Fatalf("revocation hook got (%q, %q), want the revoked client id and its full fingerprint", gotClientID, gotFingerprint)
+	}
+	s := store.Get()
+	if len(s.Enrolments) != 0 {
+		t.Fatalf("revocation left the record behind: %+v", s.Enrolments)
+	}
+	if s.FindEnrolmentByFingerprint(bundle.Enrolment.Fingerprint) != nil {
+		t.Fatal("a revoked certificate still resolves to an enrolment")
+	}
+	if _, err := os.Stat(bundle.Dir); !os.IsNotExist(err) {
+		t.Fatalf("revocation left the bundle on disk: %v", err)
+	}
+	if _, err := revokeEnrolment(store, "hermes-mail"); err == nil {
+		t.Fatal("revoking an unknown client id must report it, not succeed silently")
+	}
+}
+
+// Revocation works with no hook installed — a CLI revocation with the tray
+// stopped has no live connection to sever, and must not depend on one.
+func TestRevokeEnrolment_WorksWithNoHookInstalled(t *testing.T) {
+	_, store := newEnrolmentSandbox(t)
+	SetEnrolmentRevocationHook(nil)
+	_, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail"})
+	assertNoErr(t, err, "createEnrolment")
+	_, err = revokeEnrolment(store, "hermes-mail")
+	assertNoErr(t, err, "revokeEnrolment without a hook")
+}
+
+// An install that never enrols a client keeps a settings.json with no
+// enrolments key at all — the same round-trip guarantee Project.Kind has.
+func TestSettings_OmitsEnrolmentsWhenNoneExist(t *testing.T) {
+	dir, store := newEnrolmentSandbox(t)
+	mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+	raw, err := os.ReadFile(filepath.Join(dir, "settings.json"))
+	assertNoErr(t, err, "read settings.json")
+	if strings.Contains(string(raw), "enrolments") {
+		t.Fatalf("settings.json grew an enrolments key with no enrolments:\n%s", raw)
+	}
+}

--- a/log_rotate.go
+++ b/log_rotate.go
@@ -108,6 +108,20 @@ func (w *rotatingWriter) shiftGenerations() {
 	_ = os.Rename(w.path, w.path+".1")
 }
 
+// Sync flushes the current file to stable storage. The audit log's fail-closed
+// path for a remote caller writes and syncs its intent record before the MCP
+// runs, so "written" there has to mean on disk rather than in the page cache:
+// the failure this guards against is relay dying with the mailbox already read
+// and the record still buffered.
+func (w *rotatingWriter) Sync() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return os.ErrInvalid
+	}
+	return w.f.Sync()
+}
+
 func (w *rotatingWriter) Close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/main.go
+++ b/main.go
@@ -56,10 +56,12 @@ func main() {
 		runMcpExec(args[1:])
 	case "audit":
 		runAuditCommand(args[1:])
+	case "enrol":
+		runEnrolCommand(args[1:])
 	case "mcpList":
 		exitError("mcpList has been removed. Use: relay mcpExec --token <TOKEN> --list")
 	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\nUsage: relay [--config-dir DIR] [service|mcp|mcpExec|audit]\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown command: %s\nUsage: relay [--config-dir DIR] [service|mcp|mcpExec|audit|enrol]\n", args[0])
 		os.Exit(1)
 	}
 }

--- a/project_apply.go
+++ b/project_apply.go
@@ -143,6 +143,19 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 	if err := validateProjectShape(&candidate); err != nil {
 		return Project{}, true, err
 	}
+	// A project that stops being remote strands every enrolment granting it,
+	// so the conversion is refused while any exists (ADR-010 decision 3) —
+	// the mirror of the local→remote conversion ADR-009 constrains just
+	// below. Checked only when the result is local AND the project either was
+	// remote or had its kind named in the request: an ordinary edit to a
+	// long-standing local project has no conversion to refuse, and running
+	// the check there would turn a pre-existing bad grant into a wall in
+	// front of the very edit that might fix it.
+	if !candidate.IsRemote() && (proj.IsRemote() || f.Kind != nil) {
+		if err := s.ValidateProjectEnrolments(&candidate); err != nil {
+			return Project{}, true, err
+		}
+	}
 
 	// schemas() is a lazy fetch (real callers wire it to a live MCP-manager
 	// call); fetch it once and reuse for both the grants check and the

--- a/router.go
+++ b/router.go
@@ -319,6 +319,21 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 	// trusting LLM-supplied values. Relay is the project authority here.
 	meta := mergeProjectID(stored.Context[extID], stored.ProjectID)
 
+	// Fail-closed auditing for a remote caller (ADR-010 decision 5). This sits
+	// after auth resolution, so the actor is known and the record is
+	// attributable, and immediately before the MCP is invoked, so a call that
+	// cannot be recorded is refused rather than merely regretted. Local callers
+	// are untouched: intent() is a no-op for them and the single fail-open
+	// record below is exactly what ADR-008 specified.
+	if err := au.intent(); err != nil {
+		err = fmt.Errorf("audit: refusing tool call that cannot be recorded: %w", err)
+		// Best-effort, over the ordinary fail-open queue: if the sink is broken
+		// this will be dropped too, but a transient failure should still leave
+		// the refusal visible rather than silent.
+		au.done(AuditOutcomeError, err)
+		return nil, err
+	}
+
 	result, err := r.tools.CallTool(ctx, extID, name, args, meta)
 	au.doneResult(result, err)
 	return result, err

--- a/settings.go
+++ b/settings.go
@@ -16,6 +16,14 @@ type Settings struct {
 	Projects     []Project       `json:"projects"`
 	AdminSecret  string          `json:"admin_secret,omitempty"`
 
+	// Enrolments bind client certificates to the remote grants they may use
+	// (ADR-010 decision 2). omitempty, like Audit: an install that never
+	// enrols a remote client keeps a settings.json byte-identical to the one
+	// it had before this field existed, and no empty "enrolments": [] appears
+	// on every unrelated project edit. Note what is NOT here — there is no
+	// bearer token anywhere in this feature; the certificate is the identity.
+	Enrolments []Enrolment `json:"enrolments,omitempty"`
+
 	// Audit configures the tool-call log. Absent means defaults (enabled),
 	// so an install that predates this feature starts logging without any
 	// settings.json migration.
@@ -256,17 +264,29 @@ func (s *Settings) UpdateProjectPath(id string, path string, schemas map[string]
 }
 
 // UpdateProjectKind changes a project's kind. Does not save; use within
-// store.With. Like the other single-field Update* mutators this applies the
-// change unconditionally — the caller (applyProjectCreate / applyProjectUpdate)
-// is responsible for validating the resulting shape with validateProjectShape
-// before this runs.
+// store.With. Like the other single-field Update* mutators it leaves shape
+// validation to the caller (applyProjectCreate / applyProjectUpdate, via
+// validateProjectShape) — with one exception, below.
 func (s *Settings) UpdateProjectKind(id string, kind ProjectKind) {
 	proj, _ := s.findProjectByID(id)
 	if proj == nil {
 		return
 	}
 	// See normalizeProjectKind: local always persists as "", never "local".
-	proj.Kind = normalizeProjectKind(kind)
+	kind = normalizeProjectKind(kind)
+	// Belt-and-braces, exactly as UpdateProjectPath does it: the real refusal
+	// is ValidateProjectEnrolments at the call site, but this mutator is
+	// exported on Settings and nothing stops a future caller from invoking it
+	// directly. A remote→local conversion under a live enrolment strands that
+	// enrolment on a project whose whole shape it was never validated
+	// against, and the failure mode is a silent widening of what a remote
+	// client reaches — a host directory, its allowed_dirs context, cwd auth —
+	// rather than a loud error. Refuse silently here so a bypass of the
+	// validated path cannot produce it (ADR-010 decision 3).
+	if kind != ProjectKindRemote && proj.IsRemote() && len(s.EnrolmentsGrantingProject(id)) > 0 {
+		return
+	}
+	proj.Kind = kind
 }
 
 // UpdateProjectChatTemplates replaces a project's chat_templates list.

--- a/settings_audit_ui_test.go
+++ b/settings_audit_ui_test.go
@@ -246,3 +246,89 @@ func TestAuditTab_ShowPageTriggersInitialLoad(t *testing.T) {
 		t.Errorf("showPage('audit') sent %q query_audit messages, want 1", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Remote callers (ADR-010)
+// ---------------------------------------------------------------------------
+
+// A remote call is two records sharing one id, and its actor has no process to
+// name. Both facts have to survive to the screen: an operator looking at the
+// tab is the person who decides whether a VM is behaving.
+const auditRemoteFixture = `[{
+	id: 'rv1', ts: '2026-08-20T09:00:00.000Z', dur_ms: 0, event: 'call_tool', phase: 'intent',
+	actor: { kind:'remote', project_id:'proj_mail', project_name:'Mail', auth:'mtls',
+	         client_id:'hermes-mail',
+	         fingerprint:'sha256:9f2a41c78b0355ee1d6a4c2f8e0b7a93d5c14e6f8a2b0d9c3e7f15a8b46c2d90',
+	         remote_addr:'127.0.0.1:52233' },
+	mcp_id: 'macmcp', tool: 'mail_search', args: {q:'invoice'}, outcome: 'pending'
+}, {
+	id: 'rv2', ts: '2026-08-20T09:00:04.000Z', dur_ms: 12, event: 'call_tool',
+	actor: { kind:'remote', project_id:'proj_mail', project_name:'Mail', auth:'mtls',
+	         client_id:'hermes-mail', fingerprint:'sha256:9f2a41c7', remote_addr:'127.0.0.1:52233' },
+	mcp_id: 'macmcp', tool: 'mail_get_emails', outcome: 'throttled',
+	error: 'volume budget exceeded for enrolment hermes-mail'
+}]`
+
+func TestAuditTab_RemoteCallerIsLabelledByItsEnrolledClient(t *testing.T) {
+	vm := seedAuditVM(t, auditRemoteFixture, auditStatusOn)
+	html := evalString(t, vm, `window.renderAudit()`)
+
+	// The caller column would otherwise be a dash for every remote row: pid
+	// attribution means nothing across a network.
+	if !strings.Contains(html, "hermes-mail") {
+		t.Errorf("remote rows do not name the enrolled client:\n%s", html)
+	}
+	if !strings.Contains(html, "Any caller") {
+		t.Error("the actor-kind filter is missing from the filter bar")
+	}
+}
+
+// throttled says the grant was legitimate and the pattern of use was not, which
+// is what exfiltration looks like from the host's side. It must not read as an
+// ordinary error at a glance.
+func TestAuditTab_ThrottledAndPendingHaveTheirOwnPills(t *testing.T) {
+	vm := seedAuditVM(t, auditRemoteFixture, auditStatusOn)
+	html := evalString(t, vm, `window.renderAudit()`)
+
+	if !strings.Contains(html, "audit-throttled") {
+		t.Error("a throttled call did not get its own pill class")
+	}
+	if !strings.Contains(html, "audit-pending") {
+		t.Error("an intent record did not get its own pill class")
+	}
+}
+
+func TestAuditTab_KindFilterSelectsRemoteCallers(t *testing.T) {
+	vm := seedAuditVM(t, auditEventFixture+`.concat(`+auditRemoteFixture+`)`, auditStatusOn)
+	got := evalString(t, vm, `(function(){
+		window.state.auditFilter.kind = 'remote';
+		var rows = window.auditVisible();
+		return rows.length + ':' + rows.map(function(r){ return r.id; }).join(',');
+	})()`)
+	if got != "2:rv1,rv2" {
+		t.Errorf("kind=remote returned %q, want 2:rv1,rv2", got)
+	}
+}
+
+// The fingerprint is the only thing that still says which key made a call once
+// the enrolment naming it has been deleted, so the expanded record shows it in
+// full rather than truncated.
+func TestAuditTab_ExpandedRemoteRecordShowsFullFingerprint(t *testing.T) {
+	vm := seedAuditVM(t, auditRemoteFixture, auditStatusOn)
+	html := evalString(t, vm, `(function(){
+		window.state.auditExpanded['rv1'] = true;
+		return window.renderAudit();
+	})()`)
+
+	for _, want := range []string{
+		"Fingerprint",
+		"sha256:9f2a41c78b0355ee1d6a4c2f8e0b7a93d5c14e6f8a2b0d9c3e7f15a8b46c2d90",
+		"Remote address",
+		"127.0.0.1:52233",
+		"intent", // the phase, so an unpaired intent is legible as one
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expanded remote record is missing %q", want)
+		}
+	}
+}

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 )
 
 // Permission levels for token-based access control.
@@ -242,6 +243,67 @@ type Project struct {
 	// (settings.json is 0600 and already holds every token in plaintext), but
 	// it does erase the deliberate hand-off, so it stays opt-in per project.
 	AllowCwdAuth bool `json:"allow_cwd_auth,omitempty"`
+}
+
+// EnrolmentBudget bounds what one enrolled client may draw per rolling
+// window. The enrolment is the unit of compromise, so it is the unit that
+// carries the cap (ADR-010 decision 7): if one agent's key is stolen, the
+// attacker holds that key and nothing else, and this is what bounds the
+// damage.
+//
+// Rate and volume are budgeted together because they fail differently — a
+// call cap alone does not stop a slow drain, and a mailbox exfiltrated over
+// six hours is exfiltrated. Enforcement lives in appRouter.CallTool; this
+// type only carries the numbers.
+//
+// There is deliberately no representation of "unlimited": a zero field means
+// "unset", which normalizeEnrolmentBudget fills with the conservative default
+// rather than reading as no limit. A budget that can be switched off by
+// omitting a key from a hand-edited settings.json is a budget that will be off
+// on the one host where it mattered.
+type EnrolmentBudget struct {
+	WindowSeconds  int   `json:"window_seconds"`
+	MaxCalls       int   `json:"max_calls"`
+	MaxResultBytes int64 `json:"max_result_bytes"`
+}
+
+// Enrolment binds one client certificate to the grants it may use. It is the
+// whole of a remote caller's authority: there is no bearer token on the
+// remote path at all (ADR-010 decision 2), so a copy of settings.json — which
+// holds every project token in plaintext — grants no remote access whatsoever.
+//
+// An enrolment is keyed by CERTIFICATE, NOT BY MACHINE. One host may hold many
+// enrolments, and that is the expected shape: several agents on one VM, each
+// with its own certificate and its own grants, audited and revoked
+// independently. Nothing may assume one enrolment per machine — relay cannot
+// even tell that two enrolments are co-located, and the separation between
+// them is exactly as strong as the filesystem isolation on the client side.
+//
+// Device and capability revocation stay independent: editing ProjectIDs
+// changes what a client may reach without touching its certificate; deleting
+// the enrolment cuts the client without disturbing any project.
+type Enrolment struct {
+	// ClientID is the human-readable, unique name for this enrolment. It is
+	// also the certificate's Common Name and the bundle's directory name, so
+	// it is restricted to the filesystem-safe charset (isSafeID).
+	ClientID string `json:"client_id"`
+	// Fingerprint is the FULL SHA-256 of the client certificate's DER,
+	// "sha256:" + 64 hex chars. Never truncated — see FingerprintDER.
+	Fingerprint string `json:"fingerprint"`
+	// ProjectIDs are the grants this certificate may select among by sending
+	// a project id on the wire. A project id is not a secret; relay honours it
+	// only if this enrolment actually holds the grant. Every id here must name
+	// a project with IsRemote() true (ValidateEnrolmentGrants).
+	ProjectIDs []string        `json:"project_ids"`
+	Budget     EnrolmentBudget `json:"budget"`
+	CreatedAt  string          `json:"created_at"`
+}
+
+// GrantsProject reports whether this enrolment holds a grant for projectID.
+// The remote listener calls this before resolving a request's project id —
+// holding a certificate says who is calling, never what they may reach.
+func (e *Enrolment) GrantsProject(projectID string) bool {
+	return slices.Contains(e.ProjectIDs, projectID)
 }
 
 // IsRemote reports whether this project is a remote capability grant rather

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -388,6 +388,8 @@ textarea:focus {
 .audit-tool_error { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
 .audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
 .audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
+.audit-throttled { background: color-mix(in srgb, var(--warn) 30%, transparent); color: var(--warn); }
+.audit-pending { background: color-mix(in srgb, var(--text-2) 18%, transparent); color: var(--text-2); }
 .audit-expand td { background: color-mix(in srgb, CanvasText 5%, transparent); white-space: normal; box-shadow: inset 2px 0 0 var(--accent); }
 .audit-kv { display: grid; grid-template-columns: max-content 1fr; gap: 2px 14px; font-size: 12px; }
 .audit-kv dt { color: var(--text-2); }
@@ -702,7 +704,7 @@ window.__RELAY_INIT__ = {
     auditEvents: [],
     auditStatus: null,
     // {enabled, path, dropped, recorded, ...}
-    auditFilter: { project_id: "", mcp_id: "", outcome: "", event: "", text: "", deep: false },
+    auditFilter: { project_id: "", mcp_id: "", outcome: "", event: "", kind: "", text: "", deep: false },
     auditExpanded: {},
     // event id -> bool
     auditFollow: true,
@@ -2541,11 +2543,17 @@ window.__RELAY_INIT__ = {
       row: row || void 0
     }));
   }
-  var AUDIT_OUTCOMES = ["ok", "error", "tool_error", "denied", "unauthorized"];
+  var AUDIT_OUTCOMES = ["ok", "error", "tool_error", "denied", "unauthorized", "throttled", "pending"];
   var AUDIT_EVENT_KINDS = [
     ["call_tool", "Tool calls"],
     ["list_tools", "Tool lists"],
     ["list_skills", "Skill lists"]
+  ];
+  var AUDIT_ACTOR_KINDS = [
+    ["project", "Project"],
+    ["service", "Service"],
+    ["remote", "Remote"],
+    ["unknown", "Unauthenticated"]
   ];
   function queryAudit(deep) {
     const f = state.auditFilter;
@@ -2557,6 +2565,7 @@ window.__RELAY_INIT__ = {
       mcp_id: f.mcp_id || void 0,
       outcome: f.outcome || void 0,
       event: f.event || void 0,
+      kind: f.kind || void 0,
       text: deep ? f.text || void 0 : void 0,
       limit: deep ? 2e3 : 0,
       deep: !!deep
@@ -2570,6 +2579,7 @@ window.__RELAY_INIT__ = {
       mcp_id: f.mcp_id || void 0,
       outcome: f.outcome || void 0,
       event: f.event || void 0,
+      kind: f.kind || void 0,
       text: f.text || void 0
     }));
   }
@@ -2595,6 +2605,7 @@ window.__RELAY_INIT__ = {
     if (f.mcp_id && ev.mcp_id !== f.mcp_id) return false;
     if (f.outcome && ev.outcome !== f.outcome) return false;
     if (f.event && ev.event !== f.event) return false;
+    if (f.kind && (ev.actor || {}).kind !== f.kind) return false;
     if (f.text) {
       const a = ev.actor || {};
       const hay = [
@@ -2604,6 +2615,8 @@ window.__RELAY_INIT__ = {
         a.project_name,
         a.proc,
         a.parent,
+        a.client_id,
+        a.remote_addr,
         typeof ev.args === "string" ? ev.args : JSON.stringify(ev.args || "")
       ].join("\0").toLowerCase();
       if (hay.indexOf(f.text.toLowerCase()) === -1) return false;
@@ -2622,6 +2635,7 @@ window.__RELAY_INIT__ = {
   }
   function auditCaller(a) {
     a = a || {};
+    if (a.client_id) return a.client_id;
     if (a.parent && a.proc) return a.parent + " \u2192 " + a.proc;
     return a.proc || a.parent || (a.pid ? "pid " + a.pid : "");
   }
@@ -2675,6 +2689,7 @@ window.__RELAY_INIT__ = {
     html += auditSelect("project_id", "All projects", (state.projects || []).map((p) => [p.id, p.name]), f.project_id);
     html += auditSelect("mcp_id", "All MCPs", (state.externalMcps || []).map((m) => [m.id, m.display_name || m.id]), f.mcp_id);
     html += auditSelect("outcome", "Any outcome", AUDIT_OUTCOMES.map((o) => [o, o]), f.outcome);
+    html += auditSelect("kind", "Any caller", AUDIT_ACTOR_KINDS, f.kind);
     html += auditSelect("event", "All events", AUDIT_EVENT_KINDS, f.event);
     html += '<label style="font-size:12px;color:var(--text-2);display:flex;align-items:center;gap:5px">';
     html += '<input type="checkbox"' + (state.auditFollow ? " checked" : "") + ' onchange="toggleAuditFollow(this.checked)">Follow</label>';
@@ -2730,9 +2745,13 @@ window.__RELAY_INIT__ = {
     add("Caller pid", a.pid);
     add("Process", a.proc);
     add("Parent", a.parent);
+    add("Client", a.client_id);
+    add("Fingerprint", a.fingerprint);
+    add("Remote address", a.remote_addr);
     add("MCP", ev.mcp_id);
     add("Tool", ev.tool);
     add("Outcome", ev.outcome);
+    add("Phase", ev.phase);
     add("Error", ev.error);
     if (ev.result_bytes) add("Result", ev.result_bytes + " bytes" + (ev.result_is_error ? " (isError)" : ""));
     if (ev.tool_count) add("Tools visible", ev.tool_count);

--- a/web/shell.html
+++ b/web/shell.html
@@ -388,6 +388,8 @@ textarea:focus {
 .audit-tool_error { background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); }
 .audit-denied { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
 .audit-unauthorized { background: color-mix(in srgb, var(--danger) 26%, transparent); color: var(--danger); }
+.audit-throttled { background: color-mix(in srgb, var(--warn) 30%, transparent); color: var(--warn); }
+.audit-pending { background: color-mix(in srgb, var(--text-2) 18%, transparent); color: var(--text-2); }
 .audit-expand td { background: color-mix(in srgb, CanvasText 5%, transparent); white-space: normal; box-shadow: inset 2px 0 0 var(--accent); }
 .audit-kv { display: grid; grid-template-columns: max-content 1fr; gap: 2px 14px; font-size: 12px; }
 .audit-kv dt { color: var(--text-2); }

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -73,7 +73,7 @@ let state = {
     // on the Go side so it can be sent verbatim.
     auditEvents: [],
     auditStatus: null,                      // {enabled, path, dropped, recorded, ...}
-    auditFilter: { project_id: '', mcp_id: '', outcome: '', event: '', text: '', deep: false },
+    auditFilter: { project_id: '', mcp_id: '', outcome: '', event: '', kind: '', text: '', deep: false },
     auditExpanded: {},                      // event id -> bool
     auditFollow: true,                      // append live events as they arrive
     auditLoaded: false,
@@ -2343,11 +2343,22 @@ function dispatchServiceAction(serviceId, actionId, row) {
 // older than the ring holds.
 // ---------------------------------------------------------------------------
 
-const AUDIT_OUTCOMES = ['ok', 'error', 'tool_error', 'denied', 'unauthorized'];
+// 'throttled' is a budget refusal on a remote enrolment: the grant was
+// legitimate and the pattern of use was not. 'pending' is the intent half of a
+// remote call, written before the MCP runs and still awaiting its completion.
+const AUDIT_OUTCOMES = ['ok', 'error', 'tool_error', 'denied', 'unauthorized', 'throttled', 'pending'];
 const AUDIT_EVENT_KINDS = [
     ['call_tool', 'Tool calls'],
     ['list_tools', 'Tool lists'],
     ['list_skills', 'Skill lists'],
+];
+// Actor kinds. 'remote' is its own filter so "everything any VM did" is one
+// question rather than an inference from which actor fields are populated.
+const AUDIT_ACTOR_KINDS = [
+    ['project', 'Project'],
+    ['service', 'Service'],
+    ['remote', 'Remote'],
+    ['unknown', 'Unauthenticated'],
 ];
 
 function queryAudit(deep) {
@@ -2362,6 +2373,7 @@ function queryAudit(deep) {
         mcp_id: f.mcp_id || undefined,
         outcome: f.outcome || undefined,
         event: f.event || undefined,
+        kind: f.kind || undefined,
         text: deep ? (f.text || undefined) : undefined,
         limit: deep ? 2000 : 0,
         deep: !!deep,
@@ -2376,6 +2388,7 @@ function exportAudit() {
         mcp_id: f.mcp_id || undefined,
         outcome: f.outcome || undefined,
         event: f.event || undefined,
+        kind: f.kind || undefined,
         text: f.text || undefined,
     }));
 }
@@ -2411,9 +2424,11 @@ function auditMatches(ev) {
     if (f.mcp_id && ev.mcp_id !== f.mcp_id) return false;
     if (f.outcome && ev.outcome !== f.outcome) return false;
     if (f.event && ev.event !== f.event) return false;
+    if (f.kind && (ev.actor || {}).kind !== f.kind) return false;
     if (f.text) {
         const a = ev.actor || {};
         const hay = [ev.tool, ev.mcp_id, ev.error, a.project_name, a.proc, a.parent,
+                     a.client_id, a.remote_addr,
                      typeof ev.args === 'string' ? ev.args : JSON.stringify(ev.args || '')]
             .join('\u0000').toLowerCase();
         if (hay.indexOf(f.text.toLowerCase()) === -1) return false;
@@ -2438,6 +2453,9 @@ function auditFmtTime(ts) {
 // throwaway and the parent is the agent that actually asked.
 function auditCaller(a) {
     a = a || {};
+    // A remote caller has no process to name — pid attribution is meaningless
+    // across a network — so the enrolled client stands in for it.
+    if (a.client_id) return a.client_id;
     if (a.parent && a.proc) return a.parent + ' \u2192 ' + a.proc;
     return a.proc || a.parent || (a.pid ? 'pid ' + a.pid : '');
 }
@@ -2494,6 +2512,7 @@ function renderAudit() {
     html += auditSelect('project_id', 'All projects', (state.projects || []).map(p => [p.id, p.name]), f.project_id);
     html += auditSelect('mcp_id', 'All MCPs', (state.externalMcps || []).map(m => [m.id, m.display_name || m.id]), f.mcp_id);
     html += auditSelect('outcome', 'Any outcome', AUDIT_OUTCOMES.map(o => [o, o]), f.outcome);
+    html += auditSelect('kind', 'Any caller', AUDIT_ACTOR_KINDS, f.kind);
     html += auditSelect('event', 'All events', AUDIT_EVENT_KINDS, f.event);
     html += '<label style="font-size:12px;color:var(--text-2);display:flex;align-items:center;gap:5px">';
     html += '<input type="checkbox"' + (state.auditFollow ? ' checked' : '') + ' onchange="toggleAuditFollow(this.checked)">Follow</label>';
@@ -2551,9 +2570,17 @@ function renderAuditDetail(ev) {
     add('Caller pid', a.pid);
     add('Process', a.proc);
     add('Parent', a.parent);
+    add('Client', a.client_id);
+    // The fingerprint is shown in full: after an enrolment is deleted it is the
+    // only thing left that says which key made the call.
+    add('Fingerprint', a.fingerprint);
+    add('Remote address', a.remote_addr);
     add('MCP', ev.mcp_id);
     add('Tool', ev.tool);
     add('Outcome', ev.outcome);
+    // An intent with no completion sharing this id means relay invoked an MCP
+    // and never learned the outcome. Worth surfacing, not worth hiding.
+    add('Phase', ev.phase);
     add('Error', ev.error);
     if (ev.result_bytes) add('Result', ev.result_bytes + ' bytes' + (ev.result_is_error ? ' (isError)' : ''));
     if (ev.tool_count) add('Tools visible', ev.tool_count);


### PR DESCRIPTION
Implements ADR-010 decisions **2, 3, 5, 6, and 8**, plus the `throttled` outcome decision 7
will use. Built as two parallel workstreams over disjoint files and landed together.

**Nothing can reach a remote project yet.** There is still no listener — that is the next
part, and it is what the seams here are shaped for.

## Part 1 — CA, enrolment model, enrol CLI

Relay is its own CA. `ca.key`/`ca.crt` live in the config dir at 0600 rather than in
`settings.json`, which is atomically rewritten in full and would carry PEM blobs badly.
Generation is lazy and mutex-guarded so a first-use race cannot mint two CAs.

An enrolment binds a certificate to the grants it may use. **There is no token field
anywhere in this feature** — that is the whole of decision 2: once a certificate is
mandatory, a bearer token is a second long-lived plaintext secret buying nothing. A test
asserts no `token`/`secret`/`bearer` key ever serializes, so a stolen `settings.json`
grants no remote access at all.

Enrolments are keyed by **certificate, not machine**, so several agents can share one VM
with different grants, audited and revoked independently.

Grants are validated at both points this PR owns — at enrolment (every grant must resolve
to `IsRemote()`) and at conversion (remote→local refused while an enrolment references the
project, naming the offenders). The third point, call-time re-checking, belongs to the
listener.

## Part 2 — Two-phase audit, attested identity

Decision 5's guarantee is entirely about ordering, and the draft ADR had it wrong. Events
are written *after* a call completes because `doneResult` needs result bytes — so "refuse a
call that cannot be logged" protected nothing. A remote call now writes a **durable, synced
intent record before the MCP is invoked**; if that write fails the call is refused and the
MCP never runs. A completion record keyed to the same `id` follows.

Local behaviour is untouched and asserted rather than assumed: still exactly one record
with no phase, still drops rather than blocks with a full queue, still completes with an
unwritable sink.

Remote callers are attested by certificate — `client_id`, full untruncated `fingerprint`,
`remote_addr` — with `pid`/`proc`/`parent` *absent* rather than zero-filled, asserted
against the raw JSON. Identity rides in the context exactly as the peer pid already does,
so `bridge.ToolRouter` is unchanged, which ADR-008's Consequences require.

`WithRemoteCaller` refuses an identity with no fingerprint: the certificate is the
attestation, and the presence of that context value is what switches a call onto the
fail-closed path, so it must not be acquirable without one.

## Verified beyond the unit tests

I checked the issued certificate directly rather than trusting the tests:

```
X509v3 Key Usage: critical            Digital Signature
X509v3 Extended Key Usage:            TLS Web Client Authentication
X509v3 Basic Constraints: critical    CA:FALSE
openssl verify -CAfile ca.crt client.crt  ->  OK
```

So a client cert can neither mint further certificates nor act as a server. Bundle dir is
0700 with 0600 members; the recorded fingerprint is byte-identical to the DER hash at full
64-hex length. End-to-end, `relay enrol create --grant <remote>` emits a bundle and
`--grant <local>` is refused naming the project.

`go vet` clean · `go test ./...` green · `-race` green on all new tests ·
`web/dist/settings.html` regenerates byte-identical.

## Two additions beyond the ADR, called out for review

1. **`pending` outcome on intent lines.** `outcome` is non-omitempty and every reader looks
   at it, so `""` would render a blank pill and match no filter. Correlation is still by
   `id` + `phase` as the ADR specifies.
2. **`IssueServerCert`.** The bundle ships `ca.crt` "so the client can verify the server",
   which presumes a CA-signed server cert. Exposed from the CA rather than leaving the
   listener author to reach into the key.

## Known gaps, deliberately not stubbed

- **`relay enrol revoke` severs nothing live.** A CLI process has no connection table, so it
  removes the record only. Decision 8 requires revocation to close open connections; the
  seam (`SetEnrolmentRevocationHook`) is in place for the tray to fill.
- **`audit.enabled: false` disables the fail-closed guarantee** — `intent()` returns nil and
  a remote call proceeds unrecorded. Whether disabling auditing should refuse *all* remote
  traffic is a policy question ADR-010 does not settle; flagged in code and docs rather than
  decided unilaterally.
- Deleting a project an enrolment grants leaves a dangling grant; call-time re-checking
  fails it closed.
- The Settings UI enrolment list is not built. `Settings.Enrolments` and
  `EnrolmentsGrantingProject` are what that view needs.

Refs ADR-010.
