### PR TITLE
Detect nested JSON-Schema in schemaHasField, closing a fail-open

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -531,7 +531,23 @@ func (s *Settings) ValidateProjectGrants(proj *Project, schemas map[string]json.
 	return nil
 }
 
-// schemaHasField checks if a context schema declares a given field.
+// schemaHasField reports whether a context schema declares a given field, in
+// either shape an MCP might reasonably use.
+//
+// fsMCP declares its context flat — {"allowed_dirs": {...}} — but the ordinary
+// JSON-Schema shape nests the same declaration under "properties", and relay's
+// own test fixtures use that form. Checking only the flat shape made the answer
+// depend on how an MCP happened to spell an identical declaration.
+//
+// Getting that wrong fails OPEN, which is why both shapes are checked here
+// rather than a shape being mandated elsewhere. This function is the first of
+// ADR-009 decision 3's two defences: it is what stops a filesystem-scoped MCP
+// being granted to a pathless remote project. A false negative does not merely
+// skip a warning — the grant is allowed, the second defence then correctly
+// declines to derive allowed_dirs for a remote project, the MCP receives no
+// value at all, and an MCP that reads an absent allowlist as "unrestricted"
+// (fsMCP does) hands a client on another machine the whole host filesystem.
+// ADR-009 names that exact sequence as the thing this check exists to prevent.
 func schemaHasField(schema json.RawMessage, field string) bool {
 	if len(schema) == 0 {
 		return false
@@ -540,7 +556,21 @@ func schemaHasField(schema json.RawMessage, field string) bool {
 	if err := json.Unmarshal(schema, &fields); err != nil {
 		return false
 	}
-	_, ok := fields[field]
+	if _, ok := fields[field]; ok {
+		return true
+	}
+	// JSON-Schema form: the declarations live under "properties". Checked after
+	// the flat lookup so a schema that genuinely declares a field called
+	// "properties" is still matched by the flat rule first.
+	props, ok := fields["properties"]
+	if !ok {
+		return false
+	}
+	var nested map[string]json.RawMessage
+	if err := json.Unmarshal(props, &nested); err != nil {
+		return false
+	}
+	_, ok = nested[field]
 	return ok
 }
 

--- a/settings_test.go
+++ b/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -982,4 +983,65 @@ func TestResolveServiceID(t *testing.T) {
 			t.Fatal("should return empty for unknown name")
 		}
 	})
+}
+
+// schemaHasField decides whether an MCP is filesystem-scoped, and a false
+// negative fails OPEN: the grant is permitted, the second defence then declines
+// to derive allowed_dirs for a remote project, the MCP receives nothing, and an
+// MCP that reads an absent allowlist as "unrestricted" hands a client on another
+// machine the whole host filesystem. So the answer must not depend on which of
+// two equivalent spellings an MCP chose.
+func TestSchemaHasField_DetectsBothSchemaShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		field  string
+		want   bool
+	}{
+		{"flat, as fsMCP declares it", `{"allowed_dirs":{"type":"array"}}`, "allowed_dirs", true},
+		{"nested under properties, the ordinary JSON-Schema shape",
+			`{"type":"object","properties":{"allowed_dirs":{"type":"array"}}}`, "allowed_dirs", true},
+		{"nested, field genuinely absent",
+			`{"type":"object","properties":{"allowed_mailboxes":{"type":"array"}}}`, "allowed_dirs", false},
+		{"flat, field genuinely absent", `{"allowed_mailboxes":{"type":"array"}}`, "allowed_dirs", false},
+		{"a field literally named properties still matches flat first",
+			`{"properties":{"type":"array"}}`, "properties", true},
+		{"properties present but not an object", `{"properties":"nonsense"}`, "allowed_dirs", false},
+		{"empty schema", ``, "allowed_dirs", false},
+		{"malformed json", `{not valid`, "allowed_dirs", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := schemaHasField(json.RawMessage(tc.schema), tc.field); got != tc.want {
+				t.Errorf("schemaHasField(%s, %q) = %v, want %v", tc.schema, tc.field, got, tc.want)
+			}
+		})
+	}
+}
+
+// The regression that matters: the same filesystem-scoped MCP must be refused a
+// remote grant regardless of how it spelled its schema. Before the fix the
+// nested form was granted, which is the exact outcome ADR-009 decision 3 exists
+// to prevent.
+func TestValidateProjectGrants_RefusesFilesystemMcpInEitherSchemaShape(t *testing.T) {
+	shapes := map[string]string{
+		"flat":   `{"allowed_dirs":{"type":"array"}}`,
+		"nested": `{"type":"object","properties":{"allowed_dirs":{"type":"array"}}}`,
+	}
+	for name, schema := range shapes {
+		t.Run(name, func(t *testing.T) {
+			s := &Settings{Projects: []Project{{
+				ID: "p1", Name: "Remote", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"fsmcp"},
+			}}}
+			err := s.ValidateProjectGrants(&s.Projects[0], map[string]json.RawMessage{
+				"fsmcp": json.RawMessage(schema),
+			})
+			if err == nil {
+				t.Fatalf("%s schema: remote project was granted a filesystem-scoped MCP", name)
+			}
+			if !strings.Contains(err.Error(), "fsmcp") {
+				t.Errorf("refusal should name the offending MCP, got: %v", err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes #17.

`schemaHasField` checked only the flat schema shape, so whether relay recognised an MCP as filesystem-scoped depended on which of two equivalent spellings the MCP chose — and the wrong answer fails **open**.

Reproduced before the fix, same MCP and field, opposite outcomes:

```
NESTED FORM NOT DETECTED — now proving it reaches a remote grant
FAIL-OPEN CONFIRMED: remote project granted a filesystem-scoped MCP; ValidateProjectGrants returned nil
flat form correctly refused: remote project cannot be granted "fsmcp": it is a
  filesystem-scoped MCP (declares allowed_dirs) and a remote project has no path to scope it to
```

**The second defence does not cover this**, by design. `SyncProjectToken` correctly declines to derive `allowed_dirs` for a remote project, so the MCP receives nothing — and ADR-009 decision 3 states what that means: *"omitting the field entirely lets the MCP fall back to whatever default it has, possibly unrestricted."* fsMCP's fallback is unrestricted. Full chain: nested schema → grant permitted → nothing injected → MCP defaults to unrestricted → **a client on another machine reaches the whole host filesystem**.

Not reachable with today's installed MCPs (fsMCP uses the flat form). It was a trap armed for the next MCP that declared its context schema the ordinary way — and relay's own test fixture uses that form.

Flat is checked first, so a schema genuinely declaring a field called `properties` still matches. Tests cover both spellings present, both absent, the `properties`-as-a-field edge, a non-object `properties`, and the regression that matters — the same MCP refused a remote grant either way.

Found while designing #16. fsMCP treating an empty allowlist as unrestricted is documented standalone behaviour, so tightening it belongs in that discussion rather than here.