### PR TITLE
Carry the trigger-marker offset back by runes, not bytes

### DIFF
--- a/skills.go
+++ b/skills.go
@@ -371,13 +371,37 @@ func extractTriggerKeywords(desc string) string {
 	flat := oneLine(strings.TrimSpace(desc))
 	low := strings.ToLower(flat)
 	for _, m := range triggerMarkers {
-		if i := strings.Index(low, m); i >= 0 {
-			rest := flat[i+len(m):]
-			if end := strings.IndexByte(rest, '.'); end >= 0 {
-				rest = rest[:end]
-			}
-			return strings.TrimSpace(rest)
+		i := strings.Index(low, m)
+		if i < 0 {
+			continue
 		}
+		// The offset was found in the lowercased copy and cannot be applied to
+		// the original: strings.ToLower is not length-preserving in UTF-8. Most
+		// affected runes shrink (U+212A KELVIN SIGN, U+1E9E, U+2126, …) and two
+		// grow (U+023A, U+023E), so a byte offset from `low` either lands
+		// mid-clause in `flat` — silently harvesting the wrong routing keywords
+		// — or runs off the end and panics.
+		//
+		// ToLower maps one rune to exactly one rune, so RUNE indices survive
+		// even when byte lengths do not. Translate through the rune count.
+		rest := sliceAfterRunes(flat, utf8.RuneCountInString(low[:i+len(m)]))
+		if end := strings.IndexByte(rest, '.'); end >= 0 {
+			rest = rest[:end]
+		}
+		return strings.TrimSpace(rest)
+	}
+	return ""
+}
+
+// sliceAfterRunes returns s with its first n runes removed. Used to carry an
+// offset discovered in a case-folded copy back onto the original text, where
+// only the rune index is trustworthy.
+func sliceAfterRunes(s string, n int) string {
+	for i := range s {
+		if n == 0 {
+			return s[i:]
+		}
+		n--
 	}
 	return ""
 }

--- a/skills_test.go
+++ b/skills_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"relaygo/mcp"
 )
@@ -534,4 +535,77 @@ func keysOf(m map[string]SkillBucket) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// extractTriggerKeywords locates a marker in a lowercased copy and must carry
+// that position back onto the original. strings.ToLower is not length-preserving
+// in UTF-8 — 23 runes shrink, 2 grow — so a byte offset either lands mid-clause
+// (silently harvesting the wrong routing keywords, which is the worse failure
+// because it degrades routing without erroring) or runs off the end and panics.
+func TestExtractTriggerKeywords_SurvivesNonASCII(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want string
+	}{
+		{"plain ascii", "Use this whenever the user asks about invoices.", "the user asks about invoices"},
+		// Non-ASCII is written with explicit escapes: these runes are the whole
+		// point of the test and must not depend on how a file was transcribed.
+		// U+023A and U+023E GROW when lowercased (2 bytes -> 3) and panicked.
+		{"growing rune U+023A", "\u023Ause whenever x.", "x"},
+		{"growing rune U+023E", "\u023Euse whenever x.", "x"},
+		{"several growing runes", "\u023A\u023A\u023Ause whenever x.", "x"},
+		// U+212A KELVIN SIGN SHRINKS (3 bytes -> 1). Three of them dragged the
+		// offset 6 bytes left, so this returned "s for an invoice" — the tail of
+		// the marker itself, silently wrong rather than loud.
+		{"shrinking rune U+212A", "\u212A\u212A\u212Ause whenever the user asks for an invoice.", "an invoice"},
+		{"shrinking rune U+1E9E", "\u1E9Euse whenever mail arrives.", "mail arrives"},
+		{"emoji before the marker", "\U0001F4E7use whenever mail arrives.", "mail arrives"},
+		{"cjk before the marker", "\u90F5\u4FBFuse whenever mail arrives.", "mail arrives"},
+		{"no marker at all", "Just a description with no trigger.", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked on %q: %v", tc.desc, r)
+				}
+			}()
+			if got := extractTriggerKeywords(tc.desc); got != tc.want {
+				t.Errorf("extractTriggerKeywords(%q) = %q, want %q", tc.desc, got, tc.want)
+			}
+		})
+	}
+}
+
+// Every rune whose lowercase form differs in byte length must be survivable —
+// a hostile or merely multilingual tool description must not be able to crash
+// skill generation for a whole project.
+func TestExtractTriggerKeywords_NoRuneCrashesGeneration(t *testing.T) {
+	var checked int
+	for r := rune(0); r < 0x10000; r++ {
+		if !utf8.ValidRune(r) {
+			continue
+		}
+		orig := string(r)
+		if len(orig) == len(strings.ToLower(orig)) {
+			continue
+		}
+		checked++
+		desc := orig + "use whenever x."
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					t.Fatalf("panicked on U+%04X: %v", r, rec)
+				}
+			}()
+			if got := extractTriggerKeywords(desc); got != "x" {
+				t.Errorf("U+%04X: got %q, want %q", r, got, "x")
+			}
+		}()
+	}
+	if checked == 0 {
+		t.Fatal("found no length-changing runes; the test is not exercising anything")
+	}
+	t.Logf("verified %d runes whose lowercase form changes byte length", checked)
 }


### PR DESCRIPTION
Fixes #19. Found by an adversarial review of `relayRemote`, which mirrors this function, then confirmed live here.

`extractTriggerKeywords` found a marker in a lowercased copy and applied that **byte** offset to the original. `strings.ToLower` is not length-preserving in UTF-8 — 23 runes shrink, two grow.

```
PANIC on "ȺȺȺuse whenever x.": slice bounds out of range [22:21]
PANIC on "ȾȾȾuse whenever x.": slice bounds out of range [22:21]
"KKKuse whenever the user asks for an invoice." -> "s for an invoice"
```

The panic is loud. The misalignment is worse: that clause becomes the frontmatter `description` an agent routes on, so it degrades routing silently.

`ToLower` maps one rune to exactly one rune, so **rune** indices survive when byte lengths do not. A bounds check alone would have fixed the panic and kept the silent half.

Tool descriptions come from MCP servers — third-party input for any HTTP MCP, and `relayRemote` receives them from a host across a network.

Tests: both growing runes, a shrinking one, U+1E9E, emoji, CJK, plus an exhaustive sweep of every rune below U+10000 whose lowercase form changes byte length (25) asserting none panics and each yields the right clause. Verified the suite fails with the fix reverted.

One note worth recording: my first draft of this test used a literal that had been transcribed as ASCII `K` rather than U+212A, so it passed while exercising nothing. The table now uses explicit `\u` escapes so the test cannot be silently defanged by how the file travels.