### PR TITLE
ADR-010 part 2: RemoteServer, budgets, and a reachable remote project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ __pycache__/
 # Scratch
 prompt.md
 /plans/
+
+# Agent worktrees
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ audit_cmd.go             `relay audit` CLI
 enrolment.go             Enrolment CRUD, grant validation, revocation + its live-connection hook
 enrolment_ca.go          Relay's self-signed CA: lazy generation, client/server cert issuance, fingerprints
 enrol_cmd.go             `relay enrol` CLI
+remote_server.go         Remote mTLS listener: two-entry dispatch table, cert→enrolment→grant, revocation hook
 external_mcp.go          stdio/HTTP MCP clients + runtime schema storage (McpConnection iface)
 http_mcp.go, oauth.go    HTTP transport + OAuth 2.1 (PKCE, dynamic registration, refresh)
 mcp_cmd.go, exec_cmd.go, service_cmd.go   CLI subcommands
@@ -60,7 +61,9 @@ service_status_client.go, service_status_poller.go   Generic per-service status 
 ipc_*.go                 Settings-UI IPC handlers (projects, services, mcps, service action/config, audit)
 service_config_file.go   resolveConfigPath security gate for the manifest config editor
 settings_html.go         Settings WKWebView HTML/JS
-bridge/                  Unix-socket IPC (newline-delimited JSON); manifest.go holds Manifest/FieldDecl
+bridge/                  Unix-socket IPC (newline-delimited JSON); manifest.go holds Manifest/FieldDecl.
+                         frameconn.go is the framing/scanner/deadline plumbing BOTH listeners share;
+                         remote_request.go + remote_caller.go are the remote wire type and attested identity
 mcp/                     MCP types + stdio server (proxies to the bridge)
 ```
 
@@ -130,9 +133,44 @@ live connections.
 Grants are validated at enrolment (`ValidateEnrolmentGrants` — every grant must
 name a project with `IsRemote()` true) and at conversion
 (`ValidateProjectEnrolments` — remote→local is refused while any enrolment
-grants the project, naming the offenders). Call-time re-checking belongs to the
-listener. As of this writing there is still no listener, so a remote project
-cannot yet be *reached*; the model, the CA, and the enrolment flow exist.
+grants the project, naming the offenders), and a third time at call time by the
+listener (`RemoteServer.resolveGrant` re-checks `IsRemote()` immediately before
+dispatch, so a grant that went stale by any route relay did not anticipate
+fails closed).
+
+### The remote listener
+
+`RemoteServer` (`remote_server.go`) is a **second listener beside**
+`BridgeServer` — never a mode of it. Its dispatch table (`remoteHandlers`) has
+exactly two entries, `ListTools` and `CallTool`: the other eight bridge request
+types have no code path from a remote connection at all, so a new admin op is
+unreachable from a VM until someone deliberately adds it to a list that is
+visibly a security boundary.
+
+Mutual TLS against relay's own CA (`tls.RequireAndVerifyClientCert`). The peer
+certificate is fingerprinted and resolved to an enrolment **before any request
+is read** — an unenrolled certificate is closed without processing, so it
+cannot probe. The resolved identity goes into the context via
+`bridge.WithRemoteCaller`, which is what puts every call on the fail-closed
+audit path. The wire type (`bridge.RemoteRequest`) carries only
+`type` / `name` / `arguments` / `project_id`; there is no token and no cwd, and
+decoding is strict (`DisallowUnknownFields`) so a client sending `cwd` gets a
+loud error rather than silent divergence. The project token is resolved
+host-side from the granted project and never appears on the wire.
+
+Config — absent block means **no listener at all**, and the default binds
+loopback so misconfiguration cannot expose the control plane to a LAN:
+
+```json
+"remote": { "enabled": true, "listen": "127.0.0.1:9910" }
+```
+
+The listener **refuses to start when auditing is disabled**: a remote grant is
+justified by the calls it records, so serving remote traffic unrecorded is not
+a degraded mode. Local tooling is unaffected. It also sets read+write deadlines
+(inactivity, not a cap on work) and keeps a connection table keyed by
+fingerprint so `SetEnrolmentRevocationHook` closes a revoked client's *live*
+connections.
 
 See [ADR-010](docs/decisions/010-remote-client-transport-and-identity.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,22 @@ decoding is strict (`DisallowUnknownFields`) so a client sending `cwd` gets a
 loud error rather than silent divergence. The project token is resolved
 host-side from the granted project and never appears on the wire.
 
+Every remote call is budgeted (`enrolment_budget.go`). Each enrolment carries a
+rolling-window call-rate and result-volume cap, enforced in `appRouter.CallTool`
+and refused with the `throttled` outcome — distinct from `denied` (a tool the
+grant never included) and `tool_error` (a boundary inside the MCP) because it is
+the only one of the three that says the grant was legitimate and the *pattern of
+use* was not. Budgets live on the **enrolment, not the project**: the enrolment
+is the unit of compromise, so it is the unit that bounds one. Rate is checked
+before the MCP runs; volume is necessarily charged after a call returns, so the
+guarantee is "at most one call's worth over the cap", not a hard ceiling. Local
+callers are not budgeted at all — one context lookup and nothing else.
+
+Auditing is a hard dependency of remote access: with `audit.enabled: false` the
+listener refuses to start rather than serving unrecorded calls. The case for
+letting a VM reach host mail rests on detection, so there is deliberately no
+window in which a remote call runs without a record.
+
 Config — absent block means **no listener at all**, and the default binds
 loopback so misconfiguration cannot expose the control plane to a LAN:
 

--- a/bridge/frameconn.go
+++ b/bridge/frameconn.go
@@ -1,0 +1,135 @@
+package bridge
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"relaygo/jsonrpc"
+)
+
+// FrameConn is the newline-delimited-JSON plumbing both listeners sit on: the
+// scanner setup, the serialized write path, the read loop, and the end-of-
+// stream classification. It exists so that BridgeServer and RemoteServer share
+// the *transport*, and nothing else.
+//
+// That split is the point. ADR-010 decision 1 wants the two dispatch tables
+// visibly distinct — a request type reachable from a VM must be a line someone
+// deliberately added to a two-entry list — while the framing underneath has no
+// security content at all and is exactly the code that rots when it is copied.
+// Serve therefore takes the per-line handler as a parameter and knows nothing
+// about request types, tokens, or identity.
+type FrameConn struct {
+	conn    net.Conn
+	scanner *bufio.Scanner
+	// name labels this connection in logs ("bridge", "remote"), so a read
+	// error says which listener it came from without threading a logger.
+	name string
+	// idle is the inactivity timeout applied to reads and writes. Zero means
+	// no deadlines at all, which is what the Unix socket uses: the peer there
+	// is same-user and a stalled local client is not an attack. On a network
+	// listener a peer that opens a connection and never speaks is exactly the
+	// slowloris vector decision 9 calls out, so RemoteServer sets it.
+	idle time.Duration
+
+	// writeMu serializes writes: progress frames are emitted from the
+	// external-MCP reader goroutine while the main goroutine is blocked inside
+	// the in-flight call, so the terminal response and any progress frames
+	// would otherwise race on conn.Write.
+	writeMu sync.Mutex
+}
+
+// NewFrameConn wraps an accepted connection. idle <= 0 disables deadlines.
+func NewFrameConn(conn net.Conn, name string, idle time.Duration) *FrameConn {
+	c := &FrameConn{conn: conn, scanner: NewScanner(conn), name: name, idle: idle}
+	c.touch()
+	return c
+}
+
+// touch pushes the read/write deadline out by the idle timeout. Called after
+// every frame read and before every frame written, which makes the timeout an
+// INACTIVITY bound rather than a cap on how long a call may take — the same
+// treatment bridge/client.go gives its own deadline, and for the same reason: a
+// tool call that legitimately runs for minutes (LLM inference, a large mail
+// search) must not be severed just because it is slow.
+func (c *FrameConn) touch() {
+	if c.idle <= 0 {
+		return
+	}
+	_ = c.conn.SetDeadline(time.Now().Add(c.idle))
+}
+
+// WriteFrame marshals and writes one response frame, serialized against every
+// other writer on this connection.
+func (c *FrameConn) WriteFrame(resp BridgeResponse) error {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		data, _ = json.Marshal(ErrorResponse(jsonrpc.CodeInternalError, err.Error()))
+	}
+	data = append(data, '\n')
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	c.touch()
+	_, werr := c.conn.Write(data)
+	return werr
+}
+
+// Serve reads frames until the peer disconnects, the connection errors, or a
+// write fails, invoking handle for each line and writing what it returns. Each
+// call gets a context carrying a progress sink so a long-running CallTool can
+// stream RespProgress frames before its terminal response; handlers that don't
+// stream ignore it.
+func (c *FrameConn) Serve(ctx context.Context, handle func(ctx context.Context, line string) BridgeResponse) {
+	for c.scanner.Scan() {
+		c.touch()
+		line := c.scanner.Text()
+		reqCtx := WithProgress(ctx, func(u ProgressUpdate) {
+			_ = c.WriteFrame(BridgeResponse{Type: RespProgress, Progress: &u})
+		})
+		if err := c.WriteFrame(handle(reqCtx, line)); err != nil {
+			return
+		}
+	}
+	c.reportReadEnd(ctx)
+}
+
+// reportReadEnd classifies why the read loop ended. An oversized line is told
+// to the peer before the connection drops — the scanner cannot resync past it,
+// so without this the client sees only a generic read failure.
+func (c *FrameConn) reportReadEnd(ctx context.Context) {
+	switch err := c.scanner.Err(); {
+	case err == nil:
+		// Clean EOF: peer closed the connection. Nothing to report.
+	case errors.Is(err, bufio.ErrTooLong):
+		_ = c.WriteFrame(ErrorResponse(jsonrpc.CodeInvalidParams, fmt.Sprintf("message exceeds maximum size of %d bytes", MaxMessageSize)))
+		slog.Warn(c.name+": dropping connection, message exceeds size limit", "max_bytes", MaxMessageSize)
+	case ctx.Err() != nil:
+		// Connection was closed by shutdown (the close-on-cancel goroutine in
+		// each server's handler); the resulting read error is expected.
+		slog.Debug(c.name+" connection closed during shutdown", "error", err)
+	default:
+		slog.Warn(c.name+" connection read error", "error", err)
+	}
+}
+
+// ErrorResponse builds an error frame with the given JSON-RPC code.
+func ErrorResponse(code int, msg string) BridgeResponse {
+	return BridgeResponse{Type: RespError, Code: code, Message: msg}
+}
+
+// ErrorCode extracts a JSON-RPC error code from an error chain. Router methods
+// wrap auth/permission errors with jsonrpc.CodedError so a listener can
+// classify them without fragile string matching; anything else is internal.
+func ErrorCode(err error) int {
+	var coded *jsonrpc.CodedError
+	if errors.As(err, &coded) {
+		return coded.RPCCode
+	}
+	return jsonrpc.CodeInternalError
+}

--- a/bridge/remote_request.go
+++ b/bridge/remote_request.go
@@ -1,0 +1,61 @@
+package bridge
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// RemoteRequest is the ENTIRE wire format of the remote listener (ADR-010
+// decision 4). Note what is not here.
+//
+// There is no Token field. Identity on this path is the client certificate,
+// resolved to an enrolment before a single byte of a request is read, so a
+// bearer secret would be a second long-lived plaintext credential that buys
+// nothing: a leaked token is useless without the key, and its absence is what
+// makes a stolen settings.json grant no remote access at all (decision 2).
+//
+// There is no Cwd field either. Directory auth is already unreachable here by
+// construction — it fires only when no token is present, and identity arrives
+// from the connection — but "unreachable by a chain of reasoning" and
+// "unrepresentable" are different properties, and only the second survives
+// somebody refactoring the router. A separate type is what makes it the
+// second.
+//
+// ProjectID selects among an enrolment's grants. It is deliberately NOT a
+// secret: relay honours it only when the resolved enrolment actually holds
+// that grant, so sending someone else's project id is a refusal rather than an
+// escalation.
+type RemoteRequest struct {
+	Type      string          `json:"type"`
+	Name      string          `json:"name,omitempty"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+	ProjectID string          `json:"project_id,omitempty"`
+}
+
+// DecodeRemoteRequest parses one wire line STRICTLY: an unrecognised key is an
+// error, not something to skip.
+//
+// Go's default is to ignore unknown JSON keys silently, which would leave a
+// client that sent `cwd` believing it had authenticated by directory while it
+// had in fact authenticated by certificate. Both succeed identically today, so
+// the divergence would surface much later and in the confusing direction —
+// after the certificate was revoked and the caller kept working, or after the
+// grant changed and the cwd it trusted did nothing. Strict decoding turns that
+// into an error at the door.
+//
+// The cost is that adding a field to this struct requires deploying both ends
+// together. Both ends are ours, so that is a coordination step rather than a
+// compatibility break (decision 4).
+func DecodeRemoteRequest(line []byte) (*RemoteRequest, error) {
+	dec := json.NewDecoder(bytes.NewReader(line))
+	dec.DisallowUnknownFields()
+	var req RemoteRequest
+	if err := dec.Decode(&req); err != nil {
+		return nil, err
+	}
+	if req.Type == "" {
+		return nil, fmt.Errorf("request has no type")
+	}
+	return &req, nil
+}

--- a/bridge/server.go
+++ b/bridge/server.go
@@ -1,10 +1,8 @@
 package bridge
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -89,7 +87,7 @@ func (s *BridgeServer) Close() {
 
 // bridgeError creates an error BridgeResponse with the given code and message.
 func bridgeError(code int, msg string) BridgeResponse {
-	return BridgeResponse{Type: RespError, Code: code, Message: msg}
+	return ErrorResponse(code, msg)
 }
 
 func (s *BridgeServer) handleConn(conn net.Conn) {
@@ -122,54 +120,10 @@ func (s *BridgeServer) handleConn(conn net.Conn) {
 		_ = conn.Close()
 	}()
 
-	scanner := NewScanner(conn)
-
-	// Serialize all writes to this connection: progress frames are written
-	// from the external-MCP reader goroutine while the main goroutine is
-	// blocked inside the in-flight call, so the final response and any
-	// progress frames can race on conn.Write without this mutex.
-	var writeMu sync.Mutex
-	writeFrame := func(resp BridgeResponse) error {
-		data, err := json.Marshal(resp)
-		if err != nil {
-			data, _ = json.Marshal(bridgeError(jsonrpc.CodeInternalError, err.Error()))
-		}
-		data = append(data, '\n')
-		writeMu.Lock()
-		defer writeMu.Unlock()
-		_, werr := conn.Write(data)
-		return werr
-	}
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		// Attach a progress sink so a long-running CallTool can stream
-		// RespProgress frames to this caller before its terminal response.
-		// Only CallTool's downstream invokes it; other handlers ignore it.
-		reqCtx := WithProgress(ctx, func(u ProgressUpdate) {
-			_ = writeFrame(BridgeResponse{Type: RespProgress, Progress: &u})
-		})
-		resp := s.handleRequest(reqCtx, line)
-		if err := writeFrame(resp); err != nil {
-			return
-		}
-	}
-	switch err := scanner.Err(); {
-	case err == nil:
-		// Clean EOF: peer closed the connection. Nothing to report.
-	case errors.Is(err, bufio.ErrTooLong):
-		// A single line exceeded MaxMessageSize. The scanner can't resync, so
-		// tell the caller why before dropping the connection — otherwise the
-		// client only sees a generic "read failed" when its own read errors out.
-		_ = writeFrame(bridgeError(jsonrpc.CodeInvalidParams, fmt.Sprintf("message exceeds maximum size of %d bytes", MaxMessageSize)))
-		slog.Warn("bridge: dropping connection, message exceeds size limit", "max_bytes", MaxMessageSize)
-	case ctx.Err() != nil:
-		// Connection was closed by shutdown (the socket-close-on-cancel above);
-		// the resulting read error is expected, not a fault.
-		slog.Debug("bridge connection closed during shutdown", "error", err)
-	default:
-		slog.Warn("bridge connection read error", "error", err)
-	}
+	// No deadlines: this is a 0600 Unix socket, so the peer is same-user and a
+	// stalled client is a bug rather than an attack. RemoteServer, whose peer
+	// is across a network, passes a non-zero idle timeout instead.
+	NewFrameConn(conn, "bridge", 0).Serve(ctx, s.handleRequest)
 }
 
 // bridgeHandler defines a handler for a bridge request type.
@@ -240,11 +194,7 @@ func handleCallTool(ctx context.Context, req *BridgeRequest, router ToolRouter) 
 // Router methods wrap auth/permission errors with jsonrpc.CodedError so the
 // bridge can classify them without fragile string matching.
 func classifyErrorCode(err error) int {
-	var coded *jsonrpc.CodedError
-	if errors.As(err, &coded) {
-		return coded.RPCCode
-	}
-	return jsonrpc.CodeInternalError
+	return ErrorCode(err)
 }
 
 func handleReconcile(ctx context.Context, _ *BridgeRequest, router ToolRouter) BridgeResponse {

--- a/enrolment_budget.go
+++ b/enrolment_budget.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"relaygo/bridge"
+)
+
+// Per-enrolment rate and volume budgets (ADR-010 decision 7).
+//
+// ADR-008 bought detection; nothing bought interdiction. A remote grant of
+// mail_search + mail_get_emails can drain a mailbox as fast as Mail.app
+// answers, fully logged and wholly unimpeded — the audit log a faithful record
+// of the exact threat ADR-009 names. This file is the interdiction: the only
+// thing in the design that makes an exfiltration attempt *stop* rather than be
+// written down.
+//
+// Both limits are enforced in appRouter.CallTool, the chokepoint ADR-008 chose
+// and for the same reason: every transport already funnels through it and the
+// actor is known by the time it runs.
+//
+// Rate and volume are budgeted together because they fail differently. A call
+// cap alone does not stop a slow drain, and a mailbox exfiltrated over six
+// hours is exfiltrated. A byte cap alone does not stop a client hammering a
+// cheap tool.
+//
+// THE ENROLMENT IS THE UNIT, NOT THE PROJECT. The enrolment is the unit of
+// compromise — a stolen key is one enrolment's key and nothing else — so it is
+// the unit that carries the cap. Two agents sharing a grant have independent
+// budgets, and a compromised one cannot consume its neighbour's. A project
+// ceiling is a coherent later addition (it protects the resource rather than
+// bounding a single compromise) and is deliberately not this.
+
+// enrolmentBudgets holds the rolling-window accounting for every enrolment
+// that has called recently.
+//
+// The zero value is ready to use, and that is deliberate: it makes enforcement
+// the default rather than something a constructor has to remember to switch
+// on. An appRouter assembled by hand — in a test, in a future call site — still
+// budgets its remote callers, so the failure mode of forgetting is a bounded
+// caller rather than an unlimited one.
+type enrolmentBudgets struct {
+	// mu guards the map and the clock only. All the actual accounting happens
+	// under the per-enrolment lock inside budgetWindow, so two enrolments
+	// calling concurrently contend for nothing more than a map read: one noisy
+	// client must not be able to serialise the others behind it, which would
+	// be a denial of service built out of the thing meant to prevent one.
+	mu      sync.RWMutex
+	windows map[string]*budgetWindow
+
+	// clock is injected by tests so window rollover is deterministic. Nil
+	// means time.Now. A budget whose expiry can only be observed by sleeping
+	// is a budget that gets tested with a sleep, and a sleeping test is a
+	// flaky test.
+	clock func() time.Time
+}
+
+// budgetWindow is one enrolment's rolling window.
+//
+// Both series are kept as timestamped entries rather than as counters reset on
+// a clock boundary. A fixed bucket hands an attacker 2x the budget for free by
+// straddling the reset — spend it all just before the boundary, spend it all
+// again just after — which is exactly the burst the cap exists to refuse.
+type budgetWindow struct {
+	mu sync.Mutex
+	// calls holds the admission time of every call still inside the window.
+	// Bounded by MaxCalls: a call that would exceed the cap is refused and
+	// never appended, so this cannot grow past the budget it enforces.
+	calls []time.Time
+	// volume holds the completion time and size of every result still inside
+	// the window, and bytes is their running sum. Bounded by MaxCalls for the
+	// same reason.
+	volume []volumeSample
+	bytes  int64
+}
+
+type volumeSample struct {
+	at    time.Time
+	bytes int64
+}
+
+// enrolmentBudget resolves the budget governing one remote caller.
+//
+// Lookup is by the certificate fingerprint the connection attested, not by the
+// client id it names: the fingerprint is the identity that was proven, and a
+// re-issued certificate under a recycled client id is a different key that
+// deserves a fresh ledger rather than an inherited one.
+//
+// A fingerprint that resolves to no enrolment gets the conservative defaults,
+// never an exemption. Decision 2's listener closes a connection whose
+// certificate does not resolve, so this should be unreachable — which is
+// precisely why it must not read as "unlimited" if it ever is reached. Refusing
+// the call outright would be the wrong shape here: whether a caller holds a
+// grant at all is an authorization question this budget check has no business
+// answering, and mislabelling it would put `throttled` in the log where
+// `denied` belongs.
+func (s *Settings) enrolmentBudget(rc bridge.RemoteCaller) EnrolmentBudget {
+	if s != nil {
+		if e := s.FindEnrolmentByFingerprint(rc.Fingerprint); e != nil {
+			// normalize again on read rather than trusting the stored record:
+			// settings.json is hand-editable, and a zero field there must fill
+			// with the default rather than switch the budget off.
+			return normalizeEnrolmentBudget(e.Budget)
+		}
+	}
+	return normalizeEnrolmentBudget(EnrolmentBudget{})
+}
+
+// admit reserves one call against the enrolment's budget, or returns the error
+// that refuses it. Called BEFORE the MCP is invoked: a rate refusal that let
+// the tool run first would have already read the mailbox it was refusing to
+// let anyone read.
+//
+// Both limits are checked here, but only the rate limit is bounded in advance.
+// The volume check is necessarily retrospective — see charge.
+//
+// A reserved call is never handed back, not even when the call is refused
+// downstream (a failed intent record, say). Releasing it would let a caller
+// retry a failing call without limit, which is the one shape of traffic a rate
+// cap most obviously has to bound; counting an attempt that relay itself
+// refused costs a legitimate client one slot out of a window.
+func (b *enrolmentBudgets) admit(rc bridge.RemoteCaller, budget EnrolmentBudget) error {
+	budget = normalizeEnrolmentBudget(budget)
+	span := time.Duration(budget.WindowSeconds) * time.Second
+	w, now := b.windowFor(rc.Fingerprint)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.prune(now.Add(-span))
+
+	if len(w.calls) >= budget.MaxCalls {
+		return fmt.Errorf("throttled: enrolment %q has used %d of %d calls in the last %ds",
+			rc.ClientID, len(w.calls), budget.MaxCalls, budget.WindowSeconds)
+	}
+	// >= rather than >: the budget is "at most MaxResultBytes per window", so
+	// once the window holds that many the allowance is spent. Fail closed on
+	// the boundary rather than granting one more call at exactly the cap.
+	if w.bytes >= budget.MaxResultBytes {
+		return fmt.Errorf("throttled: enrolment %q has drawn %d of %d result bytes in the last %ds",
+			rc.ClientID, w.bytes, budget.MaxResultBytes, budget.WindowSeconds)
+	}
+	w.calls = append(w.calls, now)
+	return nil
+}
+
+// charge records the size of a completed result against the volume budget.
+//
+// THIS RUNS AFTER THE CALL, AND THAT IS A REAL LIMIT, NOT AN OVERSIGHT. Result
+// size is not knowable before the MCP answers, so a call that pushes the total
+// over the cap completes and returns its bytes; the NEXT call is the one
+// refused. The guarantee is therefore "at most one call's worth of overshoot",
+// not "never more than MaxResultBytes leaves the host". Anything stronger would
+// need a per-call size ceiling or a streaming cutoff, which is a different
+// mechanism from a rolling budget and is not what decision 7 specifies.
+//
+// n is the same quantity the audit layer records as ResultBytes — the length of
+// the raw MCP result — deliberately reusing that notion rather than inventing a
+// second measurement that could disagree with the log.
+func (b *enrolmentBudgets) charge(rc bridge.RemoteCaller, budget EnrolmentBudget, n int) {
+	if n <= 0 {
+		return
+	}
+	budget = normalizeEnrolmentBudget(budget)
+	span := time.Duration(budget.WindowSeconds) * time.Second
+	w, now := b.windowFor(rc.Fingerprint)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.prune(now.Add(-span))
+	w.volume = append(w.volume, volumeSample{at: now, bytes: int64(n)})
+	w.bytes += int64(n)
+}
+
+// windowFor returns the enrolment's window and the current time, creating the
+// window on first use.
+//
+// Windows are never reclaimed, and nothing here sweeps them. The key space is
+// the set of enrolled certificate fingerprints — decision 2's listener closes
+// any connection whose certificate does not resolve to an enrolment, so no
+// unauthenticated caller can mint keys here — and each window self-prunes to at
+// most MaxCalls entries. Reclaiming an idle window would save a few hundred
+// bytes per enrolment ever created and would open a race where a sweep drops
+// the window a long-running call is about to charge its bytes to, which is
+// exactly the accounting a slow drain would like to see lost.
+func (b *enrolmentBudgets) windowFor(fingerprint string) (*budgetWindow, time.Time) {
+	b.mu.RLock()
+	w, clock := b.windows[fingerprint], b.clock
+	b.mu.RUnlock()
+
+	now := time.Now()
+	if clock != nil {
+		now = clock()
+	}
+	if w != nil {
+		return w, now
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Re-check: two connections from one enrolment can arrive here together,
+	// and they must end up on the same ledger or the cap is per-goroutine.
+	if w := b.windows[fingerprint]; w != nil {
+		return w, now
+	}
+	if b.windows == nil {
+		b.windows = make(map[string]*budgetWindow)
+	}
+	w = &budgetWindow{}
+	b.windows[fingerprint] = w
+	return w, now
+}
+
+// setClock installs a clock for deterministic tests. Not used in production,
+// where clock stays nil and time.Now is read directly.
+func (b *enrolmentBudgets) setClock(fn func() time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.clock = fn
+}
+
+// prune drops every entry that has aged out of the window. Entries are
+// appended in non-decreasing time order, so expiry is always a prefix.
+//
+// An entry exactly cutoff-old is dropped: with cutoff = now-window, a call made
+// exactly one window ago no longer counts, which is what "per rolling window"
+// means and what makes the boundary deterministic to test.
+func (w *budgetWindow) prune(cutoff time.Time) {
+	i := 0
+	for i < len(w.calls) && !w.calls[i].After(cutoff) {
+		i++
+	}
+	if i > 0 {
+		w.calls = slices.Delete(w.calls, 0, i)
+	}
+	j := 0
+	for j < len(w.volume) && !w.volume[j].at.After(cutoff) {
+		w.bytes -= w.volume[j].bytes
+		j++
+	}
+	if j > 0 {
+		w.volume = slices.Delete(w.volume, 0, j)
+	}
+}

--- a/enrolment_budget_test.go
+++ b/enrolment_budget_test.go
@@ -1,0 +1,579 @@
+package main
+
+// Per-enrolment rate and volume budgets (ADR-010 decision 7).
+//
+// The assertions that matter here are about *interdiction*, not about
+// bookkeeping: a refused call must not have reached the MCP, one enrolment's
+// exhaustion must not touch another's allowance, and a local caller must be
+// provably untouched by any of it. Window expiry is driven by an injected
+// clock — a budget tested with a sleep is a budget tested flakily.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"relaygo/bridge"
+)
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// fakeClock is the injected time source. Guarded, because the concurrency test
+// reads it from many goroutines at once.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// budgetFingerprint derives a distinct full-length fingerprint per client id.
+// Full length on purpose: the ledger is keyed by the attested certificate, and
+// a test that keyed it by a short string would not exercise that.
+func budgetFingerprint(clientID string) string {
+	sum := sha256.Sum256([]byte(clientID))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// budgetCtx stands in for the remote listener, attesting an identity the way a
+// verified TLS connection does. Nothing here is caller-asserted.
+func budgetCtx(clientID string) context.Context {
+	return bridge.WithRemoteCaller(context.Background(), bridge.RemoteCaller{
+		ClientID:    clientID,
+		Fingerprint: budgetFingerprint(clientID),
+		RemoteAddr:  "127.0.0.1:52233",
+	})
+}
+
+// countingMock returns an MCP that answers with result and a thread-safe count
+// of how many times it was actually invoked. The count is the whole point of
+// several tests below: a refusal that still ran the tool has interdicted
+// nothing, and only the invocation count can tell the difference.
+func countingMock(result string) (*mockMcpConn, func() int) {
+	var mu sync.Mutex
+	n := 0
+	m := newMockConn("macmcp", simpleTools("mail_search", "mail_get_emails"),
+		func(context.Context, string, interface{}) (json.RawMessage, error) {
+			mu.Lock()
+			n++
+			mu.Unlock()
+			return json.RawMessage(result), nil
+		})
+	return m, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return n
+	}
+}
+
+// budgetRouter builds a router whose settings hold one enrolment per entry in
+// budgets, stored VERBATIM — no normalization — so a zero budget can be proven
+// not to mean "unlimited" on the read path rather than only on the write path.
+func budgetRouter(t *testing.T, mock *mockMcpConn, budgets map[string]EnrolmentBudget) (*appRouter, *AuditRecorder, *fakeClock) {
+	t.Helper()
+	mkSandboxRelayHome(t)
+
+	s := makeSettings(map[string]Permission{"macmcp": PermOn}, nil, nil)
+	for clientID, b := range budgets {
+		s.Enrolments = append(s.Enrolments, Enrolment{
+			ClientID:    clientID,
+			Fingerprint: budgetFingerprint(clientID),
+			ProjectIDs:  []string{"test-project"},
+			Budget:      b,
+		})
+	}
+	mgr := NewExternalMcpManager(nil)
+	addMockConn(mgr, "macmcp", mock)
+
+	r := newTestRouter(t, s, mgr)
+	rec := newTestAudit(t, nil)
+	r.audit = rec
+	clk := newFakeClock()
+	r.budgets.setClock(clk.now)
+	return r, rec, clk
+}
+
+// lastEvent returns the most recent record on disk.
+func lastEvent(t *testing.T, rec *AuditRecorder) AuditEvent {
+	t.Helper()
+	events := readLoggedEvents(t, rec)
+	if len(events) == 0 {
+		t.Fatal("audit log is empty")
+	}
+	return events[len(events)-1]
+}
+
+// windowCount reports how many enrolments the ledger is tracking. Used to prove
+// a local call leaves no trace in it at all.
+func windowCount(b *enrolmentBudgets) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.windows)
+}
+
+// drawn reports the bytes currently charged to an enrolment's window.
+func drawn(b *enrolmentBudgets, clientID string) int64 {
+	b.mu.RLock()
+	w := b.windows[budgetFingerprint(clientID)]
+	b.mu.RUnlock()
+	if w == nil {
+		return 0
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.bytes
+}
+
+const budgetResult = `{"content":[{"type":"text","text":"3 messages"}]}`
+
+// ---------------------------------------------------------------------------
+// Rate
+// ---------------------------------------------------------------------------
+
+func TestEnrolmentBudget_CallWithinBudgetSucceeds(t *testing.T) {
+	mock, calls := countingMock(budgetResult)
+	r, rec, _ := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {WindowSeconds: 60, MaxCalls: 10, MaxResultBytes: 1 << 20},
+	})
+
+	ctx := budgetCtx("hermes-mail")
+	for i := 0; i < 3; i++ {
+		if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err != nil {
+			t.Fatalf("call %d inside the budget was refused: %v", i+1, err)
+		}
+	}
+	if calls() != 3 {
+		t.Errorf("MCP ran %d times, want 3", calls())
+	}
+	for _, ev := range readLoggedEvents(t, rec) {
+		if ev.Outcome == AuditOutcomeThrottled {
+			t.Errorf("a call inside the budget was logged as throttled: %+v", ev)
+		}
+	}
+}
+
+// The core interdiction. Asserting the third call returned an error is not
+// enough: a refusal that happens after the tool ran has read the mailbox it was
+// refusing to let anyone read, so the invocation count is the real assertion.
+func TestEnrolmentBudget_RateRefusalIsThrottledAndTheMcpNeverRuns(t *testing.T) {
+	mock, calls := countingMock(budgetResult)
+	r, rec, _ := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {WindowSeconds: 60, MaxCalls: 2, MaxResultBytes: 1 << 20},
+	})
+
+	ctx := budgetCtx("hermes-mail")
+	for i := 0; i < 2; i++ {
+		if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err != nil {
+			t.Fatalf("call %d inside the budget was refused: %v", i+1, err)
+		}
+	}
+	result, err := r.CallTool(ctx, "mail_search", nil, testToken)
+	if err == nil {
+		t.Fatalf("the call over the rate budget succeeded, returned %s", result)
+	}
+	if !strings.Contains(err.Error(), "throttled") {
+		t.Errorf("refusal should name the reason, got: %v", err)
+	}
+	if calls() != 2 {
+		t.Errorf("MCP ran %d times; a throttled call must never reach it", calls())
+	}
+
+	ev := lastEvent(t, rec)
+	if ev.Outcome != AuditOutcomeThrottled {
+		t.Errorf("outcome = %q, want %q — throttled is the only outcome that says the grant was legitimate and the use was not",
+			ev.Outcome, AuditOutcomeThrottled)
+	}
+	// No MCP was reached, so there is no side effect for an intent record to
+	// bracket: the refusal is one record, like a denial.
+	if ev.Phase != "" {
+		t.Errorf("phase = %q, want a single standalone record", ev.Phase)
+	}
+	if ev.Actor.Kind != AuditActorRemote || ev.Actor.ClientID != "hermes-mail" {
+		t.Errorf("refusal is not attributable: kind=%q client=%q", ev.Actor.Kind, ev.Actor.ClientID)
+	}
+	if ev.Actor.ProjectID != "test-project" {
+		t.Errorf("refusal lost the project grant: %q", ev.Actor.ProjectID)
+	}
+	if ev.Tool != "mail_search" {
+		t.Errorf("refusal lost the tool name: %q", ev.Tool)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Volume
+// ---------------------------------------------------------------------------
+
+// Volume is accounted after the fact, because a result's size is not knowable
+// before the MCP answers. The call that crosses the cap therefore COMPLETES and
+// the next one is refused. This test asserts exactly that, rather than a
+// guarantee the design cannot make.
+func TestEnrolmentBudget_VolumeOverrunRefusesTheNextCall(t *testing.T) {
+	mock, calls := countingMock(budgetResult)
+	// Half a result's worth: the very first call overshoots.
+	r, rec, _ := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {WindowSeconds: 60, MaxCalls: 100, MaxResultBytes: int64(len(budgetResult) / 2)},
+	})
+
+	ctx := budgetCtx("hermes-mail")
+	if _, err := r.CallTool(ctx, "mail_get_emails", nil, testToken); err != nil {
+		t.Fatalf("the first call must complete — its size was not knowable in advance: %v", err)
+	}
+	if got := drawn(&r.budgets, "hermes-mail"); got != int64(len(budgetResult)) {
+		t.Errorf("charged %d bytes, want %d (the same quantity the audit log records as ResultBytes)",
+			got, len(budgetResult))
+	}
+
+	if _, err := r.CallTool(ctx, "mail_get_emails", nil, testToken); err == nil {
+		t.Fatal("the call after the volume budget was spent succeeded")
+	} else if !strings.Contains(err.Error(), "result bytes") {
+		t.Errorf("refusal should name the volume budget, got: %v", err)
+	}
+	if calls() != 1 {
+		t.Errorf("MCP ran %d times, want 1: the second call must be refused before it", calls())
+	}
+	if ev := lastEvent(t, rec); ev.Outcome != AuditOutcomeThrottled {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, AuditOutcomeThrottled)
+	}
+}
+
+// Rate alone does not stop a slow drain: with a generous call cap and a mean
+// byte cap, a client that paces itself is still cut off.
+func TestEnrolmentBudget_VolumeBindsEvenWhenTheRateIsFine(t *testing.T) {
+	mock, calls := countingMock(budgetResult)
+	r, _, clk := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {WindowSeconds: 600, MaxCalls: 1000, MaxResultBytes: int64(2 * len(budgetResult))},
+	})
+
+	ctx := budgetCtx("hermes-mail")
+	refusedAt := 0
+	for i := 1; i <= 10; i++ {
+		if _, err := r.CallTool(ctx, "mail_get_emails", nil, testToken); err != nil {
+			refusedAt = i
+			break
+		}
+		// One call a minute: nowhere near the rate cap, and still refused.
+		clk.advance(time.Minute)
+	}
+	if refusedAt != 3 {
+		t.Errorf("slow drain was refused at call %d, want 3 (two results fill a two-result budget)", refusedAt)
+	}
+	if calls() != 2 {
+		t.Errorf("MCP ran %d times, want 2", calls())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The window is rolling, not a bucket that resets
+// ---------------------------------------------------------------------------
+
+// A fixed bucket hands an attacker 2x the budget by straddling the reset. This
+// test pins the rolling behaviour: allowance returns entry by entry as each
+// individual call ages out, not all at once on a boundary.
+func TestEnrolmentBudget_WindowRollsOverPerCall(t *testing.T) {
+	mock, _ := countingMock(budgetResult)
+	r, _, clk := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {WindowSeconds: 60, MaxCalls: 2, MaxResultBytes: 1 << 30},
+	})
+	ctx := budgetCtx("hermes-mail")
+
+	// t+0 and t+30 fill the window.
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	clk.advance(30 * time.Second)
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err == nil {
+		t.Fatal("third call inside a full window succeeded")
+	}
+
+	// Just short of the first call ageing out, it is still refused.
+	clk.advance(29 * time.Second)
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err == nil {
+		t.Fatal("allowance returned before the window had actually rolled")
+	}
+
+	// t+60: the first call has aged out, exactly one slot is free.
+	clk.advance(time.Second)
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err != nil {
+		t.Fatalf("call after the window rolled was refused: %v", err)
+	}
+	// ...and only one. A bucket that reset would have handed back both.
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err == nil {
+		t.Fatal("window reset as a fixed bucket: the whole budget came back at once")
+	}
+}
+
+// Volume ages out of the rolling window too, or a slow drain would be
+// permanently locked out by its first big result.
+func TestEnrolmentBudget_VolumeAgesOutOfTheWindow(t *testing.T) {
+	mock, _ := countingMock(budgetResult)
+	r, _, clk := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {WindowSeconds: 60, MaxCalls: 100, MaxResultBytes: int64(len(budgetResult))},
+	})
+	ctx := budgetCtx("hermes-mail")
+
+	if _, err := r.CallTool(ctx, "mail_get_emails", nil, testToken); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := r.CallTool(ctx, "mail_get_emails", nil, testToken); err == nil {
+		t.Fatal("second call ran with the volume budget already spent")
+	}
+	clk.advance(60 * time.Second)
+	if _, err := r.CallTool(ctx, "mail_get_emails", nil, testToken); err != nil {
+		t.Fatalf("volume did not age out of the window: %v", err)
+	}
+	if got := drawn(&r.budgets, "hermes-mail"); got != int64(len(budgetResult)) {
+		t.Errorf("window holds %d bytes after rollover, want only the fresh call's %d", got, len(budgetResult))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The enrolment is the unit
+// ---------------------------------------------------------------------------
+
+// Two agents sharing a grant have independent budgets: the enrolment is the
+// unit of compromise, so a compromised one must not be able to consume its
+// neighbour's allowance. A project-level cap would fail this test, which is the
+// point of it.
+func TestEnrolmentBudget_EnrolmentsAreIndependent(t *testing.T) {
+	mock, calls := countingMock(budgetResult)
+	r, _, _ := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail":   {WindowSeconds: 60, MaxCalls: 1, MaxResultBytes: int64(len(budgetResult))},
+		"hermes-triage": {WindowSeconds: 60, MaxCalls: 1, MaxResultBytes: int64(len(budgetResult))},
+	})
+
+	// One enrolment burns both of its limits to the floor.
+	if _, err := r.CallTool(budgetCtx("hermes-mail"), "mail_search", nil, testToken); err != nil {
+		t.Fatalf("first call for hermes-mail: %v", err)
+	}
+	if _, err := r.CallTool(budgetCtx("hermes-mail"), "mail_search", nil, testToken); err == nil {
+		t.Fatal("hermes-mail exceeded its own budget")
+	}
+
+	// Its neighbour, holding the same grant, is untouched.
+	if _, err := r.CallTool(budgetCtx("hermes-triage"), "mail_search", nil, testToken); err != nil {
+		t.Fatalf("one enrolment's exhaustion starved another sharing the grant: %v", err)
+	}
+	if got := drawn(&r.budgets, "hermes-triage"); got != int64(len(budgetResult)) {
+		t.Errorf("hermes-triage drew %d bytes, want only its own %d", got, len(budgetResult))
+	}
+	if calls() != 2 {
+		t.Errorf("MCP ran %d times, want 2 (one admitted call each)", calls())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Local callers are untouched
+// ---------------------------------------------------------------------------
+
+// No remote identity in the context means no budget, no accounting, and no
+// ledger entry — one context lookup and nothing else. Budgets bound a remote
+// enrolment's blast radius; applying them to the local tray would be a
+// throttle on the machine's own owner.
+func TestEnrolmentBudget_LocalCallsAreUnbudgeted(t *testing.T) {
+	mock, calls := countingMock(budgetResult)
+	// A budget so tight that any accounting at all would refuse the second call.
+	r, rec, _ := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {WindowSeconds: 3600, MaxCalls: 1, MaxResultBytes: 1},
+	})
+
+	for i := 0; i < 20; i++ {
+		if _, err := r.CallTool(context.Background(), "mail_search", nil, testToken); err != nil {
+			t.Fatalf("local call %d was budgeted: %v", i+1, err)
+		}
+	}
+	if calls() != 20 {
+		t.Errorf("MCP ran %d times, want 20", calls())
+	}
+	if n := windowCount(&r.budgets); n != 0 {
+		t.Errorf("local calls created %d ledger entries; they must not be accounted at all", n)
+	}
+	for _, ev := range readLoggedEvents(t, rec) {
+		if ev.Outcome == AuditOutcomeThrottled {
+			t.Fatalf("a local call was throttled: %+v", ev)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Zero and absent budgets never read as unlimited
+// ---------------------------------------------------------------------------
+
+func TestEnrolmentBudget_ZeroAndAbsentResolveToDefaults(t *testing.T) {
+	s := makeSettings(nil, nil, nil)
+	s.Enrolments = append(s.Enrolments, Enrolment{
+		ClientID:    "hermes-mail",
+		Fingerprint: budgetFingerprint("hermes-mail"),
+		// Hand-edited settings.json with the budget key stripped.
+		Budget: EnrolmentBudget{},
+	})
+	want := normalizeEnrolmentBudget(EnrolmentBudget{})
+
+	known := bridge.RemoteCaller{ClientID: "hermes-mail", Fingerprint: budgetFingerprint("hermes-mail")}
+	if got := s.enrolmentBudget(known); got != want {
+		t.Errorf("a zero stored budget resolved to %+v, want the conservative defaults %+v", got, want)
+	}
+	// Unreachable in practice — the listener closes a connection whose
+	// certificate resolves to nothing — which is exactly why it must fail
+	// closed rather than exempt.
+	unknown := bridge.RemoteCaller{ClientID: "stranger", Fingerprint: budgetFingerprint("stranger")}
+	if got := s.enrolmentBudget(unknown); got != want {
+		t.Errorf("an unresolved fingerprint resolved to %+v, want the conservative defaults %+v", got, want)
+	}
+	var nilSettings *Settings
+	if got := nilSettings.enrolmentBudget(known); got != want {
+		t.Errorf("nil settings resolved to %+v, want the conservative defaults %+v", got, want)
+	}
+}
+
+// The end-to-end half of the same property: a stored zero budget throttles at
+// the default, rather than never.
+func TestEnrolmentBudget_ZeroBudgetStillThrottles(t *testing.T) {
+	mock, calls := countingMock(budgetResult)
+	r, _, _ := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		"hermes-mail": {},
+	})
+
+	ctx := budgetCtx("hermes-mail")
+	for i := 1; i <= defaultEnrolmentMaxCalls; i++ {
+		if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err != nil {
+			t.Fatalf("call %d of the default allowance was refused: %v", i, err)
+		}
+	}
+	if _, err := r.CallTool(ctx, "mail_search", nil, testToken); err == nil {
+		t.Fatalf("a zero budget read as unlimited: %d calls all succeeded", defaultEnrolmentMaxCalls+1)
+	}
+	if calls() != defaultEnrolmentMaxCalls {
+		t.Errorf("MCP ran %d times, want %d", calls(), defaultEnrolmentMaxCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+// Several connections from one enrolment can call at once, and the cap has to
+// hold across all of them: accounting that is per-goroutine is not a cap. Run
+// under -race, which is where a ledger built out of an unguarded map or a
+// read-modify-write on a counter shows up.
+func TestEnrolmentBudget_ConcurrentCallsAccountExactly(t *testing.T) {
+	const (
+		maxCalls  = 20
+		attempts  = 60
+		clientID  = "hermes-mail"
+		perResult = len(budgetResult)
+	)
+	mock, calls := countingMock(budgetResult)
+	r, _, _ := budgetRouter(t, mock, map[string]EnrolmentBudget{
+		clientID: {WindowSeconds: 3600, MaxCalls: maxCalls, MaxResultBytes: 1 << 30},
+	})
+
+	ctx := budgetCtx(clientID)
+	var wg sync.WaitGroup
+	results := make([]error, attempts)
+	start := make(chan struct{})
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := r.CallTool(ctx, "mail_search", nil, testToken)
+			results[i] = err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	admitted, throttled := 0, 0
+	for _, err := range results {
+		switch {
+		case err == nil:
+			admitted++
+		case strings.Contains(err.Error(), "throttled"):
+			throttled++
+		default:
+			t.Fatalf("unexpected error from a concurrent call: %v", err)
+		}
+	}
+	if admitted != maxCalls {
+		t.Errorf("%d of %d concurrent calls were admitted, want exactly %d", admitted, attempts, maxCalls)
+	}
+	if throttled != attempts-maxCalls {
+		t.Errorf("%d calls were throttled, want %d", throttled, attempts-maxCalls)
+	}
+	if calls() != maxCalls {
+		t.Errorf("MCP ran %d times, want %d", calls(), maxCalls)
+	}
+	if got, want := drawn(&r.budgets, clientID), int64(maxCalls*perResult); got != want {
+		t.Errorf("ledger holds %d bytes after concurrent calls, want %d", got, want)
+	}
+}
+
+// Concurrent traffic from many enrolments must stay independent — and must not
+// serialise behind one another, which is what the per-enrolment lock buys.
+func TestEnrolmentBudget_ConcurrentEnrolmentsStayIndependent(t *testing.T) {
+	const enrolments = 8
+	mock, calls := countingMock(budgetResult)
+
+	budgets := map[string]EnrolmentBudget{}
+	for i := 0; i < enrolments; i++ {
+		budgets[fmt.Sprintf("agent-%d", i)] = EnrolmentBudget{WindowSeconds: 3600, MaxCalls: 2, MaxResultBytes: 1 << 30}
+	}
+	r, _, _ := budgetRouter(t, mock, budgets)
+
+	var wg sync.WaitGroup
+	errs := make([]error, enrolments*4)
+	for i := 0; i < enrolments; i++ {
+		ctx := budgetCtx(fmt.Sprintf("agent-%d", i))
+		for j := 0; j < 4; j++ {
+			wg.Add(1)
+			go func(slot int) {
+				defer wg.Done()
+				_, err := r.CallTool(ctx, "mail_search", nil, testToken)
+				errs[slot] = err
+			}(i*4 + j)
+		}
+	}
+	wg.Wait()
+
+	admitted := 0
+	for _, err := range errs {
+		if err == nil {
+			admitted++
+		}
+	}
+	// Every enrolment gets its own two, no more and no fewer.
+	if admitted != enrolments*2 {
+		t.Errorf("%d calls admitted across %d enrolments, want %d", admitted, enrolments, enrolments*2)
+	}
+	if calls() != enrolments*2 {
+		t.Errorf("MCP ran %d times, want %d", calls(), enrolments*2)
+	}
+	if n := windowCount(&r.budgets); n != enrolments {
+		t.Errorf("ledger tracks %d enrolments, want %d", n, enrolments)
+	}
+}

--- a/remote_server.go
+++ b/remote_server.go
@@ -1,0 +1,612 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"slices"
+	"sync"
+	"time"
+
+	"relaygo/bridge"
+	"relaygo/jsonrpc"
+)
+
+// RemoteServer is the listener a client on another machine reaches relay
+// through (ADR-010 decisions 1, 2, 4 and 9). It sits BESIDE BridgeServer and
+// never wraps or replaces it: the Unix socket keeps its ten request types and
+// its local trust model untouched, and this listener has two request types and
+// a completely different one.
+//
+// The three properties that make it a different listener rather than a flag on
+// the old one:
+//
+//   - Its dispatch table holds exactly ListTools and CallTool. The other eight
+//     bridge request types are not refused by a check — there is no code path
+//     from here to ResolvePtyEnv or RegisterManifest at all. A new admin op is
+//     unreachable from a VM until someone deliberately adds it to a two-entry
+//     list that is visibly a security boundary (decision 1).
+//   - Identity comes from a client certificate resolved to an enrolment BEFORE
+//     any request is read, so an unenrolled caller cannot probe (decision 2).
+//   - The wire has no field to authenticate with, and unknown fields are an
+//     error rather than a shrug (decision 4).
+
+// defaultRemoteListen binds loopback deliberately. Misconfiguration must not
+// expose the control plane to a LAN, and same-machine development must need no
+// configuration at all — a remote project is reachable from 127.0.0.1 exactly
+// as it is from another machine, because remoteness is a property of the
+// grant's shape and not of the caller's location. Reaching relay from a VM is
+// then a deliberate act (widening this address, or running a tunnel) rather
+// than something that happens by leaving a field unset (decision 9).
+const defaultRemoteListen = "127.0.0.1:9910"
+
+var (
+	// remoteHandshakeTimeout bounds the time between a TCP accept and a
+	// completed TLS handshake. This is the actual slowloris bound: a peer that
+	// connects and never speaks holds a goroutine and an fd until it expires.
+	// BridgeServer needs no equivalent because its peer is same-user behind a
+	// 0600 socket.
+	remoteHandshakeTimeout = 15 * time.Second
+
+	// remoteIdleTimeout bounds SILENCE on an established connection, never work
+	// in progress: FrameConn pushes the deadline out on every frame read and
+	// every frame written, so a tool call that legitimately runs for an hour
+	// while streaming progress is untouched, and one that runs for an hour in
+	// silence still gets its response written (the write refreshes the deadline
+	// before it happens). What this does cut off is a connection nobody is
+	// using — a compromised agent parking sockets, or a peer that vanished
+	// without a FIN.
+	//
+	// Vars rather than consts so tests can shorten them.
+	remoteIdleTimeout = 5 * time.Minute
+)
+
+// ---------------------------------------------------------------------------
+// Configuration (decision 9)
+// ---------------------------------------------------------------------------
+
+// RemoteConfig is the "remote" block in settings.json:
+//
+//	"remote": {
+//	  "enabled": true,
+//	  "listen": "127.0.0.1:9910"
+//	}
+//
+// Absent block means NO LISTENER AT ALL — not a listener bound to nothing, not
+// a listener that refuses every call. Nothing is opened, so an install that
+// never enrolled a client has no network surface to reason about.
+//
+// Enabled is a *bool for the same reason AuditConfig's is: absent, false and
+// true have to stay distinguishable. They differ in what absent MEANS, and the
+// difference is deliberate. Auditing defaults on because a missing block on an
+// old install should keep recording; a network listener defaults OFF, so a
+// block that names a listen address but forgets `enabled` opens nothing and
+// says so in the log. Starting a listener nobody asked for is the failure mode
+// this whole ADR exists to avoid, and "the operator clearly meant it" is not a
+// good enough reason to guess.
+type RemoteConfig struct {
+	Enabled *bool  `json:"enabled,omitempty"`
+	Listen  string `json:"listen,omitempty"`
+}
+
+// resolvedRemoteConfig is RemoteConfig with defaults applied.
+type resolvedRemoteConfig struct {
+	Enabled bool
+	Listen  string
+}
+
+// resolve applies decision 9's defaults. Nil-safe: an absent block resolves to
+// disabled, which is the whole of "disabled unless configured".
+func (c *RemoteConfig) resolve() resolvedRemoteConfig {
+	if c == nil {
+		return resolvedRemoteConfig{Enabled: false, Listen: defaultRemoteListen}
+	}
+	out := resolvedRemoteConfig{
+		Enabled: boolOr(c.Enabled, false),
+		Listen:  c.Listen,
+	}
+	if out.Listen == "" {
+		out.Listen = defaultRemoteListen
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// The narrow router surface
+// ---------------------------------------------------------------------------
+
+// RemoteToolRouter is the ENTIRE router surface a remote connection can reach.
+// It is a separate, two-method interface rather than bridge.ToolRouter so that
+// the narrowing is a compile-time property: this file cannot call
+// ResolvePtyEnv even by accident, because it does not hold anything that has
+// the method. *appRouter satisfies it.
+type RemoteToolRouter interface {
+	ListTools(ctx context.Context, token string) (json.RawMessage, error)
+	CallTool(ctx context.Context, name string, args json.RawMessage, token string) (json.RawMessage, error)
+}
+
+var _ RemoteToolRouter = (*appRouter)(nil)
+
+// remoteHandler handles one remote request. token is the internal project
+// token RemoteServer resolved from the enrolment's grant — see resolveGrant
+// for why it is a server-side implementation detail rather than a credential
+// the client holds.
+type remoteHandler func(ctx context.Context, req *bridge.RemoteRequest, router RemoteToolRouter, token string) bridge.BridgeResponse
+
+// remoteHandlers is the dispatch table decision 1 is about. It has two
+// entries. Adding a third is a deliberate act with its own review, not a
+// discovery that something already worked: nothing here falls through to
+// bridgeHandlers, and no request type outside this map reaches any router
+// method at all.
+var remoteHandlers = map[string]remoteHandler{
+	bridge.ReqListTools: handleRemoteListTools,
+	bridge.ReqCallTool:  handleRemoteCallTool,
+}
+
+func handleRemoteListTools(ctx context.Context, _ *bridge.RemoteRequest, router RemoteToolRouter, token string) bridge.BridgeResponse {
+	tools, err := router.ListTools(ctx, token)
+	if err != nil {
+		return bridge.ErrorResponse(bridge.ErrorCode(err), err.Error())
+	}
+	return bridge.BridgeResponse{Type: bridge.RespTools, Tools: tools}
+}
+
+func handleRemoteCallTool(ctx context.Context, req *bridge.RemoteRequest, router RemoteToolRouter, token string) bridge.BridgeResponse {
+	result, err := router.CallTool(ctx, req.Name, req.Arguments, token)
+	if err != nil {
+		return bridge.ErrorResponse(bridge.ErrorCode(err), err.Error())
+	}
+	return bridge.BridgeResponse{Type: bridge.RespResult, Result: result}
+}
+
+// ---------------------------------------------------------------------------
+// The listener
+// ---------------------------------------------------------------------------
+
+// RemoteServer is the mTLS listener. A nil *RemoteServer is a valid "no
+// listener configured" value and every method tolerates it, so the tray wires
+// it in unconditionally and the disabled case needs no branch at the call
+// sites.
+type RemoteServer struct {
+	router RemoteToolRouter
+	store  SettingsStore
+	// audit is held only to re-assert that recording is live. RemoteServer
+	// never writes an event itself — that happens at appRouter.CallTool, the
+	// chokepoint every transport funnels through.
+	audit    *AuditRecorder
+	listener net.Listener
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+
+	// conns is the connection table revocation acts on, keyed by certificate
+	// fingerprint — the enrolment's identity, and the value the revocation hook
+	// hands us. Keyed by fingerprint rather than by client id because the
+	// fingerprint is what the connection itself proved; a client id is a label
+	// on a record that has, by the time the hook fires, already been deleted.
+	mu    sync.Mutex
+	conns map[string]map[*remoteConn]struct{}
+}
+
+// remoteConn is one live, authenticated connection.
+type remoteConn struct {
+	conn        net.Conn
+	clientID    string
+	fingerprint string
+}
+
+// NewRemoteServer binds the remote listener, or returns (nil, nil) when no
+// listener is configured.
+//
+// Three refusals live here rather than deeper in, because a listener that is
+// open but cannot serve safely is worse than one that never opened: it answers
+// a TCP connect, it accepts a handshake, and it teaches an operator that the
+// port is fine.
+//
+//   - Not configured → no listener at all (decision 9).
+//   - Auditing disabled → REFUSED, loudly. The case for letting a VM reach host
+//     mail rests entirely on detection: ADR-009's threat model is exfiltration,
+//     and ADR-010 decision 5 pays availability for evidence. Remove the
+//     evidence and the justification for the whole feature goes with it. Local
+//     tooling is unaffected — this refusal is scoped to this listener and
+//     nothing else consults it.
+//   - No CA, or no server certificate → refused, since there is no meaningful
+//     degraded mode for mutual TLS.
+func NewRemoteServer(ctx context.Context, store SettingsStore, router RemoteToolRouter, audit *AuditRecorder) (*RemoteServer, error) {
+	cfg := store.Get().Remote.resolve()
+	if !cfg.Enabled {
+		slog.Debug("remote listener not enabled; no socket opened")
+		return nil, nil
+	}
+
+	if !audit.Enabled() {
+		return nil, fmt.Errorf("remote listener refuses to start while the tool-call audit log is disabled: " +
+			"a remote grant is justified by the calls it records, so serving remote traffic unrecorded is not a degraded mode — " +
+			"set audit.enabled to true, or remove the remote block from settings.json")
+	}
+
+	ca, err := LoadOrCreateCA()
+	if err != nil {
+		return nil, fmt.Errorf("remote listener: %w", err)
+	}
+	// Issued per process start rather than persisted: the client verifies it
+	// against the CA certificate in its bundle, so rotation costs the client
+	// nothing and the host keeps one fewer private key on disk.
+	cert, err := ca.IssueServerCert(remoteCertHosts(cfg.Listen)...)
+	if err != nil {
+		return nil, fmt.Errorf("remote listener: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		// The certificate IS the identity, so a handshake that did not prove
+		// one is not a connection worth having. RequireAndVerifyClientCert
+		// against relay's own pool means nothing signed by any other authority
+		// — public CA included — can complete a handshake here.
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  ca.Pool(),
+		// Both ends are ours and the CA is ours, so there is no legacy peer to
+		// accommodate and no reason to offer anything older.
+		MinVersion: tls.VersionTLS13,
+	}
+
+	ln, err := tls.Listen("tcp", cfg.Listen, tlsCfg)
+	if err != nil {
+		return nil, fmt.Errorf("remote listener: listen on %s: %w", cfg.Listen, err)
+	}
+
+	sctx, cancel := context.WithCancel(ctx)
+	s := &RemoteServer{
+		router:   router,
+		store:    store,
+		audit:    audit,
+		listener: ln,
+		ctx:      sctx,
+		cancel:   cancel,
+		conns:    map[string]map[*remoteConn]struct{}{},
+	}
+
+	// Revocation must sever live connections, not merely take effect on the
+	// next one: this protocol holds persistent connections in a scanner loop,
+	// so a compromised agent that never reconnects would otherwise keep working
+	// indefinitely (decision 8). The enrolment code deletes the record and
+	// fires this hook; closing the socket is ours because the connection table
+	// is ours.
+	SetEnrolmentRevocationHook(s.closeEnrolment)
+
+	slog.Info("remote listener started", "addr", ln.Addr().String())
+	return s, nil
+}
+
+// remoteCertHosts returns the SANs the server certificate must carry for a
+// client to verify a connection to the configured listen address.
+//
+// Loopback is always included: it is the default bind and the address
+// same-machine development uses. A wildcard bind cannot be enumerated — relay
+// has no way to know which of the host's addresses a client will name — so an
+// operator who binds one deliberately names the reachable address in `listen`
+// and gets a SAN for it, while `0.0.0.0` alone gets loopback only and a client
+// dialling a LAN address sees a verification failure rather than an
+// unauthenticated tunnel.
+func remoteCertHosts(listen string) []string {
+	hosts := []string{"127.0.0.1", "::1", "localhost"}
+	host, _, err := net.SplitHostPort(listen)
+	if err != nil || host == "" {
+		return hosts
+	}
+	if host == "0.0.0.0" || host == "::" || slices.Contains(hosts, host) {
+		return hosts
+	}
+	return append(hosts, host)
+}
+
+// Addr returns the address the listener actually bound, which is what a test
+// binding :0 needs and what an operator reading the log wants. "" when there
+// is no listener.
+func (s *RemoteServer) Addr() string {
+	if s == nil {
+		return ""
+	}
+	return s.listener.Addr().String()
+}
+
+// Serve accepts connections until the listener is closed. Mirrors
+// BridgeServer.Serve.
+func (s *RemoteServer) Serve() error {
+	if s == nil {
+		return nil
+	}
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return err
+		}
+		s.wg.Add(1)
+		go s.handleConn(conn)
+	}
+}
+
+// StopAccepting closes the listener and cancels in-flight request contexts,
+// the first phase of the same two-phase shutdown BridgeServer uses.
+func (s *RemoteServer) StopAccepting() {
+	if s == nil {
+		return
+	}
+	s.cancel()
+	_ = s.listener.Close()
+}
+
+// Close completes shutdown: stops accepting, uninstalls the revocation hook,
+// and drains the connection handlers. There is no socket file to unlink.
+func (s *RemoteServer) Close() {
+	if s == nil {
+		return
+	}
+	s.StopAccepting()
+	// Drop the hook before draining: a revocation arriving mid-shutdown has
+	// nothing left to close, and leaving a closure over a dead server installed
+	// in a process-global would keep it reachable after teardown.
+	SetEnrolmentRevocationHook(nil)
+	s.wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Connection handling
+// ---------------------------------------------------------------------------
+
+// handleConn resolves the certificate to an enrolment and only then reads
+// anything. The ordering is decision 2's requirement and not an optimisation:
+// a connection whose certificate does not resolve is closed WITHOUT PROCESSING
+// A REQUEST, so an unenrolled caller — even one holding a certificate relay
+// itself signed for an enrolment since revoked — cannot probe for valid grants,
+// valid tool names, or the shape of an error.
+func (s *RemoteServer) handleConn(conn net.Conn) {
+	defer s.wg.Done()
+	defer conn.Close()
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("remote handler panic (recovered)", "panic", r)
+		}
+	}()
+
+	// connCtx is the connection's lifetime; the request context derived from it
+	// further down carries the caller identity. Two names rather than one
+	// reassigned variable, because the watchdog goroutine below reads it
+	// concurrently and rebinding a captured variable under it is a race.
+	connCtx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+	// Close the connection when this handler or the server is cancelled, so a
+	// handler parked in Scan() unblocks at shutdown. Same reasoning as
+	// BridgeServer's; here it is also what makes revocation's Close() take
+	// effect promptly.
+	go func() {
+		<-connCtx.Done()
+		_ = conn.Close()
+	}()
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		// Unreachable: the listener is tls.Listen. Refuse rather than fall
+		// through to a plaintext path that must never exist.
+		slog.Error("remote: non-TLS connection on the remote listener; closing")
+		return
+	}
+
+	// Handshake explicitly, under its own deadline, so the identity below is
+	// resolved before any read and a peer that never speaks cannot camp.
+	_ = conn.SetDeadline(time.Now().Add(remoteHandshakeTimeout))
+	if err := tlsConn.HandshakeContext(connCtx); err != nil {
+		slog.Warn("remote: TLS handshake failed", "remote_addr", conn.RemoteAddr().String(), "error", err)
+		return
+	}
+
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		// Unreachable under RequireAndVerifyClientCert; kept because the
+		// consequence of it ever becoming reachable is an unidentified caller.
+		slog.Warn("remote: handshake completed with no peer certificate; closing", "remote_addr", conn.RemoteAddr().String())
+		return
+	}
+
+	fingerprint := FingerprintCert(state.PeerCertificates[0])
+	enrolment := s.store.Get().FindEnrolmentByFingerprint(fingerprint)
+	if enrolment == nil {
+		// A CA-signed certificate that no enrolment claims. This is the state a
+		// revoked client is in, and it gets no request read and no error frame
+		// — the disconnect tells it nothing it did not already know.
+		slog.Warn("remote: closing connection, certificate is not enrolled",
+			"fingerprint", fingerprint, "remote_addr", conn.RemoteAddr().String())
+		return
+	}
+
+	// Belt and braces against a window the start-up refusal cannot cover: the
+	// recorder could have been closed under us. There must be no path on which
+	// a remote call runs unrecorded.
+	if !s.audit.Enabled() {
+		slog.Error("remote: closing connection, auditing is not active",
+			"client_id", enrolment.ClientID, "remote_addr", conn.RemoteAddr().String())
+		return
+	}
+
+	// This is the value that puts every call on this connection onto the
+	// fail-closed audit path, and every field in it is derived from the
+	// connection rather than asserted by the caller (decision 6). Called once
+	// per connection because none of it can change while the socket is open.
+	ctx := bridge.WithRemoteCaller(connCtx, bridge.RemoteCaller{
+		ClientID:    enrolment.ClientID,
+		Fingerprint: fingerprint,
+		RemoteAddr:  conn.RemoteAddr().String(),
+	})
+
+	rc := &remoteConn{conn: conn, clientID: enrolment.ClientID, fingerprint: fingerprint}
+	s.track(rc)
+	defer s.untrack(rc)
+
+	slog.Info("remote client connected", "client_id", enrolment.ClientID, "remote_addr", conn.RemoteAddr().String())
+
+	bridge.NewFrameConn(conn, "remote", remoteIdleTimeout).
+		Serve(ctx, func(ctx context.Context, line string) bridge.BridgeResponse {
+			return s.handleRequest(ctx, fingerprint, line)
+		})
+}
+
+// handleRequest decodes one frame and dispatches it. Every refusal here
+// happens before the router is touched.
+func (s *RemoteServer) handleRequest(ctx context.Context, fingerprint, line string) bridge.BridgeResponse {
+	req, err := bridge.DecodeRemoteRequest([]byte(line))
+	if err != nil {
+		// Strict decoding means a client sending `cwd` (or `token`) lands
+		// here — loudly — rather than having the field ignored and believing
+		// it authenticated by something it did not (decision 4).
+		return bridge.ErrorResponse(jsonrpc.CodeInvalidParams, "remote request: "+err.Error())
+	}
+
+	h, ok := remoteHandlers[req.Type]
+	if !ok {
+		// Not a refusal by policy check: the type simply has no handler on this
+		// listener. ResolvePtyEnv and friends are unreachable here in the same
+		// way "Frobnicate" is.
+		slog.Warn("remote: request type is not available on the remote listener", "type", req.Type)
+		return bridge.ErrorResponse(jsonrpc.CodeMethodNotFound,
+			"request type is not available to remote clients: "+req.Type)
+	}
+
+	token, err := s.resolveGrant(fingerprint, req.ProjectID)
+	if err != nil {
+		return bridge.ErrorResponse(bridge.ErrorCode(err), err.Error())
+	}
+
+	return h(ctx, req, s.router, token)
+}
+
+// resolveGrant turns "this certificate, that project id" into the internal
+// project token appRouter.CallTool expects, refusing anything that does not
+// resolve cleanly. This is the chain the whole design rests on, so each link
+// is spelled out:
+//
+//  1. Re-resolve the ENROLMENT from current settings on every request, not
+//     once per connection. A revocation that raced the connection table, or a
+//     grant edited while the socket stayed open, must take effect on the next
+//     call rather than at the next reconnect.
+//  2. Select the project id. An enrolment holding exactly one grant may leave
+//     it off — sending it would be ceremony. An enrolment holding several must
+//     say which, because guessing would make the choice relay's rather than
+//     the caller's.
+//  3. Honour the id only if the enrolment HOLDS that grant. The id is not a
+//     secret and is not treated as one; it selects among grants, it never
+//     confers one.
+//  4. Re-check IsRemote() immediately before dispatch (decision 3, point 3).
+//     Enrolment-time and conversion-time validation already cover the paths
+//     relay anticipated; this covers the ones it did not — a hand-edited
+//     settings.json, a mutator called directly, a future code path nobody has
+//     written yet. IsRemote(), never a Kind comparison: the zero value is
+//     local and must stay unreadable as remote.
+//  5. Resolve the token SERVER-SIDE. It is never on the wire, never in a
+//     response, and never leaves the host; it is how this listener calls the
+//     existing router, not a credential the client holds. That is exactly why
+//     decision 2 could delete the token from the remote path without changing
+//     anything below the transport.
+func (s *RemoteServer) resolveGrant(fingerprint, projectID string) (string, error) {
+	settings := s.store.Get()
+
+	enrolment := settings.FindEnrolmentByFingerprint(fingerprint)
+	if enrolment == nil {
+		return "", jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized,
+			fmt.Errorf("this certificate is no longer enrolled"))
+	}
+
+	if projectID == "" {
+		switch len(enrolment.ProjectIDs) {
+		case 0:
+			return "", jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized,
+				fmt.Errorf("enrolment %q holds no grants", enrolment.ClientID))
+		case 1:
+			projectID = enrolment.ProjectIDs[0]
+		default:
+			return "", jsonrpc.NewCodedError(jsonrpc.CodeInvalidParams,
+				fmt.Errorf("project_id is required: enrolment %q holds %d grants", enrolment.ClientID, len(enrolment.ProjectIDs)))
+		}
+	}
+
+	if !enrolment.GrantsProject(projectID) {
+		return "", jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized,
+			fmt.Errorf("enrolment %q does not grant project %q", enrolment.ClientID, projectID))
+	}
+
+	proj, _ := settings.findProjectByID(projectID)
+	if proj == nil {
+		return "", jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized,
+			fmt.Errorf("project %q no longer exists", projectID))
+	}
+	if !proj.IsRemote() {
+		return "", jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized,
+			fmt.Errorf("project %q is not a remote project: a grant that went stale is refused at call time rather than honoured", projectID))
+	}
+	if proj.Token == "" {
+		return "", jsonrpc.NewCodedError(jsonrpc.CodeInternalError,
+			fmt.Errorf("project %q has no token", projectID))
+	}
+	return proj.Token, nil
+}
+
+// ---------------------------------------------------------------------------
+// Connection table + revocation (decision 8)
+// ---------------------------------------------------------------------------
+
+func (s *RemoteServer) track(rc *remoteConn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	byFP := s.conns[rc.fingerprint]
+	if byFP == nil {
+		byFP = map[*remoteConn]struct{}{}
+		s.conns[rc.fingerprint] = byFP
+	}
+	byFP[rc] = struct{}{}
+}
+
+func (s *RemoteServer) untrack(rc *remoteConn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	byFP := s.conns[rc.fingerprint]
+	delete(byFP, rc)
+	if len(byFP) == 0 {
+		delete(s.conns, rc.fingerprint)
+	}
+}
+
+// closeEnrolment is the revocation hook: it severs every live connection
+// holding the revoked certificate.
+//
+// Deleting the record is only half of revocation. Connections here are
+// persistent and sit in a scanner loop, so a client that never reconnects
+// would keep calling tools with a credential the operator believes they
+// destroyed — for as long as the process lives. Closing the socket is what
+// makes "revoked" mean revoked now.
+//
+// Matching is on the fingerprint, which is what each connection proved. The
+// client id comes along for the log line, because the record it named is
+// already gone by the time this runs.
+func (s *RemoteServer) closeEnrolment(clientID, fingerprint string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	byFP := s.conns[fingerprint]
+	delete(s.conns, fingerprint)
+	victims := make([]*remoteConn, 0, len(byFP))
+	for rc := range byFP {
+		victims = append(victims, rc)
+	}
+	s.mu.Unlock()
+
+	for _, rc := range victims {
+		_ = rc.conn.Close()
+	}
+	if len(victims) > 0 {
+		slog.Warn("remote: closed live connections for revoked enrolment",
+			"client_id", clientID, "fingerprint", fingerprint, "connections", len(victims))
+	}
+}

--- a/remote_server_test.go
+++ b/remote_server_test.go
@@ -1,0 +1,752 @@
+package main
+
+// RemoteServer: the mTLS listener a client on another machine reaches relay
+// through (ADR-010 decisions 1, 2, 3-point-3, 4, 8 and 9).
+//
+// Every test here is hermetic and binds 127.0.0.1:0, reading the assigned port
+// back off the listener — a remote project is reachable from loopback exactly
+// as it is from another machine, because remoteness is a property of the
+// grant's shape and not of the caller's location, so the whole model is
+// exercised on one box with every guard live.
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"relaygo/bridge"
+	"relaygo/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+type remoteFixture struct {
+	t       *testing.T
+	dir     string
+	store   SettingsStore
+	router  *appRouter
+	audit   *AuditRecorder
+	server  *RemoteServer
+	project Project
+	bundle  *enrolmentBundle
+	// mcpCalls counts how many times a tool actually reached the (mock) MCP.
+	// Several tests assert on it being zero: a refusal that happens after the
+	// mailbox was read is not a refusal. Atomic because it is incremented on a
+	// connection-handler goroutine and read on the test's.
+	mcpCalls atomic.Int32
+}
+
+type remoteFixtureOpts struct {
+	// listen overrides the configured listen address. Empty means
+	// 127.0.0.1:0.
+	listen string
+	// noRemoteBlock omits the "remote" settings block entirely.
+	noRemoteBlock bool
+	// enabled, when non-nil, is written as remote.enabled verbatim; omitEnabled
+	// leaves the key out entirely, so a test can distinguish all three of
+	// absent / false / true.
+	enabled     *bool
+	omitEnabled bool
+	// disableAudit builds the router with no audit recorder at all, which is
+	// what audit.enabled:false produces (NewAuditRecorder returns nil).
+	disableAudit bool
+	// extraProjects creates additional remote projects the enrolment does not
+	// grant, so a test can widen or misname a grant.
+	extraProjects int
+	// skipServe leaves the server unstarted so a test can assert on
+	// construction alone.
+	skipServe bool
+}
+
+// newRemoteFixture builds a sandboxed relay install with one remote project,
+// one enrolment granting it, a mock MCP, and a started RemoteServer.
+func newRemoteFixture(t *testing.T, opts remoteFixtureOpts) *remoteFixture {
+	t.Helper()
+	dir := mkEmptySandboxRelayHome(t)
+	store := NewSettingsStoreAt(dir)
+	assertNoErr(t, store.EnsureInitialized(), "EnsureInitialized")
+
+	f := &remoteFixture{t: t, dir: dir, store: store}
+
+	listen := opts.listen
+	if listen == "" {
+		listen = "127.0.0.1:0"
+	}
+	enabled := opts.enabled
+	if enabled == nil && !opts.noRemoteBlock && !opts.omitEnabled {
+		enabled = ptr(true)
+	}
+
+	var createErr error
+	assertNoErr(t, store.With(func(s *Settings) {
+		s.ExternalMcps = append(s.ExternalMcps, ExternalMcp{ID: "macmcp", DisplayName: "macMCP"})
+		if !opts.noRemoteBlock {
+			s.Remote = &RemoteConfig{Enabled: enabled, Listen: listen}
+		}
+		f.project, createErr = s.CreateProjectWithTokenKind(
+			ProjectKindRemote, "Mail", "", []string{"macmcp"}, []string{}, nil, nil)
+		for i := 0; i < opts.extraProjects; i++ {
+			if _, err := s.CreateProjectWithTokenKind(
+				ProjectKindRemote, fmt.Sprintf("Extra %d", i), "", []string{"macmcp"}, []string{}, nil, nil); err != nil {
+				createErr = err
+			}
+		}
+	}), "seed settings")
+	assertNoErr(t, createErr, "create remote project")
+
+	mgr := NewExternalMcpManager(nil)
+	addMockConn(mgr, "macmcp", newMockConn("macmcp", simpleTools("mail_search"),
+		func(context.Context, string, interface{}) (json.RawMessage, error) {
+			f.mcpCalls.Add(1)
+			return json.RawMessage(`{"content":[{"type":"text","text":"3 messages"}]}`), nil
+		}))
+
+	if !opts.disableAudit {
+		f.audit = newTestAudit(t, nil)
+	}
+	f.router = &appRouter{
+		store:    store,
+		tools:    mgr,
+		services: &fakeServiceReloader{},
+		enhanced: NewEnhancedServiceRegistry(nil),
+		audit:    f.audit,
+	}
+
+	grants := []string{f.project.ID}
+	bundle, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail", ProjectIDs: grants})
+	assertNoErr(t, err, "createEnrolment")
+	f.bundle = bundle
+
+	if opts.skipServe {
+		return f
+	}
+	f.start()
+	return f
+}
+
+// start binds and serves, failing the test if construction refused.
+func (f *remoteFixture) start() {
+	f.t.Helper()
+	rs, err := NewRemoteServer(context.Background(), f.store, f.router, f.audit)
+	assertNoErr(f.t, err, "NewRemoteServer")
+	if rs == nil {
+		f.t.Fatal("NewRemoteServer returned no listener for an enabled remote block")
+	}
+	f.server = rs
+	go rs.Serve()
+	f.t.Cleanup(rs.Close)
+}
+
+// caPool returns a pool holding relay's CA — what a client verifies the server
+// with, exactly as shipped in an enrolment bundle.
+func (f *remoteFixture) caPool() *x509.CertPool {
+	f.t.Helper()
+	pem, err := os.ReadFile(f.bundle.CACertPath)
+	assertNoErr(f.t, err, "read ca.crt from bundle")
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		f.t.Fatal("bundle ca.crt is not a usable certificate")
+	}
+	return pool
+}
+
+// dial connects with the enrolled client's own bundle.
+func (f *remoteFixture) dial() *remoteTestClient {
+	f.t.Helper()
+	cert, err := tls.LoadX509KeyPair(f.bundle.CertPath, f.bundle.KeyPath)
+	assertNoErr(f.t, err, "load client keypair from bundle")
+	return f.dialWith(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      f.caPool(),
+	})
+}
+
+// dialWith connects with an arbitrary client TLS config. Returns nil when the
+// handshake itself failed, which is a legitimate outcome for several tests.
+func (f *remoteFixture) dialWith(cfg *tls.Config) *remoteTestClient {
+	f.t.Helper()
+	conn, err := tls.Dial("tcp", f.server.Addr(), cfg)
+	if err != nil {
+		return nil
+	}
+	f.t.Cleanup(func() { _ = conn.Close() })
+	return &remoteTestClient{t: f.t, conn: conn, scanner: bridge.NewScanner(conn)}
+}
+
+// remoteTestClient speaks the remote wire protocol by hand. Deliberately raw:
+// several tests send frames a typed client could not construct (a `cwd` field,
+// an admin request type), and those are precisely the frames that matter.
+type remoteTestClient struct {
+	t       *testing.T
+	conn    net.Conn
+	scanner *bufio.Scanner
+}
+
+func (c *remoteTestClient) sendRaw(line string) error {
+	c.t.Helper()
+	_ = c.conn.SetDeadline(time.Now().Add(10 * time.Second))
+	_, err := c.conn.Write([]byte(line + "\n"))
+	return err
+}
+
+// readFrame reads one response frame. The error is meaningful: a closed
+// connection is how this listener refuses a caller it will not talk to.
+func (c *remoteTestClient) readFrame() (bridge.BridgeResponse, error) {
+	c.t.Helper()
+	_ = c.conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if !c.scanner.Scan() {
+		if err := c.scanner.Err(); err != nil {
+			return bridge.BridgeResponse{}, err
+		}
+		return bridge.BridgeResponse{}, fmt.Errorf("connection closed without a response")
+	}
+	var resp bridge.BridgeResponse
+	if err := json.Unmarshal(c.scanner.Bytes(), &resp); err != nil {
+		return bridge.BridgeResponse{}, err
+	}
+	return resp, nil
+}
+
+// roundTrip sends a raw line and expects exactly one frame back.
+func (c *remoteTestClient) roundTrip(line string) bridge.BridgeResponse {
+	c.t.Helper()
+	if err := c.sendRaw(line); err != nil {
+		c.t.Fatalf("send %s: %v", line, err)
+	}
+	resp, err := c.readFrame()
+	if err != nil {
+		c.t.Fatalf("read response to %s: %v", line, err)
+	}
+	return resp
+}
+
+// ---------------------------------------------------------------------------
+// The happy path
+// ---------------------------------------------------------------------------
+
+// An enrolled client can do the two things this listener exists for, and its
+// identity on the audit record comes from the certificate rather than from
+// anything it sent.
+func TestRemoteServer_EnrolledClientListsToolsAndCallsTool(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+	if c == nil {
+		t.Fatal("enrolled client could not complete the handshake")
+	}
+
+	resp := c.roundTrip(`{"type":"ListTools"}`)
+	if resp.Type != bridge.RespTools {
+		t.Fatalf("ListTools returned %s: %s", resp.Type, resp.Message)
+	}
+	var tools []mcp.Tool
+	assertNoErr(t, json.Unmarshal(resp.Tools, &tools), "parse tools")
+	if len(tools) != 1 || tools[0].Name != "mail_search" {
+		t.Fatalf("tool list = %+v, want the one tool the grant allows", tools)
+	}
+
+	resp = c.roundTrip(`{"type":"CallTool","name":"mail_search","arguments":{"q":"invoice"}}`)
+	if resp.Type != bridge.RespResult {
+		t.Fatalf("CallTool returned %s: %s", resp.Type, resp.Message)
+	}
+	if !strings.Contains(string(resp.Result), "3 messages") {
+		t.Errorf("result did not come from the MCP: %s", resp.Result)
+	}
+	if f.mcpCalls.Load() != 1 {
+		t.Errorf("MCP was invoked %d times, want 1", f.mcpCalls.Load())
+	}
+
+	// The connection put the call on the fail-closed audit path with an
+	// attested identity — the whole point of resolving the certificate before
+	// the request.
+	events := readLoggedEvents(t, f.audit)
+	if len(events) == 0 {
+		t.Fatal("a remote tool call was not recorded at all")
+	}
+	last := events[len(events)-1]
+	if last.Actor.Kind != AuditActorRemote || last.Actor.ClientID != "hermes-mail" {
+		t.Errorf("actor = %+v, want the enrolled client attested from the certificate", last.Actor)
+	}
+	if last.Actor.Fingerprint != f.bundle.Enrolment.Fingerprint {
+		t.Errorf("fingerprint = %q, want the full enrolled fingerprint %q", last.Actor.Fingerprint, f.bundle.Enrolment.Fingerprint)
+	}
+	if last.Actor.ProjectID != f.project.ID {
+		t.Errorf("project = %q, want the granted project %q", last.Actor.ProjectID, f.project.ID)
+	}
+}
+
+// An enrolment holding exactly one grant may leave project_id off; holding
+// several, it must say which. Guessing would make the choice relay's.
+func TestRemoteServer_ProjectIDIsOptionalForOneGrantAndRequiredForSeveral(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{extraProjects: 1})
+
+	// Single grant: absent project_id defaults to it (asserted by the happy
+	// path above, repeated here as the baseline for the widening below).
+	if resp := f.dial().roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("single-grant ListTools without a project_id was refused: %s", resp.Message)
+	}
+
+	// Widen the enrolment to two grants without touching the certificate:
+	// capability and device revocation are independent.
+	var second string
+	assertNoErr(t, f.store.With(func(s *Settings) {
+		for _, p := range s.Projects {
+			if p.ID != f.project.ID {
+				second = p.ID
+			}
+		}
+		s.UpdateEnrolmentGrants("hermes-mail", []string{f.project.ID, second})
+	}), "widen grants")
+
+	c := f.dial()
+	resp := c.roundTrip(`{"type":"ListTools"}`)
+	if resp.Type != bridge.RespError || !strings.Contains(resp.Message, "project_id is required") {
+		t.Fatalf("two grants and no project_id returned %s/%q, want a refusal naming the ambiguity", resp.Type, resp.Message)
+	}
+	if resp = c.roundTrip(`{"type":"ListTools","project_id":"` + second + `"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("naming a held grant was refused: %s", resp.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Identity: resolved from the certificate before a request is read
+// ---------------------------------------------------------------------------
+
+// A certificate relay itself signed, for which no enrolment exists — the state
+// a revoked client is in. The connection must be closed WITHOUT a request being
+// processed, so an unenrolled caller cannot probe for valid grants, valid tool
+// names, or even the shape of an error.
+func TestRemoteServer_UnenrolledCertificateIsClosedWithoutReadingARequest(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+
+	ca, err := LoadOrCreateCA()
+	assertNoErr(t, err, "LoadOrCreateCA")
+	keyPEM, certPEM, _, err := ca.IssueClientCert("ghost")
+	assertNoErr(t, err, "IssueClientCert")
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	assertNoErr(t, err, "X509KeyPair")
+
+	c := f.dialWith(&tls.Config{Certificates: []tls.Certificate{cert}, RootCAs: f.caPool()})
+	if c == nil {
+		return // refused at the handshake — also acceptable, and stronger
+	}
+	// The write may succeed into a socket buffer; what must not happen is an
+	// answer.
+	_ = c.sendRaw(`{"type":"ListTools"}`)
+	if resp, err := c.readFrame(); err == nil {
+		t.Fatalf("an unenrolled certificate got a response: %s %s", resp.Type, resp.Message)
+	}
+	if f.mcpCalls.Load() != 0 {
+		t.Error("an unenrolled certificate reached an MCP")
+	}
+}
+
+// No certificate at all: mutual TLS is the door, and there is nothing behind it
+// for a caller who cannot prove an identity.
+func TestRemoteServer_ClientWithNoCertificateIsRejected(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+
+	c := f.dialWith(&tls.Config{RootCAs: f.caPool()})
+	if c == nil {
+		return // handshake refused outright
+	}
+	_ = c.sendRaw(`{"type":"ListTools"}`)
+	if resp, err := c.readFrame(); err == nil {
+		t.Fatalf("a client with no certificate got a response: %s %s", resp.Type, resp.Message)
+	}
+}
+
+// A certificate signed by some other authority must not complete a handshake:
+// ClientCAs holds relay's CA and nothing else.
+func TestRemoteServer_ForeignCertificateIsRejected(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+
+	// A second, unrelated CA — the same code path relay uses for its own,
+	// pointed at a different config dir.
+	otherDir := mkShortTempDir(t, "other-ca-")
+	otherCA, err := generateCA(otherDir+"/ca.key", otherDir+"/ca.crt")
+	assertNoErr(t, err, "generate foreign CA")
+	keyPEM, certPEM, _, err := otherCA.IssueClientCert("impostor")
+	assertNoErr(t, err, "issue foreign client cert")
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	assertNoErr(t, err, "X509KeyPair")
+
+	c := f.dialWith(&tls.Config{Certificates: []tls.Certificate{cert}, RootCAs: f.caPool()})
+	if c == nil {
+		return
+	}
+	_ = c.sendRaw(`{"type":"ListTools"}`)
+	if resp, err := c.readFrame(); err == nil {
+		t.Fatalf("a foreign-CA certificate got a response: %s %s", resp.Type, resp.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The wire has no field to authenticate with (decision 4)
+// ---------------------------------------------------------------------------
+
+// A `cwd` must be REJECTED, not ignored. Ignoring it would leave a client
+// believing it had authenticated by directory while it had in fact
+// authenticated by certificate — the two succeed identically today, so the
+// divergence would only surface later and in the confusing direction.
+func TestRemoteServer_CwdFieldIsRejectedRatherThanIgnored(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	resp := c.roundTrip(`{"type":"CallTool","name":"mail_search","cwd":"/Users/someone/project"}`)
+	if resp.Type != bridge.RespError {
+		t.Fatalf("a request carrying cwd was accepted: %s", resp.Type)
+	}
+	if !strings.Contains(resp.Message, "cwd") {
+		t.Errorf("the refusal does not name the offending field: %q", resp.Message)
+	}
+	if f.mcpCalls.Load() != 0 {
+		t.Error("a request carrying cwd still reached an MCP")
+	}
+}
+
+// Same for a token: there is no bearer secret anywhere on this path, and a
+// client that thinks otherwise should learn so at the door.
+func TestRemoteServer_TokenFieldIsRejected(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	resp := f.dial().roundTrip(`{"type":"ListTools","token":"` + f.project.Token + `"}`)
+	if resp.Type != bridge.RespError || !strings.Contains(resp.Message, "token") {
+		t.Fatalf("a request carrying a token returned %s/%q, want a refusal naming the field", resp.Type, resp.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The dispatch table has two entries (decision 1)
+// ---------------------------------------------------------------------------
+
+// The other eight bridge request types have NO code path from a remote
+// connection. This asserts the outcome; the structural guarantee is that
+// remoteHandlers has two entries and nothing falls through to bridgeHandlers.
+func TestRemoteServer_EveryNonToolRequestTypeIsUnreachable(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	for _, typ := range []string{
+		bridge.ReqResolvePtyEnv,
+		bridge.ReqRegisterManifest,
+		bridge.ReqListProjects,
+		bridge.ReqGetProject,
+		bridge.ReqResolveProjectTemplate,
+		bridge.ReqReconcileExternalMcps,
+		bridge.ReqReloadExternalMcp,
+		bridge.ReqReloadService,
+	} {
+		resp := c.roundTrip(`{"type":"` + typ + `"}`)
+		if resp.Type != bridge.RespError {
+			t.Errorf("%s was answered on the remote listener: %s", typ, resp.Type)
+			continue
+		}
+		if !strings.Contains(resp.Message, "not available to remote clients") {
+			t.Errorf("%s refused with an unexpected message: %q", typ, resp.Message)
+		}
+	}
+}
+
+// The two-entry table is the security boundary, so assert its size directly:
+// a third entry should have to be added deliberately, in a diff someone reads.
+func TestRemoteDispatchTable_HoldsExactlyListToolsAndCallTool(t *testing.T) {
+	if len(remoteHandlers) != 2 {
+		t.Fatalf("remote dispatch table has %d entries: %v", len(remoteHandlers), remoteHandlers)
+	}
+	for _, want := range []string{bridge.ReqListTools, bridge.ReqCallTool} {
+		if _, ok := remoteHandlers[want]; !ok {
+			t.Errorf("remote dispatch table is missing %s", want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Grants (decision 2) and the call-time re-check (decision 3, point 3)
+// ---------------------------------------------------------------------------
+
+// A project id is not a secret and confers nothing: naming one the enrolment
+// does not hold is a refusal, not an escalation.
+func TestRemoteServer_RefusesAProjectTheEnrolmentDoesNotGrant(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+
+	// A second remote project exists but is granted to nobody.
+	var ungranted Project
+	var err error
+	assertNoErr(t, f.store.With(func(s *Settings) {
+		ungranted, err = s.CreateProjectWithTokenKind(ProjectKindRemote, "Calendar", "", []string{"macmcp"}, []string{}, nil, nil)
+	}), "create ungranted project")
+	assertNoErr(t, err, "create ungranted project")
+
+	resp := f.dial().roundTrip(`{"type":"CallTool","name":"mail_search","project_id":"` + ungranted.ID + `"}`)
+	if resp.Type != bridge.RespError {
+		t.Fatalf("a project the enrolment does not grant was honoured: %s", resp.Type)
+	}
+	if !strings.Contains(resp.Message, "does not grant") {
+		t.Errorf("refusal message = %q, want it to name the missing grant", resp.Message)
+	}
+	if f.mcpCalls.Load() != 0 {
+		t.Error("an ungranted project reached an MCP")
+	}
+}
+
+// The call-time re-check. Enrolment-time and conversion-time validation cover
+// the routes relay anticipated; this covers the ones it did not — here, a
+// project mutated straight in the store, exactly as a hand-edited settings.json
+// would look. The grant is stale and the call must fail closed.
+func TestRemoteServer_RefusesAProjectThatIsNoLongerRemote(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	if resp := c.roundTrip(`{"type":"CallTool","name":"mail_search"}`); resp.Type != bridge.RespResult {
+		t.Fatalf("baseline call failed: %s %s", resp.Type, resp.Message)
+	}
+
+	// Bypass every validated path: flip the kind in place, leaving the
+	// enrolment's grant pointing at what is now a local project.
+	assertNoErr(t, f.store.With(func(s *Settings) {
+		for i := range s.Projects {
+			if s.Projects[i].ID == f.project.ID {
+				s.Projects[i].Kind = ProjectKindLocal
+				s.Projects[i].Path = "/tmp"
+			}
+		}
+	}), "convert project to local behind the guards")
+
+	before := f.mcpCalls.Load()
+	resp := c.roundTrip(`{"type":"CallTool","name":"mail_search"}`)
+	if resp.Type != bridge.RespError {
+		t.Fatalf("a stale grant on a now-local project was honoured: %s", resp.Type)
+	}
+	if !strings.Contains(resp.Message, "not a remote project") {
+		t.Errorf("refusal message = %q, want it to name the reason", resp.Message)
+	}
+	if f.mcpCalls.Load() != before {
+		t.Error("a stale grant reached an MCP")
+	}
+}
+
+// A deleted project is refused too — the grant resolves to nothing, and
+// nothing is not a fallback.
+func TestRemoteServer_RefusesAProjectThatNoLongerExists(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	assertNoErr(t, f.store.With(func(s *Settings) { s.RemoveProject(f.project.ID) }), "remove project")
+
+	resp := c.roundTrip(`{"type":"ListTools"}`)
+	if resp.Type != bridge.RespError {
+		t.Fatalf("a grant on a deleted project was honoured: %s", resp.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Revocation cuts live connections (decision 8)
+// ---------------------------------------------------------------------------
+
+// Taking effect on the next connection is not enough: this protocol holds
+// persistent connections in a scanner loop, so an agent that never reconnects
+// would keep working for as long as the process lives.
+func TestRemoteServer_RevokingAnEnrolmentClosesItsLiveConnection(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("baseline ListTools failed: %s", resp.Message)
+	}
+
+	if _, err := revokeEnrolment(f.store, "hermes-mail"); err != nil {
+		t.Fatalf("revokeEnrolment: %v", err)
+	}
+
+	// The socket itself must go, not merely the record.
+	_ = c.sendRaw(`{"type":"ListTools"}`)
+	if resp, err := c.readFrame(); err == nil {
+		t.Fatalf("a revoked client's live connection kept working: %s %s", resp.Type, resp.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Configuration (decision 9)
+// ---------------------------------------------------------------------------
+
+// An absent block means no listener at all — not a listener that refuses
+// everything, and not a bound port nobody looks at.
+func TestRemoteServer_DoesNotStartWhenTheConfigBlockIsAbsent(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{noRemoteBlock: true, skipServe: true})
+
+	rs, err := NewRemoteServer(context.Background(), f.store, f.router, f.audit)
+	assertNoErr(t, err, "NewRemoteServer with no remote block")
+	if rs != nil {
+		rs.Close()
+		t.Fatalf("a listener was opened with no remote block, bound to %s", rs.Addr())
+	}
+}
+
+// enabled:false is explicit and must also open nothing; a block that names a
+// listen address but omits enabled opens nothing either, because starting a
+// network listener nobody asked for is the failure mode this ADR exists to
+// avoid.
+func TestRemoteServer_DoesNotStartWhenDisabledOrUnstated(t *testing.T) {
+	for name, opts := range map[string]remoteFixtureOpts{
+		"explicit false": {enabled: ptr(false), skipServe: true},
+		"unstated":       {omitEnabled: true, skipServe: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newRemoteFixture(t, opts)
+			rs, err := NewRemoteServer(context.Background(), f.store, f.router, f.audit)
+			assertNoErr(t, err, "NewRemoteServer")
+			if rs != nil {
+				rs.Close()
+				t.Fatalf("a listener was opened for %s, bound to %s", name, rs.Addr())
+			}
+		})
+	}
+}
+
+// The listen default binds loopback, so misconfiguration cannot expose the
+// control plane to a LAN and same-machine development needs no configuration.
+func TestRemoteConfig_DefaultsToLoopback(t *testing.T) {
+	if got := (&RemoteConfig{Enabled: ptr(true)}).resolve(); got.Listen != "127.0.0.1:9910" || !got.Enabled {
+		t.Fatalf("resolved config = %+v, want loopback:9910 enabled", got)
+	}
+	if got := (*RemoteConfig)(nil).resolve(); got.Enabled {
+		t.Fatal("an absent block resolved to enabled")
+	}
+}
+
+// The server certificate covers loopback whatever else is configured, and a
+// wildcard bind adds nothing it cannot verify.
+func TestRemoteCertHosts(t *testing.T) {
+	loopback := []string{"127.0.0.1", "::1", "localhost"}
+	for listen, want := range map[string][]string{
+		"127.0.0.1:9910":    loopback,
+		"0.0.0.0:9910":      loopback,
+		"[::]:9910":         loopback,
+		"192.168.1.10:9910": append(append([]string{}, loopback...), "192.168.1.10"),
+		"relay.local:9910":  append(append([]string{}, loopback...), "relay.local"),
+	} {
+		got := remoteCertHosts(listen)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("remoteCertHosts(%q) = %v, want %v", listen, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auditing is mandatory for remote callers
+// ---------------------------------------------------------------------------
+
+// The case for letting a VM reach host mail rests on detection: ADR-009's
+// threat model is exfiltration, and decision 5 pays availability for evidence.
+// Remove the evidence and the justification goes with it — so the listener
+// refuses to open at all rather than serving calls nobody will ever see.
+func TestRemoteServer_RefusesToServeWhenAuditingIsDisabled(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{disableAudit: true, skipServe: true})
+
+	rs, err := NewRemoteServer(context.Background(), f.store, f.router, f.audit)
+	if err == nil {
+		if rs != nil {
+			rs.Close()
+		}
+		t.Fatal("the remote listener started with auditing disabled")
+	}
+	if rs != nil {
+		rs.Close()
+		t.Fatal("a listener was bound despite the refusal")
+	}
+	if !strings.Contains(err.Error(), "audit") {
+		t.Errorf("the refusal does not explain itself to an operator: %v", err)
+	}
+}
+
+// Local tooling is entirely unaffected by that refusal: the bridge still
+// serves with auditing off, exactly as it always has.
+func TestRemoteServer_AuditRefusalDoesNotAffectLocalCallers(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{disableAudit: true, skipServe: true})
+
+	if _, err := NewRemoteServer(context.Background(), f.store, f.router, f.audit); err == nil {
+		t.Fatal("expected the remote listener to refuse")
+	}
+	// The same router, called locally with a project token, keeps working.
+	if _, err := f.router.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), f.project.Token); err != nil {
+		t.Fatalf("a local caller was affected by the remote listener's refusal: %v", err)
+	}
+	if f.mcpCalls.Load() != 1 {
+		t.Errorf("local MCP calls = %d, want 1", f.mcpCalls.Load())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Deadlines (decision 9)
+// ---------------------------------------------------------------------------
+
+// BridgeServer sets no deadlines, which is fine on a 0600 Unix socket and a
+// slowloris vector on a network listener: a peer that connects and says
+// nothing must not hold a goroutine and an fd indefinitely.
+func TestRemoteServer_IdleConnectionIsClosed(t *testing.T) {
+	restore := remoteIdleTimeout
+	remoteIdleTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { remoteIdleTimeout = restore })
+
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	time.Sleep(600 * time.Millisecond)
+
+	_ = c.sendRaw(`{"type":"ListTools"}`)
+	if resp, err := c.readFrame(); err == nil {
+		t.Fatalf("an idle connection was still served: %s %s", resp.Type, resp.Message)
+	}
+}
+
+// ...and the inactivity timeout must not cut off a connection that is being
+// used, however slowly relay itself answers.
+func TestRemoteServer_ActiveConnectionSurvivesRepeatedShortGaps(t *testing.T) {
+	restore := remoteIdleTimeout
+	remoteIdleTimeout = 400 * time.Millisecond
+	t.Cleanup(func() { remoteIdleTimeout = restore })
+
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	for i := 0; i < 4; i++ {
+		time.Sleep(150 * time.Millisecond)
+		if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+			t.Fatalf("request %d on an active connection failed: %s %s", i, resp.Type, resp.Message)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Malformed input
+// ---------------------------------------------------------------------------
+
+func TestRemoteServer_MalformedFrameIsAnErrorNotADisconnect(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	if resp := c.roundTrip(`{"type":`); resp.Type != bridge.RespError {
+		t.Fatalf("malformed JSON returned %s", resp.Type)
+	}
+	// The connection survives, so a client can recover without re-handshaking.
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("connection did not survive a malformed frame: %s %s", resp.Type, resp.Message)
+	}
+}
+
+func TestRemoteServer_TypelessFrameIsRefused(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	if resp := f.dial().roundTrip(`{}`); resp.Type != bridge.RespError {
+		t.Fatalf("a frame with no type returned %s", resp.Type)
+	}
+}

--- a/remote_server_test.go
+++ b/remote_server_test.go
@@ -67,6 +67,10 @@ type remoteFixtureOpts struct {
 	// skipServe leaves the server unstarted so a test can assert on
 	// construction alone.
 	skipServe bool
+	// budget, when non-nil, is stored on the enrolment instead of the
+	// conservative defaults, so a test can drive throttling deterministically
+	// without making hundreds of calls.
+	budget *EnrolmentBudget
 }
 
 // newRemoteFixture builds a sandboxed relay install with one remote project,
@@ -124,7 +128,11 @@ func newRemoteFixture(t *testing.T, opts remoteFixtureOpts) *remoteFixture {
 	}
 
 	grants := []string{f.project.ID}
-	bundle, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail", ProjectIDs: grants})
+	req := enrolmentRequest{ClientID: "hermes-mail", ProjectIDs: grants}
+	if opts.budget != nil {
+		req.Budget = *opts.budget
+	}
+	bundle, err := createEnrolment(store, req)
 	assertNoErr(t, err, "createEnrolment")
 	f.bundle = bundle
 
@@ -748,5 +756,65 @@ func TestRemoteServer_TypelessFrameIsRefused(t *testing.T) {
 	f := newRemoteFixture(t, remoteFixtureOpts{})
 	if resp := f.dial().roundTrip(`{}`); resp.Type != bridge.RespError {
 		t.Fatalf("a frame with no type returned %s", resp.Type)
+	}
+}
+
+// Budgets and the listener were built independently: the budget tests inject a
+// remote identity into the context directly, and the listener tests never set a
+// budget. Neither proves the seam between them. This drives a real mTLS client
+// through the real listener into the real enforcement, because a rate limit that
+// only binds a synthetic context protects nothing.
+func TestRemoteServer_BudgetIsEnforcedThroughTheListener(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{
+		budget: &EnrolmentBudget{WindowSeconds: 3600, MaxCalls: 2, MaxResultBytes: 1 << 20},
+	})
+	c := f.dial()
+	if c == nil {
+		t.Fatal("enrolled client could not complete the handshake")
+	}
+
+	call := `{"type":"CallTool","name":"mail_search","arguments":{"q":"invoice"}}`
+	for i := 1; i <= 2; i++ {
+		if resp := c.roundTrip(call); resp.Type != bridge.RespResult {
+			t.Fatalf("call %d within budget returned %s: %s", i, resp.Type, resp.Message)
+		}
+	}
+
+	resp := c.roundTrip(call)
+	if resp.Type != bridge.RespError {
+		t.Fatalf("third call over a 2-call budget returned %s, want an error", resp.Type)
+	}
+	if !strings.Contains(resp.Message, "throttled") {
+		t.Errorf("refusal message = %q, want it to say it was throttled", resp.Message)
+	}
+
+	// The refusal has to happen before the tool runs. A throttle that fires
+	// after the mailbox has been read interdicts nothing.
+	if got := f.mcpCalls.Load(); got != 2 {
+		t.Errorf("MCP was invoked %d times, want 2 — the throttled call must not reach it", got)
+	}
+
+	// And it must be greppable as a throttle specifically: "the grant was
+	// legitimate and the pattern of use was not" is a different signal from
+	// denied (never granted) or tool_error (refused inside the MCP).
+	events := readLoggedEvents(t, f.audit)
+	var throttled *AuditEvent
+	for i := range events {
+		if events[i].Outcome == AuditOutcomeThrottled {
+			throttled = &events[i]
+			break
+		}
+	}
+	if throttled == nil {
+		t.Fatal("the throttled call produced no audit record with outcome throttled")
+	}
+	if throttled.Actor.Kind != AuditActorRemote || throttled.Actor.ClientID != "hermes-mail" {
+		t.Errorf("throttled actor = %+v, want the attested remote client", throttled.Actor)
+	}
+	if throttled.Actor.Fingerprint != f.bundle.Enrolment.Fingerprint {
+		t.Errorf("throttled fingerprint = %q, want the full enrolled fingerprint", throttled.Actor.Fingerprint)
+	}
+	if throttled.Tool != "mail_search" {
+		t.Errorf("throttled record names tool %q, want mail_search", throttled.Tool)
 	}
 }

--- a/router.go
+++ b/router.go
@@ -72,7 +72,12 @@ type appRouter struct {
 	// audit records every tool call, denial, and auth failure that passes
 	// through this router. Nil disables auditing entirely — every call site
 	// goes through nil-safe helpers, so nothing branches on it.
-	audit         *AuditRecorder
+	audit *AuditRecorder
+	// budgets enforces each enrolment's rolling call-rate and result-volume
+	// caps for remote callers (ADR-010 decision 7). The zero value enforces —
+	// see enrolmentBudgets — so there is nothing to wire up and no way to end
+	// up with an unbudgeted router by omission.
+	budgets       enrolmentBudgets
 	serviceTokens serviceTokenStore
 }
 
@@ -314,6 +319,34 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 		}
 	}
 
+	// Per-enrolment budgets (ADR-010 decision 7). One context lookup decides
+	// whether any of this applies: a local caller carries no remote identity,
+	// so it takes no lock, keeps no ledger, and is not accounted at all.
+	//
+	// The rate check sits here — after the grant check, before the intent
+	// record and before the MCP — because a throttled call must not invoke the
+	// tool. Refusing after the mailbox has been read would interdict nothing.
+	// It stays a single audit record rather than an intent/completion pair for
+	// the same reason a denial does: no MCP was reached, so there is no
+	// side effect for a pre-call record to bracket.
+	//
+	// `throttled` is distinct from `denied` (a tool the grant never included)
+	// and `tool_error` (a boundary inside the MCP) because it is the only one
+	// of the three that says the grant was legitimate and the pattern of use
+	// was not — which is what exfiltration looks like from the host's side.
+	rc, isRemote := bridge.RemoteCallerFromContext(ctx)
+	var budget EnrolmentBudget
+	if isRemote {
+		// Resolved once and reused below, so admission and accounting for one
+		// call are always governed by the same numbers even if an operator
+		// edits the enrolment mid-call.
+		budget = settings.enrolmentBudget(rc)
+		if err := r.budgets.admit(rc, budget); err != nil {
+			au.done(AuditOutcomeThrottled, err)
+			return nil, err
+		}
+	}
+
 	// Inject per-token context as _meta for this MCP, plus the authenticated
 	// project id so an MCP can attribute the call to a project without
 	// trusting LLM-supplied values. Relay is the project authority here.
@@ -335,6 +368,14 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 	}
 
 	result, err := r.tools.CallTool(ctx, extID, name, args, meta)
+	if isRemote {
+		// Volume is charged after the fact because a result's size is not
+		// knowable before the MCP answers: this call completes and its bytes
+		// count, and the NEXT one is refused once the window is spent. Charged
+		// even on error, because bytes that came back left the host whether or
+		// not the tool called them a success.
+		r.budgets.charge(rc, budget, len(result))
+	}
 	au.doneResult(result, err)
 	return result, err
 }

--- a/settings.go
+++ b/settings.go
@@ -28,6 +28,14 @@ type Settings struct {
 	// so an install that predates this feature starts logging without any
 	// settings.json migration.
 	Audit *AuditConfig `json:"audit,omitempty"`
+
+	// Remote configures the mTLS listener remote clients reach relay through
+	// (ADR-010 decision 9). Absent means NO LISTENER AT ALL — the opposite
+	// default to Audit above, and deliberately so: a missing audit block should
+	// keep an old install recording, while a missing remote block must never
+	// open a network socket. omitempty keeps every install that has not enabled
+	// one byte-identical to the one it had before this field existed.
+	Remote *RemoteConfig `json:"remote,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/trayapp.go
+++ b/trayapp.go
@@ -22,14 +22,18 @@ var appInstance *App
 
 // App is the main tray application state.
 type App struct {
-	ctx            context.Context
-	cancel         context.CancelFunc
-	wg             sync.WaitGroup
-	store          SettingsStore
-	platform       Platform
-	extMgr         *ExternalMcpManager
-	registry       ServiceManager
-	bridgeServer   *bridge.BridgeServer
+	ctx          context.Context
+	cancel       context.CancelFunc
+	wg           sync.WaitGroup
+	store        SettingsStore
+	platform     Platform
+	extMgr       *ExternalMcpManager
+	registry     ServiceManager
+	bridgeServer *bridge.BridgeServer
+	// remoteServer is the mTLS listener remote clients reach relay through.
+	// Nil whenever no remote block is configured, which is the overwhelmingly
+	// common case; every method on it is nil-safe so nothing branches here.
+	remoteServer   *RemoteServer
 	frontendServer *FrontendServer
 	ipcCtx         *IPCContext // pre-built once, reused on every IPC call
 	// audit is the tool-call recorder. Nil when auditing is disabled or failed
@@ -246,6 +250,21 @@ func runTrayApp() {
 
 	app.goFunc(func() { bs.Serve() })
 	slog.Info("bridge server started")
+
+	// The remote listener sits BESIDE the bridge, never in front of it: the
+	// Unix socket keeps its ten request types, and this one has two. A
+	// configuration error here is fatal to the listener and to nothing else —
+	// relay without a remote listener is relay as it has always been, whereas
+	// a remote listener that started anyway despite (say) disabled auditing is
+	// exactly the system ADR-010 exists to prevent.
+	rs, err := NewRemoteServer(ctx, store, router, audit)
+	if err != nil {
+		slog.Error("remote listener not started", "error", err)
+	}
+	app.remoteServer = rs
+	if rs != nil {
+		app.goFunc(func() { rs.Serve() })
+	}
 
 	// Set up tray icon.
 	slog.Info("setting up tray icon")
@@ -490,10 +509,16 @@ func (a *App) cleanup() {
 		if a.bridgeServer != nil {
 			a.bridgeServer.StopAccepting()
 		}
+		a.remoteServer.StopAccepting()
 		a.extMgr.StopAll()
 		if a.bridgeServer != nil {
 			a.bridgeServer.Close()
 		}
+		// Drained after the MCPs die, like the bridge: an in-flight remote
+		// CallTool fails fast rather than holding the drain open, and its
+		// completion record is still written because the audit log is closed
+		// last of all.
+		a.remoteServer.Close()
 		// Stop the frontend server before the children that proxy to relayLLM
 		// — once relayLLM dies, in-flight proxied requests fail with 502
 		// rather than hanging.


### PR DESCRIPTION
Completes ADR-010. Decisions **1, 4, 7 and 9**, decision 3's third enforcement point, and
the post-acceptance rule that auditing is mandatory for remote callers.

**A remote project can now actually be reached.**

## What landed

**`RemoteServer`** — a second listener beside `BridgeServer`, never a mode of it. Its
dispatch table holds exactly `ListTools` and `CallTool`; the other eight request types have
no code path from a remote connection. A test asserts the table holds those two and *only*
those two, because that table is the security boundary.

mTLS against relay's own CA. The peer certificate is fingerprinted and resolved to an
enrolment **before any request is read** — an unresolved certificate is closed without a
response, so it cannot probe. `RemoteRequest` carries no token and no cwd, and decodes
strictly. The granted project's token is resolved host-side and never appears on the wire.

**Budgets** — rolling-window rate and volume per enrolment at `appRouter.CallTool`, refused
as `throttled`. On the enrolment rather than the project because the enrolment is the unit
of compromise.

**Shared framing** was extracted to `bridge.FrameConn` rather than copied. The local path
passes a zero idle timeout, which `touch()` treats as "no deadline", so `BridgeServer` keeps
exactly the semantics it had — verified by the existing bridge tests, which were not
modified.

## Proven against the running app, not just the suite

A standalone mTLS client (effectively the first `relayRemote` prototype) against a real
`Relay.app`, a real remote project granting only macMCP, and a real enrolment:

```
ListTools            46 tools visible, zero fs_* tools        <- grant enforced
calendars_list       real Apple Calendar data returned        <- the actual use case
call 4 of a 3-call budget
                     -32603 throttled: used 3 of 3 calls in the last 3600s
fs_read              -32001 access denied: MCP 'fsmcp' is disabled for this token
ResolvePtyEnv        -32601 request type is not available to remote clients
{"cwd":"/Users/admin"}
                     -32602 remote request: json: unknown field "cwd"   <- rejected, not ignored
```

And the audit trail for exactly those calls:

```
00:13:16  pending    Hermes Mail  macmcp  calendars_list  0    hermes-vm-1
00:13:16  ok         Hermes Mail  macmcp  calendars_list  121  hermes-vm-1
00:13:43  throttled  Hermes Mail  macmcp  calendars_list  0    hermes-vm-1
00:13:43  denied     Hermes Mail  fsmcp   fs_read         0    hermes-vm-1
```

Intent/completion pairs share one id; `throttled` and `denied` correctly carry **no** phase,
since no MCP was reached and there is no side effect for a pre-call record to bracket. Every
record carries the attested client id, full fingerprint and remote address, with `pid`
absent rather than zero-filled.

Also confirmed at runtime: with no `remote` block, relay binds **no TCP port at all**.

## One gap this PR closes that neither workstream could

Budgets and the listener were built in parallel over disjoint files. The budget tests inject
a remote identity into the context directly; the listener tests never set a budget. **Neither
proved the seam between them** — a rate limit that only binds a synthetic context protects
nothing. `TestRemoteServer_BudgetIsEnforcedThroughTheListener` drives a real mTLS client
through the real listener into real enforcement and asserts the MCP was invoked exactly
twice under a two-call budget.

## Two deliberate choices beyond the ADR's letter

1. **A `remote` block that is present but omits `enabled` resolves to disabled** — the
   opposite default to `Audit`. The ADR only specifies that an *absent* block means no
   listener. Opening a network listener nobody explicitly asked for is the failure this ADR
   exists to avoid, so the incomplete case fails closed. Documented at both definitions.
2. **The listener refuses to start when auditing is disabled**, naming audit in the message,
   rather than failing each call — so there is no window in which a remote call runs
   unrecorded.

## Verification

`go vet` clean · `go test ./...` green · `-race` green on all new tests · existing bridge
tests unmodified and passing after the `FrameConn` extraction.

Note `go test -race ./mcp/` is separately flaky — pre-existing, reproduced on clean `main`
with none of this code present, filed as #14.

## Remaining

- `relay enrol revoke` from the CLI still severs nothing live (the tray holds the connection
  table; the hook is wired, the CLI process has no server to call it on).
- No Settings UI surface for enrolments or the remote block.
- Changing `listen` needs a relay restart.
- The `relayRemote` client itself.

Refs ADR-010.
