### PR TITLE
Remote Clients tab, and a listener that reconciles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ enhanced_services.go     In-memory registry of enhanced services; per-service re
 service_registry.go      Background process management + ephemeral service tokens
 service_pidfile.go       Pidfiles under run/; enables orphan reclaim after a force-quit
 service_status_client.go, service_status_poller.go   Generic per-service status polling + action dispatch
-ipc_*.go                 Settings-UI IPC handlers (projects, services, mcps, service action/config, audit)
+ipc_*.go                 Settings-UI IPC handlers (projects, services, mcps, service action/config, audit, enrolments)
 service_config_file.go   resolveConfigPath security gate for the manifest config editor
 settings_html.go         Settings WKWebView HTML/JS
 bridge/                  Unix-socket IPC (newline-delimited JSON); manifest.go holds Manifest/FieldDecl.
@@ -236,7 +236,13 @@ service: ADR-005.
 ## Settings UI
 
 IPC: `ipc(json)` → `window.webkit.messageHandlers.ipc.postMessage`. Tabs:
-Services, MCP Servers, Projects, Service Inspector, Tool Calls.
+Services, MCP Servers, Projects, Remote Clients, Service Inspector, Tool Calls.
+
+The Remote Clients tab (`ipc_enrolments.go`) lists every enrolment beside the
+grants it reaches — by project *name*, with the certificate fingerprint in full
+— and reads/writes the `remote` block. Creating an enrolment returns the bundle
+**directory** only: the client private key inside it never crosses the IPC
+boundary.
 
 The Projects tab is native and co-equal with Eve's project dialog — both hit the
 same `Settings.*Project*` mutators (relay via `ipc_projects.go`, Eve via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ enrolment.go             Enrolment CRUD, grant validation, revocation + its live
 enrolment_ca.go          Relay's self-signed CA: lazy generation, client/server cert issuance, fingerprints
 enrol_cmd.go             `relay enrol` CLI
 remote_server.go         Remote mTLS listener: two-entry dispatch table, cert→enrolment→grant, revocation hook
+remote_reconcile.go      RemoteSupervisor: binds/moves/closes that listener as remote.* and audit.* change
 external_mcp.go          stdio/HTTP MCP clients + runtime schema storage (McpConnection iface)
 http_mcp.go, oauth.go    HTTP transport + OAuth 2.1 (PKCE, dynamic registration, refresh)
 mcp_cmd.go, exec_cmd.go, service_cmd.go   CLI subcommands
@@ -187,6 +188,30 @@ a degraded mode. Local tooling is unaffected. It also sets read+write deadlines
 (inactivity, not a cap on work) and keeps a connection table keyed by
 fingerprint so `SetEnrolmentRevocationHook` closes a revoked client's *live*
 connections.
+
+**The listener follows settings; it is not frozen at startup.**
+`RemoteSupervisor` (`remote_reconcile.go`) converges on every settings poll and
+on every bridge-driven reconcile: it binds when the block is enabled, moves when
+`listen` changes, and closes when the block is disabled *or auditing stops being
+live* — so `audit.enabled: false` is a refusal at runtime and not only at
+launch. Convergence can never open a listener the configuration does not
+explicitly ask for (absent block and omitted `enabled` both resolve to
+disabled). A rebind binds the new address **before** closing the old listener,
+so a failed bind leaves the old one serving and says so loudly rather than
+leaving nothing behind and no error; live connections on the old address are
+then closed deliberately, because `listen` is the reachability control and a
+narrowed bind that left old sessions running would not have narrowed anything.
+The revocation hook is *owned* (`SetEnrolmentRevocationHookFor` /
+`ClearEnrolmentRevocationHookFor`) so a replaced listener's teardown cannot
+uninstall the live listener's hook.
+
+**Every authorization read on this path goes through `freshSettings`, never
+`store.Get()`.** `relay enrol create|revoke` runs in a CLI *process*, so a
+cached settings view made a newly created enrolment look unenrolled until the
+tray's next poll — indistinguishable from a genuine misconfiguration (issue
+#21). `RemoteServer.currentSettings` stats `settings.json` and re-reads only
+when it moved, which is what makes creation as immediate as revocation already
+was, per request and per connection.
 
 See [ADR-010](docs/decisions/010-remote-client-transport-and-identity.md).
 

--- a/cmd/devui/main.go
+++ b/cmd/devui/main.go
@@ -58,9 +58,11 @@ func main() {
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }
 
-// buildPage substitutes the five init-data tokens with fixtures and injects the
+// buildPage substitutes the init-data tokens with fixtures and injects the
 // mock-IPC bridge (before the page script) plus the status-poll simulator
-// (after it).
+// (after it). Every token renderSettingsHTML substitutes must appear here too:
+// an unreplaced __X_JSON__ leaves the page's init object syntactically invalid
+// and takes the whole bundle down on load.
 func buildPage(html string) string {
 	html = strings.NewReplacer(
 		"__EXTERNAL_MCPS_JSON__", fixtureExternalMcps,
@@ -68,6 +70,9 @@ func buildPage(html string) string {
 		"__RUNNING_IDS_JSON__", fixtureRunningIDs,
 		"__PROJECTS_JSON__", fixtureProjects,
 		"__MCP_TOOL_CACHE_JSON__", fixtureMcpToolCache,
+		"__ENROLMENTS_JSON__", fixtureEnrolments,
+		"__REMOTE_JSON__", fixtureRemote,
+		"__ENROLMENT_BUDGET_DEFAULTS_JSON__", fixtureEnrolmentBudgetDefaults,
 	).Replace(html)
 
 	// The mock must define window.webkit BEFORE the page's ipc() runs, so it
@@ -102,8 +107,26 @@ const fixtureRunningIDs = `["relay-llm","relaytts-daemon","stt-daemon"]`
 
 const fixtureProjects = `[
   {"id":"proj-acme","name":"Acme Website","path":"/Users/you/projects/acme","allowed_mcp_ids":["*"],"allowed_models":["*"],"chat_templates":[{"id":"tpl-1","name":"Default","model":"claude-sonnet","system_prompt":"You are a helpful assistant.","append_claude_md":true,"use_relay_tools":true}],"permission_policy":{"default_mode":"acceptEdits","allowed_tools":["Read","Grep"],"denied_tools":["Bash(rm *)"]},"generate_skill":true,"token":"relay_proj_8f2a1c9d4e6b0a7f3c5d","disabled_tools":{}},
-  {"id":"proj-internal","name":"Internal Tools","path":"/Users/you/projects/internal","allowed_mcp_ids":["fsmcp"],"allowed_models":["claude-opus","claude-sonnet"],"chat_templates":[],"permission_policy":{"default_mode":""},"generate_skill":false,"allow_cwd_auth":true,"token":"relay_proj_1a2b3c4d5e6f7a8b9c0d","disabled_tools":{"fsmcp":["write_file"]}}
+  {"id":"proj-internal","name":"Internal Tools","path":"/Users/you/projects/internal","allowed_mcp_ids":["fsmcp"],"allowed_models":["claude-opus","claude-sonnet"],"chat_templates":[],"permission_policy":{"default_mode":""},"generate_skill":false,"allow_cwd_auth":true,"token":"relay_proj_1a2b3c4d5e6f7a8b9c0d","disabled_tools":{"fsmcp":["write_file"]}},
+  {"id":"proj-mail","name":"Mail (remote)","kind":"remote","allowed_mcp_ids":["macmcp"],"allowed_models":[],"chat_templates":[],"generate_skill":false,"token":"relay_proj_0f1e2d3c4b5a6978","disabled_tools":{}}
 ]`
+
+// fixtureEnrolments exercises the Remote Clients list: a resolvable grant, and
+// a full-length fingerprint (never truncated — after an enrolment is deleted it
+// is the only thing that names that client's calls in the audit log). No key
+// material appears here, and none ever crosses this boundary in production
+// either: the create response carries a bundle DIRECTORY and nothing else.
+const fixtureEnrolments = `[
+  {"client_id":"hermes-mail","fingerprint":"sha256:9f2a4c1d6b8e0f37a5c9d2e4b6081f3a7c5e9d1b3f5a7c9e1d3b5f7a9c1e3d5b","project_ids":["proj-mail"],"budget":{"window_seconds":60,"max_calls":60,"max_result_bytes":8388608},"created_at":"2026-08-20T09:14:00Z"}
+]`
+
+// fixtureRemote is the enabled-and-auditing state. Flip enabled/configured/
+// audit_enabled here to eyeball the other three renderings: an absent block, a
+// present-but-off one, and one that is configured but dead because auditing is
+// disabled.
+const fixtureRemote = `{"configured":true,"enabled":true,"listen":"127.0.0.1:9910","effective":"127.0.0.1:9910","audit_enabled":true}`
+
+const fixtureEnrolmentBudgetDefaults = `{"window_seconds":60,"max_calls":60,"max_result_bytes":8388608}`
 
 const fixtureMcpToolCache = `{
   "fsmcp":[
@@ -138,6 +161,23 @@ var mockBridgeScript = `<script>
       case 'query_audit': window.onAuditEvents(FIXTURE_AUDIT, FIXTURE_AUDIT_STATUS); break;
       case 'export_audit': window.onAuditExported('/Users/you/Library/Application Support/relay/logs/audit/toolcalls-export-20260819-150000.jsonl'); break;
       case 'reveal_audit_log': console.log('[devui] would reveal the audit log'); break;
+      case 'create_enrolment':
+        // The real handler emits the persisted record plus a bundle DIRECTORY.
+        // The mock does the same, key material included nowhere — mirroring it
+        // any other way here would model a boundary that does not exist.
+        window.onEnrolmentCreated(
+          { client_id: msg.client_id, fingerprint: 'sha256:' + '0123456789abcdef'.repeat(4),
+            project_ids: msg.project_ids || [], budget: msg.budget, created_at: new Date().toISOString() },
+          { dir: '/Users/you/Library/Application Support/relay/enrolments/' + msg.client_id });
+        break;
+      case 'revoke_enrolment':
+        window.onEnrolmentRevoked(msg.client_id, 'sha256:' + '0123456789abcdef'.repeat(4));
+        break;
+      case 'update_remote_config':
+        if (msg.remove) { window.onRemoteConfigUpdated({ configured: false, enabled: false, listen: '', effective: '127.0.0.1:9910', audit_enabled: true }); break; }
+        window.onRemoteConfigUpdated({ configured: true, enabled: !!msg.enabled, listen: msg.listen || '',
+                                       effective: msg.listen || '127.0.0.1:9910', audit_enabled: true });
+        break;
       // add/update/remove/start/stop etc. — no-op in the harness, just logged above
     }
   }

--- a/enrolment.go
+++ b/enrolment.go
@@ -246,17 +246,66 @@ type EnrolmentRevocationHook func(clientID, fingerprint string)
 var (
 	revocationMu   sync.Mutex
 	revocationHook EnrolmentRevocationHook
+	// revocationOwner is whoever installed the hook currently in place. There
+	// is exactly one hook for the process, and the listener that owns it is
+	// rebuilt whenever `remote.listen` changes — so teardown has to be able to
+	// ask "is this still MINE?" before clearing. Without that, the ordinary
+	// rebind order (bind the new listener, THEN close the old one) has the old
+	// server's Close() silently uninstall the LIVE server's hook, and
+	// revocation stops severing connections while every test that only looks
+	// at the record still passes. Compared by interface identity, so the
+	// caller passes the pointer it registered with.
+	revocationOwner any
 )
 
-// SetEnrolmentRevocationHook installs the callback invoked by
-// CloseRevokedEnrolment. RemoteServer calls this once at startup with a
-// closure that closes every live connection presenting the given fingerprint.
-// Passing nil clears it (which is also the state in the CLI process, where
-// there is no listener to notify — see revokeEnrolment).
-func SetEnrolmentRevocationHook(fn EnrolmentRevocationHook) {
+// SetEnrolmentRevocationHookFor installs the callback invoked by
+// CloseRevokedEnrolment, on behalf of owner. RemoteServer calls this once per
+// listener with a closure that closes every live connection presenting the
+// given fingerprint; installing replaces whatever was there, because the newest
+// listener is by definition the one holding the live connections.
+func SetEnrolmentRevocationHookFor(owner any, fn EnrolmentRevocationHook) {
 	revocationMu.Lock()
 	defer revocationMu.Unlock()
 	revocationHook = fn
+	revocationOwner = owner
+}
+
+// ClearEnrolmentRevocationHookFor uninstalls the hook ONLY if owner still owns
+// it, and reports whether it did. This is the compare-and-clear a torn-down
+// listener must use: during a rebind the replacement has already installed its
+// own hook, and clearing unconditionally there would leave revocation unable to
+// sever a live connection — a security regression invisible to any test that
+// checks only that the enrolment record is gone.
+func ClearEnrolmentRevocationHookFor(owner any) bool {
+	revocationMu.Lock()
+	defer revocationMu.Unlock()
+	if revocationOwner != owner {
+		return false
+	}
+	revocationHook = nil
+	revocationOwner = nil
+	return true
+}
+
+// SetEnrolmentRevocationHook is the unowned form: it installs (or with nil,
+// clears) the hook without claiming ownership. Kept for callers that have no
+// rebind story — a CLI process has no listener to notify at all, which is why
+// the no-hook case is a supported state rather than an error.
+func SetEnrolmentRevocationHook(fn EnrolmentRevocationHook) {
+	SetEnrolmentRevocationHookFor(nil, fn)
+}
+
+// enrolmentRevocationHookOwner reports which object owns the installed hook, or
+// nil when none does. A test seam: "the hook is installed exactly once and
+// points at the live listener" is otherwise unobservable, and it is precisely
+// the property a reconcile can break quietly.
+func enrolmentRevocationHookOwner() any {
+	revocationMu.Lock()
+	defer revocationMu.Unlock()
+	if revocationHook == nil {
+		return nil
+	}
+	return revocationOwner
 }
 
 // CloseRevokedEnrolment notifies the installed hook that an enrolment is gone.
@@ -414,12 +463,13 @@ func revokeEnrolment(store SettingsStore, clientID string) (Enrolment, error) {
 	// do: taking effect on the next connection is not enough, because the
 	// wire protocol holds persistent connections in a scanner loop and a
 	// compromised agent that never reconnects would keep working. In a CLI
-	// process no hook is installed and this is a no-op — a CLI revocation
-	// reaches a running tray only through its settings poll
-	// (App.ReloadIfChanged), which changes what the NEXT connection resolves
-	// to but does not by itself close an established one. Closing that gap
-	// belongs to RemoteServer, which owns both the connection table and the
-	// reload path; it is said plainly here rather than left to be discovered.
+	// process no hook is installed and this is a no-op, so what a CLI
+	// revocation buys is narrower and worth stating exactly: the running tray's
+	// listener re-resolves the enrolment from the FILE on every request
+	// (RemoteServer.resolveGrant via freshSettings), so the very next call on
+	// an already-open socket is refused — but the socket itself stays open
+	// until that client tries something. Closing it outright still needs the
+	// process that owns the connection table, which is why the hook exists.
 	CloseRevokedEnrolment(removed.ClientID, removed.Fingerprint)
 	removeEnrolmentBundle(removed.ClientID)
 	return removed, nil

--- a/ipc_enrolments.go
+++ b/ipc_enrolments.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Remote Clients tab IPC handlers — enrolments (ADR-010 decision 8: "enrolments
+// are listed in the Settings UI beside the grants they reach — a credential you
+// cannot see is one you will not revoke") plus the read/write surface for the
+// `remote` listener block (decision 9).
+//
+// This file is the IPC sibling of enrol_cmd.go and deliberately shares its
+// orchestration: createEnrolment / revokeEnrolment do the work, and the errors
+// the UI shows are the errors those functions produce, verbatim. Nothing here
+// re-derives "which grants are legal" or "what revocation means" — a second
+// copy of either is exactly how the CLI and the tab would drift into
+// disagreeing about who can reach what.
+// ---------------------------------------------------------------------------
+
+const (
+	MsgCreateEnrolment    = "create_enrolment"
+	MsgRevokeEnrolment    = "revoke_enrolment"
+	MsgUpdateRemoteConfig = "update_remote_config"
+)
+
+// ipcCreateEnrolmentMsg is the tab's create form. It mirrors enrolmentRequest
+// (the transport-agnostic body the CLI also fills) rather than inventing a
+// second shape — enrolment.go's comment on that type anticipated exactly this
+// caller.
+type ipcCreateEnrolmentMsg struct {
+	ClientID   string          `json:"client_id"`
+	ProjectIDs []string        `json:"project_ids"`
+	Budget     EnrolmentBudget `json:"budget"`
+}
+
+// ipcEnrolmentIDMsg names one enrolment. Separate from ipcIDMsg because an
+// enrolment is keyed by client id, not by an "id" field, and reusing the
+// generic message would make the two look interchangeable when they are not.
+type ipcEnrolmentIDMsg struct {
+	ClientID string `json:"client_id"`
+}
+
+// ipcRemoteConfigMsg edits the `remote` block. Remove is its own field rather
+// than "enabled: false with an empty listen" because deleting the block and
+// disabling the listener are genuinely different states — an absent block is
+// the only one that says nothing was ever configured — and the UI renders them
+// differently.
+type ipcRemoteConfigMsg struct {
+	Remove  bool   `json:"remove"`
+	Enabled bool   `json:"enabled"`
+	Listen  string `json:"listen"`
+}
+
+// enrolmentBundleView is everything the UI is told about an emitted bundle:
+// the DIRECTORY, and nothing else.
+//
+// createEnrolment writes a client private key into that directory. The key
+// does not cross this boundary — not its bytes, not a preview, not a "reveal"
+// button — because the settings WebView is a rendering surface, and key
+// material that reaches it has been copied somewhere nobody will think to
+// wipe. The private key travelling to the client once is already the weakest
+// step in ADR-010 (decision 8); adding a second copy of it to a browser
+// context is not a trade this UI gets to make on the operator's behalf.
+//
+// The operator is told where the directory is and to MOVE it, which is exactly
+// what `relay enrol create` says. The three filenames inside it are static UI
+// copy rather than fields here, so there is no field on this struct that a
+// future edit could quietly widen from "path" to "contents".
+type enrolmentBundleView struct {
+	Dir string `json:"dir"`
+}
+
+// remoteConfigView is the `remote` block as the tab needs to read it: the raw
+// stored values, what they resolve to, and whether auditing is on.
+//
+// Configured is separate from Enabled because an ABSENT block and a present
+// one that resolves to disabled are different facts about the install, and
+// decision 9 makes the difference load-bearing: absent means no listener was
+// ever asked for, while present-and-off means someone configured one and it is
+// not running. Effective carries resolve()'s answer so the UI can show the
+// loopback default without hardcoding it a second time.
+type remoteConfigView struct {
+	// Configured reports whether settings.json has a "remote" block at all.
+	Configured bool `json:"configured"`
+	// Enabled is the resolved answer — false for an absent block, and false
+	// for a block that omits `enabled`. A network listener is never opened by
+	// omission (decision 9), which is the opposite default to Audit.
+	Enabled bool `json:"enabled"`
+	// Listen is the address exactly as stored; empty means "unset, take the
+	// default", which is what Effective then shows.
+	Listen    string `json:"listen"`
+	Effective string `json:"effective"`
+	// AuditEnabled gates everything else: the listener refuses to start while
+	// auditing is off, so a remote block that looks configured is dead in that
+	// state and the UI has to say so rather than let it look live.
+	AuditEnabled bool `json:"audit_enabled"`
+}
+
+// remoteConfigViewOf projects the `remote` block for the UI.
+//
+// auditEnabled is passed in rather than derived here because the two callers
+// legitimately know different things. The IPC handlers hold the live
+// *AuditRecorder and pass its Enabled(), which also accounts for a recorder
+// that failed to open its file; the first paint (renderSettingsHTML) has only
+// the settings and passes the configured value. The recorder is the more
+// truthful of the two and wins wherever it exists.
+func remoteConfigViewOf(s *Settings, auditEnabled bool) remoteConfigView {
+	// resolve() is nil-safe and is the same function the listener consults, so
+	// the tab cannot disagree with NewRemoteServer about what a block means.
+	resolved := s.Remote.resolve()
+	v := remoteConfigView{
+		Configured:   s.Remote != nil,
+		Enabled:      resolved.Enabled,
+		Effective:    resolved.Listen,
+		AuditEnabled: auditEnabled,
+	}
+	if s.Remote != nil {
+		v.Listen = s.Remote.Listen
+	}
+	return v
+}
+
+// enrolmentBudgetDefaults is the conservative starting budget, shipped to the
+// UI so the create form's placeholders name the real numbers instead of a
+// second copy of them that can rot.
+func enrolmentBudgetDefaults() EnrolmentBudget {
+	return normalizeEnrolmentBudget(EnrolmentBudget{})
+}
+
+// ipcCreateEnrolment signs a client certificate, persists the record, and emits
+// the bundle DIRECTORY (never its contents — see enrolmentBundleView).
+func ipcCreateEnrolment(ctx *IPCContext, raw json.RawMessage) {
+	msg, ok := unmarshalIPC[ipcCreateEnrolmentMsg](raw, MsgCreateEnrolment)
+	if !ok {
+		return
+	}
+	clientID := strings.TrimSpace(msg.ClientID)
+	if clientID == "" {
+		// Matches `relay enrol create`'s "--client-id is required".
+		ctx.UI.EmitEvent("onEnrolmentError", "client id is required")
+		return
+	}
+	// Grant legality is deliberately NOT pre-checked here. ValidateEnrolment
+	// runs inside createEnrolment's store.With, which is the only place two
+	// concurrent creates cannot both claim a client id; a second opinion out
+	// here could only ever disagree with the one that counts. The UI offering
+	// nothing but remote projects is a courtesy, not the enforcement.
+	bundle, err := createEnrolment(ctx.Store, enrolmentRequest{
+		ClientID:   clientID,
+		ProjectIDs: msg.ProjectIDs,
+		Budget:     msg.Budget,
+	})
+	if err != nil {
+		ctx.UI.EmitEvent("onEnrolmentError", err.Error())
+		return
+	}
+	ctx.UI.EmitEvent("onEnrolmentCreated",
+		marshalForUI(bundle.Enrolment),
+		marshalForUI(enrolmentBundleView{Dir: bundle.Dir}))
+}
+
+// ipcRevokeEnrolment deletes an enrolment through revokeEnrolment, which is
+// what makes revocation mean anything: it fires the revocation hook so the
+// listener severs LIVE connections holding that certificate, and removes the
+// emitted bundle. Deleting the record directly (RemoveEnrolment) would leave a
+// compromised agent in its scanner loop working indefinitely, since it never
+// needs to reconnect.
+func ipcRevokeEnrolment(ctx *IPCContext, raw json.RawMessage) {
+	msg, ok := unmarshalIPC[ipcEnrolmentIDMsg](raw, MsgRevokeEnrolment)
+	if !ok || msg.ClientID == "" {
+		return
+	}
+	removed, err := revokeEnrolment(ctx.Store, msg.ClientID)
+	if err != nil {
+		ctx.UI.EmitEvent("onEnrolmentError", err.Error())
+		return
+	}
+	// The fingerprint rides along for the same reason `relay enrol revoke`
+	// prints it: once the record is gone it is the only thing that identifies
+	// that client's calls in the audit log.
+	ctx.UI.EmitEvent("onEnrolmentRevoked", removed.ClientID, removed.Fingerprint)
+}
+
+// ipcUpdateRemoteConfig writes the `remote` block.
+func ipcUpdateRemoteConfig(ctx *IPCContext, raw json.RawMessage) {
+	msg, ok := unmarshalIPC[ipcRemoteConfigMsg](raw, MsgUpdateRemoteConfig)
+	if !ok {
+		return
+	}
+	listen := strings.TrimSpace(msg.Listen)
+	if !msg.Remove && listen != "" {
+		if err := validateRemoteListen(listen); err != nil {
+			ctx.UI.EmitEvent("onRemoteConfigError", err.Error())
+			return
+		}
+	}
+
+	if !ctx.withSettings(func(s *Settings) {
+		if msg.Remove {
+			// Back to "no block at all", which is a state the operator can
+			// otherwise never return to once they have touched this form.
+			s.Remote = nil
+			return
+		}
+		if s.Remote == nil {
+			s.Remote = &RemoteConfig{}
+		}
+		// Empty stays empty rather than being filled with the default: the
+		// listener applies resolve()'s loopback default itself, and writing it
+		// out here would freeze today's default into every settings.json.
+		s.Remote.Listen = listen
+		if msg.Enabled {
+			enabled := true
+			s.Remote.Enabled = &enabled
+		} else {
+			// Off collapses to an ABSENT key rather than an explicit false.
+			// Both resolve to disabled, so storing one spelling keeps every
+			// disabled block identical — the same reasoning normalizeProjectKind
+			// applies to a local project's Kind. It also means creating the
+			// block by setting only an address can never write `enabled: true`
+			// on the operator's behalf: opening a network listener is a thing
+			// they say, not a thing relay infers.
+			s.Remote.Enabled = nil
+		}
+	}) {
+		return
+	}
+
+	ctx.UI.EmitEvent("onRemoteConfigUpdated",
+		marshalForUI(remoteConfigViewOf(ctx.Store.Get(), ctx.Audit.Enabled())))
+}
+
+// validateRemoteListen refuses an address the listener could only fail to bind,
+// at the moment the operator is still looking at the field. Without it a typo
+// persists silently and surfaces as a listener that is simply absent after the
+// next restart, with the reason in a log nobody is reading.
+//
+// An empty HOST (":9910") is NOT refused: binding every interface is a
+// deliberate, documented act (decision 9 defaults to loopback so that reaching
+// relay from a VM has to be chosen, not so that choosing it is forbidden). The
+// UI warns about it instead.
+func validateRemoteListen(addr string) error {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("listen address %q is not host:port (e.g. %s)", addr, defaultRemoteListen)
+	}
+	if port == "" {
+		return fmt.Errorf("listen address %q has no port (e.g. %s)", addr, defaultRemoteListen)
+	}
+	// LookupPort resolves numeric ports without touching the network and also
+	// accepts the service names tls.Listen would accept, so this agrees with
+	// what the listener will actually do.
+	if _, err := net.LookupPort("tcp", port); err != nil {
+		return fmt.Errorf("listen address %q has an invalid port %q", addr, port)
+	}
+	return nil
+}

--- a/ipc_enrolments_test.go
+++ b/ipc_enrolments_test.go
@@ -1,0 +1,495 @@
+package main
+
+// Hermetic tests for the Remote Clients IPC handlers. Mirrors the CLI coverage
+// in enrolment_test.go: every handler proves it (a) emits the right event,
+// (b) persists through the SettingsStore, and (c) refuses what enrolment.go
+// refuses, with enrolment.go's wording rather than a second opinion.
+//
+// The load-bearing one is TestIPCCreateEnrolment_NeverEmitsKeyMaterial: the
+// bundle contains a client private key, and the whole reason the IPC surface
+// hands back a directory rather than the bundle struct is that key material
+// must never reach a WebView.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"relaygo/bridge"
+)
+
+// newEnrolmentIPC stands up an IPCContext over a sandboxed store whose config
+// dir also holds the CA and the emitted bundles — nothing here can touch the
+// real ~/Library/Application Support/relay.
+//
+// auditEnabled builds a bare recorder rather than a real one: the only method
+// this surface calls on it is Enabled(), and starting a writer goroutine to
+// answer one bool would be the tail wagging the dog. A nil recorder is the
+// genuine "auditing is off" state — Enabled() is nil-safe.
+func newEnrolmentIPC(t *testing.T, auditEnabled bool) (*IPCContext, SettingsStore, *recordingUI) {
+	t.Helper()
+	_, store := newEnrolmentSandbox(t)
+	ui := &recordingUI{}
+	var rec *AuditRecorder
+	if auditEnabled {
+		rec = &AuditRecorder{cfg: resolvedAuditConfig{Enabled: true}}
+	}
+	return &IPCContext{
+		Ctx:                    context.Background(),
+		Store:                  store,
+		UI:                     ui,
+		Platform:               stubPlatform{},
+		Registry:               noopServiceManager{},
+		Enhanced:               NewEnhancedServiceRegistry(nil),
+		UpdateMenu:             func() {},
+		PushServiceStatusBatch: func() {},
+		GoFunc:                 func(fn func()) { fn() },
+		NotifyReconcile:        func(string) error { return nil },
+		NotifyReloadMcp:        func(string, string) error { return nil },
+		Audit:                  rec,
+	}, store, ui
+}
+
+// emittedJSON renders every event the UI recorded as one JSON blob, which is
+// what a leak test needs: it does not matter which argument of which event
+// something rode out on, only that it left the process.
+func emittedJSON(t *testing.T, ui *recordingUI) string {
+	t.Helper()
+	ui.mu.Lock()
+	defer ui.mu.Unlock()
+	var b strings.Builder
+	for _, ev := range ui.events {
+		b.WriteString(ev.Name)
+		for _, a := range ev.Args {
+			data, err := json.Marshal(a)
+			if err != nil {
+				t.Fatalf("marshal event arg: %v", err)
+			}
+			b.Write(data)
+		}
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestIPCCreateEnrolment_PersistsAndEmitsBundleDirectory(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	mail := mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+
+	ipcCreateEnrolment(ipc, mustRaw(t, map[string]interface{}{
+		"client_id":   "hermes-mail",
+		"project_ids": []string{mail.ID},
+	}))
+
+	args, ok := findEvent(ui, "onEnrolmentCreated")
+	if !ok {
+		t.Fatalf("expected onEnrolmentCreated; got %+v", ui.events)
+	}
+	var created Enrolment
+	if err := json.Unmarshal(args[0].(json.RawMessage), &created); err != nil {
+		t.Fatalf("unmarshal enrolment: %v", err)
+	}
+	if created.ClientID != "hermes-mail" || !created.GrantsProject(mail.ID) {
+		t.Fatalf("emitted enrolment does not match the request: %+v", created)
+	}
+	// An unset budget takes the conservative default, never "unlimited".
+	if created.Budget.MaxCalls != defaultEnrolmentMaxCalls {
+		t.Errorf("unset budget did not default: %+v", created.Budget)
+	}
+	if store.Get().FindEnrolment("hermes-mail") == nil {
+		t.Error("enrolment was not persisted")
+	}
+
+	// The bundle payload is a directory and nothing else. A second key on this
+	// object is the shape a key would arrive in.
+	var bundle map[string]interface{}
+	if err := json.Unmarshal(args[1].(json.RawMessage), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle view: %v", err)
+	}
+	if len(bundle) != 1 {
+		t.Fatalf("bundle view carries more than the directory: %+v", bundle)
+	}
+	dir, _ := bundle["dir"].(string)
+	if dir == "" {
+		t.Fatal("bundle view has no dir")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "client.key")); err != nil {
+		t.Errorf("bundle directory has no client.key on disk: %v", err)
+	}
+}
+
+// The one that matters. createEnrolment writes a private key to disk; not one
+// byte of it may ride out on an IPC event, in any field, on any argument.
+func TestIPCCreateEnrolment_NeverEmitsKeyMaterial(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	mail := mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+
+	ipcCreateEnrolment(ipc, mustRaw(t, map[string]interface{}{
+		"client_id":   "hermes-mail",
+		"project_ids": []string{mail.ID},
+	}))
+
+	args, ok := findEvent(ui, "onEnrolmentCreated")
+	if !ok {
+		t.Fatalf("expected onEnrolmentCreated; got %+v", ui.events)
+	}
+	var bundle map[string]string
+	if err := json.Unmarshal(args[1].(json.RawMessage), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle view: %v", err)
+	}
+	keyPEM, err := os.ReadFile(filepath.Join(bundle["dir"], "client.key"))
+	if err != nil {
+		t.Fatalf("read the emitted key: %v", err)
+	}
+
+	emitted := emittedJSON(t, ui)
+	// The literal key bytes, in whole and in part. A partial match catches a
+	// truncated "preview" as surely as a whole one catches a full copy.
+	if strings.Contains(emitted, strings.TrimSpace(string(keyPEM))) {
+		t.Fatal("the client private key was emitted to the settings UI")
+	}
+	for _, needle := range []string{"PRIVATE KEY", "-----BEGIN", "BEGIN EC", "BEGIN RSA"} {
+		if strings.Contains(emitted, needle) {
+			t.Fatalf("PEM material %q reached the settings UI: %s", needle, emitted)
+		}
+	}
+	// Body-of-the-key check: any long line from the PEM appearing anywhere in
+	// the emitted payload is key material regardless of how it was framed.
+	for _, line := range strings.Split(string(keyPEM), "\n") {
+		if len(line) < 40 {
+			continue
+		}
+		if strings.Contains(emitted, line) {
+			t.Fatalf("a line of the private key reached the settings UI")
+		}
+	}
+}
+
+// A grant naming a local project is refused, and the refusal is enrolment.go's
+// — it names the project so the operator knows which grant to drop.
+func TestIPCCreateEnrolment_RefusesLocalProjectGrant(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	local := mkStoreProject(t, store, ProjectKindLocal, "Workspace", t.TempDir())
+
+	ipcCreateEnrolment(ipc, mustRaw(t, map[string]interface{}{
+		"client_id":   "hermes-mail",
+		"project_ids": []string{local.ID},
+	}))
+
+	args, ok := findEvent(ui, "onEnrolmentError")
+	if !ok {
+		t.Fatalf("expected onEnrolmentError; got %+v", ui.events)
+	}
+	msg, _ := args[0].(string)
+	for _, want := range []string{local.ID, "Workspace", "local project"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal must name %q; got: %s", want, msg)
+		}
+	}
+	// A refused enrolment persists nothing and emits no credential.
+	if got := store.Get().Enrolments; len(got) != 0 {
+		t.Fatalf("refused enrolment was persisted: %+v", got)
+	}
+	if _, ok := findEvent(ui, "onEnrolmentCreated"); ok {
+		t.Fatal("a refused enrolment emitted a bundle")
+	}
+}
+
+func TestIPCCreateEnrolment_RequiresClientID(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	ipcCreateEnrolment(ipc, mustRaw(t, map[string]interface{}{"client_id": "   "}))
+
+	args, ok := findEvent(ui, "onEnrolmentError")
+	if !ok {
+		t.Fatalf("expected onEnrolmentError; got %+v", ui.events)
+	}
+	if msg, _ := args[0].(string); !strings.Contains(msg, "client id is required") {
+		t.Errorf("unexpected refusal: %s", msg)
+	}
+	if len(store.Get().Enrolments) != 0 {
+		t.Error("an enrolment was created without a client id")
+	}
+}
+
+// A duplicate client id is refused rather than shadowing the first record.
+func TestIPCCreateEnrolment_RefusesDuplicateClientID(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	mail := mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+	body := mustRaw(t, map[string]interface{}{
+		"client_id":   "hermes-mail",
+		"project_ids": []string{mail.ID},
+	})
+	ipcCreateEnrolment(ipc, body)
+	ipcCreateEnrolment(ipc, body)
+
+	args, ok := findEvent(ui, "onEnrolmentError")
+	if !ok {
+		t.Fatalf("expected onEnrolmentError on the second create; got %+v", ui.events)
+	}
+	if msg, _ := args[0].(string); !strings.Contains(msg, "already exists") {
+		t.Errorf("unexpected refusal: %s", msg)
+	}
+	if got := len(store.Get().Enrolments); got != 1 {
+		t.Fatalf("want 1 enrolment after a duplicate create, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Revoke
+// ---------------------------------------------------------------------------
+
+// Revoking deletes the record, removes the bundle, and — the half a record
+// deletion cannot do — fires the hook that severs live connections. Going
+// through revokeEnrolment rather than RemoveEnrolment is what buys that third
+// property, so the test asserts on it directly.
+func TestIPCRevokeEnrolment_DeletesRecordBundleAndFiresHook(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	mail := mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+	ipcCreateEnrolment(ipc, mustRaw(t, map[string]interface{}{
+		"client_id":   "hermes-mail",
+		"project_ids": []string{mail.ID},
+	}))
+	created := store.Get().FindEnrolment("hermes-mail")
+	if created == nil {
+		t.Fatal("setup: enrolment was not created")
+	}
+	fingerprint := created.Fingerprint
+	// bridge.ConfigDir() is redirected to the sandbox by newEnrolmentSandbox.
+	bundleDir := filepath.Join(bridge.ConfigDir(), enrolmentBundleDir, "hermes-mail")
+
+	var hookClient, hookFingerprint string
+	SetEnrolmentRevocationHook(func(clientID, fp string) {
+		hookClient, hookFingerprint = clientID, fp
+	})
+	t.Cleanup(func() { SetEnrolmentRevocationHook(nil) })
+
+	ipcRevokeEnrolment(ipc, mustRaw(t, map[string]interface{}{"client_id": "hermes-mail"}))
+
+	args, ok := findEvent(ui, "onEnrolmentRevoked")
+	if !ok {
+		t.Fatalf("expected onEnrolmentRevoked; got %+v", ui.events)
+	}
+	if got, _ := args[0].(string); got != "hermes-mail" {
+		t.Errorf("revoked event named %q", got)
+	}
+	// The fingerprint rides along because once the record is gone it is the
+	// only thing that identifies this client's calls in the audit log.
+	if got, _ := args[1].(string); got != fingerprint {
+		t.Errorf("revoked event fingerprint = %q, want the full %q", got, fingerprint)
+	}
+	if store.Get().FindEnrolment("hermes-mail") != nil {
+		t.Error("the enrolment record survived revocation")
+	}
+	if _, err := os.Stat(bundleDir); !os.IsNotExist(err) {
+		t.Errorf("the emitted bundle survived revocation: %v", err)
+	}
+	if hookClient != "hermes-mail" || hookFingerprint != fingerprint {
+		t.Errorf("revocation hook got (%q, %q); live connections would not be severed", hookClient, hookFingerprint)
+	}
+}
+
+func TestIPCRevokeEnrolment_UnknownClientIsRefusedByName(t *testing.T) {
+	ipc, _, ui := newEnrolmentIPC(t, true)
+	ipcRevokeEnrolment(ipc, mustRaw(t, map[string]interface{}{"client_id": "ghost"}))
+
+	args, ok := findEvent(ui, "onEnrolmentError")
+	if !ok {
+		t.Fatalf("expected onEnrolmentError; got %+v", ui.events)
+	}
+	if msg, _ := args[0].(string); !strings.Contains(msg, "ghost") {
+		t.Errorf("refusal must name the client id; got: %s", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The remote block
+// ---------------------------------------------------------------------------
+
+// Saving an address without turning the listener on must NOT write
+// enabled: true. Opening a network listener is a thing the operator says, not
+// a thing relay infers from an address being present.
+func TestIPCUpdateRemoteConfig_CreatingTheBlockDoesNotEnableIt(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	if store.Get().Remote != nil {
+		t.Fatal("setup: expected no remote block")
+	}
+
+	ipcUpdateRemoteConfig(ipc, mustRaw(t, map[string]interface{}{
+		"enabled": false,
+		"listen":  "127.0.0.1:9911",
+	}))
+
+	cfg := store.Get().Remote
+	if cfg == nil {
+		t.Fatal("the remote block was not created")
+	}
+	if cfg.Enabled != nil {
+		t.Errorf("disabled collapsed to an explicit %v rather than an absent key", *cfg.Enabled)
+	}
+	if cfg.Listen != "127.0.0.1:9911" {
+		t.Errorf("listen = %q", cfg.Listen)
+	}
+	if cfg.resolve().Enabled {
+		t.Error("a block created by setting an address resolved to enabled")
+	}
+
+	args, ok := findEvent(ui, "onRemoteConfigUpdated")
+	if !ok {
+		t.Fatalf("expected onRemoteConfigUpdated; got %+v", ui.events)
+	}
+	var view remoteConfigView
+	if err := json.Unmarshal(args[0].(json.RawMessage), &view); err != nil {
+		t.Fatalf("unmarshal view: %v", err)
+	}
+	// present-but-disabled: configured true, enabled false. The UI needs both
+	// to distinguish it from an absent block.
+	if !view.Configured || view.Enabled {
+		t.Errorf("view = %+v, want configured=true enabled=false", view)
+	}
+}
+
+func TestIPCUpdateRemoteConfig_EnableThenRemove(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+
+	ipcUpdateRemoteConfig(ipc, mustRaw(t, map[string]interface{}{
+		"enabled": true,
+		"listen":  "127.0.0.1:9910",
+	}))
+	cfg := store.Get().Remote
+	if cfg == nil || cfg.Enabled == nil || !*cfg.Enabled {
+		t.Fatalf("enabling did not write enabled: true; got %+v", cfg)
+	}
+
+	// Removing returns the install to "no block at all", which is a different
+	// state from a disabled listener: nothing is opened, and nothing was ever
+	// asked for.
+	ipcUpdateRemoteConfig(ipc, mustRaw(t, map[string]interface{}{"remove": true}))
+	if got := store.Get().Remote; got != nil {
+		t.Fatalf("remove left a block behind: %+v", got)
+	}
+
+	args, _ := findEvent(ui, "onRemoteConfigUpdated")
+	var view remoteConfigView
+	if err := json.Unmarshal(args[0].(json.RawMessage), &view); err != nil {
+		t.Fatalf("unmarshal view: %v", err)
+	}
+	if view.Configured || view.Enabled {
+		t.Errorf("view after remove = %+v, want configured=false enabled=false", view)
+	}
+	// With no block, the effective address is still reported so the UI can
+	// show what a listener WOULD bind — and it is loopback.
+	if view.Effective != defaultRemoteListen {
+		t.Errorf("effective = %q, want the loopback default %q", view.Effective, defaultRemoteListen)
+	}
+}
+
+func TestIPCUpdateRemoteConfig_RefusesMalformedListen(t *testing.T) {
+	ipc, store, ui := newEnrolmentIPC(t, true)
+	for _, addr := range []string{"not-an-address", "127.0.0.1", "127.0.0.1:not-a-port"} {
+		ipcUpdateRemoteConfig(ipc, mustRaw(t, map[string]interface{}{
+			"enabled": true,
+			"listen":  addr,
+		}))
+		args, ok := findEvent(ui, "onRemoteConfigError")
+		if !ok {
+			t.Fatalf("listen %q was accepted; got %+v", addr, ui.events)
+		}
+		if msg, _ := args[0].(string); !strings.Contains(msg, addr) {
+			t.Errorf("refusal must quote the address; got %s", msg)
+		}
+		if got := store.Get().Remote; got != nil {
+			t.Fatalf("a malformed address was persisted: %+v", got)
+		}
+	}
+}
+
+// A blank address stores blank rather than freezing today's default into
+// settings.json — resolve() applies the default at read time instead.
+func TestIPCUpdateRemoteConfig_BlankListenStaysBlank(t *testing.T) {
+	ipc, store, _ := newEnrolmentIPC(t, true)
+	ipcUpdateRemoteConfig(ipc, mustRaw(t, map[string]interface{}{"enabled": true, "listen": "  "}))
+
+	cfg := store.Get().Remote
+	if cfg == nil || cfg.Listen != "" {
+		t.Fatalf("blank listen was not stored blank: %+v", cfg)
+	}
+	if got := cfg.resolve().Listen; got != defaultRemoteListen {
+		t.Errorf("blank listen resolved to %q, want %q", got, defaultRemoteListen)
+	}
+}
+
+// Disabled auditing is a hard stop for remote access — the listener refuses to
+// start — so the view reports it alongside the block's own state and the UI
+// renders "off as a consequence" rather than "configured".
+func TestRemoteConfigView_ReportsAuditAsTheGateOnRemoteAccess(t *testing.T) {
+	ipcOn, storeOn, _ := newEnrolmentIPC(t, true)
+	ipcUpdateRemoteConfig(ipcOn, mustRaw(t, map[string]interface{}{"enabled": true, "listen": "127.0.0.1:9910"}))
+	if v := remoteConfigViewOf(storeOn.Get(), ipcOn.Audit.Enabled()); !v.Enabled || !v.AuditEnabled {
+		t.Errorf("audit on: view = %+v, want enabled + audit_enabled", v)
+	}
+
+	// Same block, no recorder: the block still reads enabled (that is what is
+	// configured) while audit_enabled is false, which is the pair the UI turns
+	// into "remote access is off because auditing is disabled".
+	ipcOff, storeOff, _ := newEnrolmentIPC(t, false)
+	ipcUpdateRemoteConfig(ipcOff, mustRaw(t, map[string]interface{}{"enabled": true, "listen": "127.0.0.1:9910"}))
+	v := remoteConfigViewOf(storeOff.Get(), ipcOff.Audit.Enabled())
+	if !v.Enabled {
+		t.Errorf("audit off: block should still read as configured-enabled, got %+v", v)
+	}
+	if v.AuditEnabled {
+		t.Errorf("audit off: view claims auditing is on: %+v", v)
+	}
+}
+
+// The first paint carries the same three facts as the IPC view, so the tab is
+// correct before any message is exchanged.
+func TestRenderSettingsHTML_SeedsEnrolmentsAndRemoteBlock(t *testing.T) {
+	_, store := newEnrolmentSandbox(t)
+	mail := mkStoreProject(t, store, ProjectKindRemote, "Mail", "")
+	if _, err := createEnrolment(store, enrolmentRequest{ClientID: "hermes-mail", ProjectIDs: []string{mail.ID}}); err != nil {
+		t.Fatalf("createEnrolment: %v", err)
+	}
+	store.With(func(s *Settings) {
+		enabled := true
+		s.Remote = &RemoteConfig{Enabled: &enabled, Listen: "127.0.0.1:9910"}
+	})
+
+	s := store.Get()
+	html := renderSettingsHTML(s, nil, nil)
+	fingerprint := s.Enrolments[0].Fingerprint
+
+	for _, want := range []string{"hermes-mail", fingerprint, `"configured":true`, `"listen":"127.0.0.1:9910"`} {
+		if !strings.Contains(html, want) {
+			t.Errorf("first paint is missing %q", want)
+		}
+	}
+	// And no key material rides along on the first paint either.
+	for _, forbidden := range []string{"PRIVATE KEY", "-----BEGIN"} {
+		if strings.Contains(html, forbidden) {
+			t.Errorf("first paint carries %q", forbidden)
+		}
+	}
+}
+
+// Every __X_JSON__ token in the shell must be substituted by renderSettingsHTML.
+// An unreplaced one leaves window.__RELAY_INIT__ syntactically invalid, which
+// does not fail loudly in one tab — it throws on load and takes the entire
+// settings bundle with it. Adding a token to web/shell.html without adding it
+// to the replacer is the whole failure mode, so this asserts on the class of
+// mistake rather than on today's list. (cmd/devui carries the same list for
+// the same reason.)
+func TestRenderSettingsHTML_LeavesNoUnsubstitutedPlaceholder(t *testing.T) {
+	_, store := newEnrolmentSandbox(t)
+	html := renderSettingsHTML(store.Get(), nil, nil)
+	if left := regexp.MustCompile(`__[A-Z0-9_]+_JSON__`).FindAllString(html, -1); len(left) > 0 {
+		t.Fatalf("renderSettingsHTML left placeholders unsubstituted: %v", left)
+	}
+}

--- a/ipc_handlers.go
+++ b/ipc_handlers.go
@@ -79,6 +79,13 @@ func (a *App) pushFullSettings() {
 		"running_ids":    a.registry.RunningIDs(),
 		"projects":       s.Projects,
 		"mcp_tool_cache": a.buildToolCache(s),
+		// Enrolments and the remote block ride along so the Remote Clients tab
+		// reflects an enrolment created or revoked by `relay enrol` while the
+		// window is open. The audit state comes from the live recorder rather
+		// than from settings, because a recorder that failed to start is the
+		// same "remote is off" for the operator as one switched off on purpose.
+		"enrolments": s.Enrolments,
+		"remote":     remoteConfigViewOf(s, a.audit.Enabled()),
 	})
 }
 
@@ -296,6 +303,11 @@ var ipcHandlers = map[string]func(*IPCContext, json.RawMessage){
 	MsgQueryAudit:     ipcQueryAudit,
 	MsgExportAudit:    ipcExportAudit,
 	MsgRevealAuditLog: ipcRevealAuditLog,
+
+	// Remote Clients (ipc_enrolments.go)
+	MsgCreateEnrolment:    ipcCreateEnrolment,
+	MsgRevokeEnrolment:    ipcRevokeEnrolment,
+	MsgUpdateRemoteConfig: ipcUpdateRemoteConfig,
 }
 
 // onSettingsIpc is called from the WKWebView IPC handler.

--- a/remote_reconcile.go
+++ b/remote_reconcile.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// RemoteSupervisor keeps the remote listener in step with settings.json without
+// a restart, the way ExternalMcpManager.Reconcile keeps MCP processes in step
+// and ReloadService keeps a service process in step.
+//
+// The listener used to be built exactly once, in runTrayApp. That made
+// `remote.enabled` and `remote.listen` the only settings in relay whose only
+// application mechanism was quitting the tray — and it made the safety
+// properties around them stale rather than enforced: turning auditing off left
+// a listener serving, and moving the bind address left it on the old one.
+//
+// Reconcile is a CONVERGENCE step, not a command: it compares what settings ask
+// for against what is actually bound and does the minimum to close the gap.
+// That is what makes it safe to call on every settings poll, and it is why
+// there is no Start/Stop/Restart trio — a caller cannot ask for a listener the
+// configuration does not describe, which is the property ADR-010 decision 9
+// exists to protect.
+//
+// A nil *RemoteSupervisor is a valid "this process has no listener to manage"
+// value and every method tolerates it, exactly as RemoteServer does.
+type RemoteSupervisor struct {
+	ctx    context.Context
+	store  SettingsStore
+	router RemoteToolRouter
+	audit  *AuditRecorder
+	// goFunc runs the accept loop, and the drain of a listener that has been
+	// replaced, under the owner's waitgroup so shutdown waits for both. nil
+	// falls back to a bare `go`, which is what a test wants.
+	goFunc func(func())
+
+	mu     sync.Mutex
+	server *RemoteServer
+	// closed latches at shutdown so a reconcile racing cleanup cannot bind a
+	// fresh socket behind it.
+	closed bool
+	// lastReport is the last (address, failure) pair reported, so a reconcile
+	// that runs every two seconds does not turn one misconfigured port into a
+	// log flood. State CHANGES are loud; a steady failure is loud once and then
+	// repeats at debug.
+	lastReport string
+}
+
+// NewRemoteSupervisor wires a supervisor. It binds nothing — call Reconcile.
+func NewRemoteSupervisor(ctx context.Context, store SettingsStore, router RemoteToolRouter, audit *AuditRecorder, goFunc func(func())) *RemoteSupervisor {
+	return &RemoteSupervisor{ctx: ctx, store: store, router: router, audit: audit, goFunc: goFunc}
+}
+
+// Addr returns the address the live listener is bound to, or "" when there is
+// none. Reads the actual socket, not the configured string, so a test binding
+// :0 gets the assigned port and an operator gets the truth.
+func (sup *RemoteSupervisor) Addr() string {
+	if sup == nil {
+		return ""
+	}
+	sup.mu.Lock()
+	defer sup.mu.Unlock()
+	return sup.server.Addr()
+}
+
+// Server returns the live listener, or nil. For tests that need to assert on
+// the object identity the revocation hook points at.
+func (sup *RemoteSupervisor) Server() *RemoteServer {
+	if sup == nil {
+		return nil
+	}
+	sup.mu.Lock()
+	defer sup.mu.Unlock()
+	return sup.server
+}
+
+// Reconcile converges the live listener onto what settings.json now says.
+//
+// The returned error is the same one that was logged; it exists so a caller can
+// surface a bind failure and a test can assert on it. Nothing about the
+// supervisor's state depends on the caller handling it — a failure always
+// leaves a coherent state behind, never a half-bound one.
+//
+// Five outcomes, in the order they are decided:
+//
+//  1. Not enabled → stop whatever is running and open nothing. An ABSENT block
+//     and a block that omits `enabled` both land here, because RemoteConfig
+//     resolves both to disabled (deliberately the opposite of AuditConfig).
+//     Reconciliation must never open a listener the configuration does not
+//     explicitly ask for, so this branch is checked before anything else.
+//  2. Enabled but auditing is not live → stop, and say why. Auditing is a hard
+//     dependency of remote access, not a preference: the case for letting a VM
+//     reach host mail rests entirely on the calls being recorded. Turning
+//     auditing off at runtime therefore has to CLOSE the listener, not leave it
+//     serving until the next restart.
+//  3. Enabled, auditing live, and the bound address already matches → do
+//     nothing at all. Live connections are untouched. This is the overwhelmingly
+//     common outcome, since this runs on every settings poll.
+//  4. Enabled and the address differs (or nothing is bound) → bind the NEW
+//     address first, and only then tear the old listener down. A rebind that
+//     fails must not leave relay with no listener and no error, so the old one
+//     keeps serving its old address and the failure is loud.
+//  5. Bind failed → old state stands, error returned and logged. The next poll
+//     retries, so a port freed by whatever was holding it is picked up without
+//     an operator doing anything.
+func (sup *RemoteSupervisor) Reconcile() error {
+	if sup == nil {
+		return nil
+	}
+	sup.mu.Lock()
+	defer sup.mu.Unlock()
+	if sup.closed || sup.ctx.Err() != nil {
+		return nil
+	}
+
+	settings := freshSettings(sup.store)
+	desired := settings.Remote.resolve()
+
+	if !desired.Enabled {
+		sup.stopLocked("settings no longer enable the remote listener")
+		sup.reportLocked("", nil)
+		return nil
+	}
+
+	if !remoteAuditingLive(settings, sup.audit) {
+		err := errors.New("remote listener not serving: the tool-call audit log is not recording, and a remote grant is " +
+			"justified by the calls it records — set audit.enabled to true and relaunch relay so the recorder starts " +
+			"(it is built once, at launch), or remove the remote block from settings.json")
+		sup.stopLocked("auditing is no longer active")
+		sup.reportLocked(desired.Listen, err)
+		return err
+	}
+
+	if sup.server != nil && sup.server.cfg.Listen == desired.Listen {
+		// Already converged. Deliberately NOT a rebind-anyway: rebinding on an
+		// unchanged address would cut every live connection every two seconds.
+		sup.reportLocked(desired.Listen, nil)
+		return nil
+	}
+
+	// Bind before tearing down. NewRemoteServer installs the revocation hook as
+	// part of coming up, so from this line on the hook points at the NEW
+	// listener; the old one's teardown below compare-and-clears and therefore
+	// leaves it alone.
+	ns, err := NewRemoteServer(sup.ctx, sup.store, sup.router, sup.audit)
+	if err != nil {
+		// Reported and returned as the SAME error, so what a test asserts on and
+		// what an operator reads in the log cannot drift apart.
+		err = fmt.Errorf("remote listener could not bind %s: %w", desired.Listen, err)
+		sup.reportLocked(desired.Listen, err)
+		return err
+	}
+	if ns == nil {
+		// Only reachable if settings changed to disabled between our read and
+		// NewRemoteServer's. Treat it as outcome 1 rather than as success:
+		// whatever the file says now is what wins.
+		sup.stopLocked("settings disabled the remote listener mid-reconcile")
+		sup.reportLocked("", nil)
+		return nil
+	}
+
+	old := sup.server
+	sup.server = ns
+	sup.run(func() { _ = ns.Serve() })
+
+	if old != nil {
+		// Live connections on the OLD address are cut, deliberately.
+		//
+		// `listen` is the reachability control. If sessions established on the
+		// old address survived the move, then narrowing the bind (0.0.0.0 →
+		// 127.0.0.1, say) would not actually narrow anything for the client
+		// that most matters — and this protocol holds persistent connections in
+		// a scanner loop, so "they will drop eventually" means "never". That is
+		// the same reasoning ADR-010 decision 8 applies to revocation, and the
+		// answer is the same here.
+		//
+		// The cost is bounded and visible: an in-flight call on the old socket
+		// fails, and the client reconnects at the new address with its identity
+		// and grants untouched. Nothing about the client's authorization
+		// changed — only where relay listens.
+		//
+		// StopAccepting is synchronous so the old address stops answering
+		// before this returns; the drain is not, because a handler blocked in a
+		// tool call would otherwise hold the settings poll for as long as the
+		// MCP takes.
+		old.StopAccepting()
+		ClearEnrolmentRevocationHookFor(old)
+		sup.run(old.Close)
+		slog.Warn("remote listener moved; connections on the old address were closed",
+			"from", old.cfg.Listen, "to", ns.Addr())
+	}
+
+	// No "reconciled" line here: NewRemoteServer already logged the address it
+	// bound, and a second line saying the same thing on every change is how a
+	// log stops being read.
+	sup.reportLocked(desired.Listen, nil)
+	return nil
+}
+
+// StopAccepting closes the listener and latches the supervisor shut, so a
+// reconcile racing shutdown cannot bind a fresh socket behind it. Phase one of
+// the tray's drain-then-kill cleanup.
+func (sup *RemoteSupervisor) StopAccepting() {
+	if sup == nil {
+		return
+	}
+	sup.mu.Lock()
+	defer sup.mu.Unlock()
+	sup.closed = true
+	sup.server.StopAccepting()
+}
+
+// Close completes shutdown, draining the live listener's handlers. Synchronous:
+// at shutdown the caller genuinely does want to wait.
+func (sup *RemoteSupervisor) Close() {
+	if sup == nil {
+		return
+	}
+	sup.mu.Lock()
+	sup.closed = true
+	s := sup.server
+	sup.server = nil
+	sup.mu.Unlock()
+	s.Close()
+}
+
+// stopLocked tears the live listener down and leaves nothing in its place.
+// Silent when there was nothing running, so the disabled steady state — by far
+// the most common configuration — says nothing on every poll.
+func (sup *RemoteSupervisor) stopLocked(why string) {
+	if sup.server == nil {
+		return
+	}
+	old := sup.server
+	sup.server = nil
+	old.StopAccepting()
+	// Clear here rather than leaving it to the background drain: after this
+	// call there is no listener, and a revocation must not be handed to a
+	// closure over a torn-down server.
+	ClearEnrolmentRevocationHookFor(old)
+	sup.run(old.Close)
+	slog.Warn("remote listener stopped", "addr", old.cfg.Listen, "reason", why)
+}
+
+// reportLocked logs a state change once. addr+err identical to last time means
+// the situation has not changed, so the repeat goes to debug: this runs on a
+// two-second poll, and a misconfigured port must not bury the log.
+func (sup *RemoteSupervisor) reportLocked(addr string, err error) {
+	key := addr
+	if err != nil {
+		key += "\x00" + err.Error()
+	}
+	repeat := key == sup.lastReport
+	sup.lastReport = key
+	if err == nil {
+		return
+	}
+	if repeat {
+		slog.Debug("remote listener still not available", "listen", addr, "error", err)
+		return
+	}
+	slog.Error("remote listener not available", "listen", addr, "error", err)
+}
+
+// run launches fn on the owner's waitgroup when there is one. Tests pass nil
+// and get a bare goroutine.
+func (sup *RemoteSupervisor) run(fn func()) {
+	if sup.goFunc != nil {
+		sup.goFunc(fn)
+		return
+	}
+	go fn()
+}

--- a/remote_reconcile_test.go
+++ b/remote_reconcile_test.go
@@ -1,0 +1,596 @@
+package main
+
+// The remote listener follows settings.json instead of freezing whatever was
+// true at startup — both halves of it:
+//
+//   - The AUTHORIZATION half (issue #21): an enrolment written by another
+//     process is honoured by an already-running listener, and one deleted by
+//     another process stops being honoured, without waiting for a settings
+//     poll or a restart.
+//   - The LIFECYCLE half: `remote.enabled` and `remote.listen` bind, move and
+//     close the listener as they change, and the refusals ADR-010 builds on
+//     (no listener unless explicitly enabled, no listener without auditing)
+//     hold at reconcile time and not merely at launch.
+//
+// Everything here is hermetic: a sandboxed config dir per test, 127.0.0.1:0
+// with the port read back off the listener, and never a byte written outside
+// the sandbox.
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"relaygo/bridge"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// supervise builds a supervisor over the fixture's store, router and recorder.
+// Nothing is bound until Reconcile runs — which is the point: the supervisor
+// only ever opens what the configuration describes.
+//
+// Cleanup clears the revocation hook unconditionally as well as closing the
+// listener, because the hook is a process-global and a test that deliberately
+// leaves a listener replaced must not leak its owner into the next test.
+func (f *remoteFixture) supervise() *RemoteSupervisor {
+	f.t.Helper()
+	sup := NewRemoteSupervisor(context.Background(), f.store, f.router, f.audit, nil)
+	f.t.Cleanup(func() {
+		sup.Close()
+		SetEnrolmentRevocationHook(nil)
+	})
+	return sup
+}
+
+// cliWriter returns a SECOND, independent store over the same config dir. That
+// is precisely what `relay enrol create` is — another process, with its own
+// cache, writing the same settings.json — and it is the condition issue #21
+// occurs under. Nothing in these tests may reach the running listener's store,
+// or the test proves only that a process can read its own writes.
+func (f *remoteFixture) cliWriter() SettingsStore {
+	return NewSettingsStoreAt(f.dir)
+}
+
+// dialAddr connects to an explicit address with an explicit bundle, so a test
+// can dial a listener the fixture does not own (the supervisor's) or use a
+// certificate the fixture did not create (one a CLI process enrolled).
+func (f *remoteFixture) dialAddr(addr string, b *enrolmentBundle) *remoteTestClient {
+	f.t.Helper()
+	cert, err := tls.LoadX509KeyPair(b.CertPath, b.KeyPath)
+	assertNoErr(f.t, err, "load client keypair from bundle")
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      f.caPool(),
+	})
+	if err != nil {
+		return nil
+	}
+	f.t.Cleanup(func() { _ = conn.Close() })
+	return &remoteTestClient{t: f.t, conn: conn, scanner: bridge.NewScanner(conn)}
+}
+
+// freeLoopbackAddr reserves an ephemeral loopback port and immediately releases
+// it, so a test can name a concrete address that is free. Never a hardcoded
+// port: a fixed one collides with the developer's own running relay.
+func freeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assertNoErr(t, err, "reserve a loopback port")
+	addr := ln.Addr().String()
+	assertNoErr(t, ln.Close(), "release the reserved port")
+	return addr
+}
+
+// occupiedLoopbackAddr holds a loopback port for the test's lifetime, so a bind
+// of that address genuinely fails.
+func occupiedLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assertNoErr(t, err, "occupy a loopback port")
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().String()
+}
+
+// assertNothingListensAt fails if a TCP connection to addr succeeds. This is
+// what "the listener stopped" has to mean — the port answering with a refusal
+// would still be a listener.
+func assertNothingListensAt(t *testing.T, addr, what string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: something is still accepting connections on %s", what, addr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// assertConnectionStopsAnswering fails unless the connection stops serving
+// requests within a short window. Polled rather than checked once: the socket
+// is closed by a watchdog goroutine when its context is cancelled, so "closed"
+// is prompt but not synchronous with the call that caused it.
+func assertConnectionStopsAnswering(t *testing.T, c *remoteTestClient, what string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if err := c.sendRaw(`{"type":"ListTools"}`); err != nil {
+			return
+		}
+		if _, err := c.readFrame(); err != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: the connection was still being served", what)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue #21: a record written by another process is honoured immediately
+// ---------------------------------------------------------------------------
+
+// The headline. `relay enrol create` runs in a CLI process; the tray owns the
+// listener. Before the fix the listener resolved certificates against its own
+// cached settings, so a freshly created enrolment was refused as "certificate
+// is not enrolled" until the tray's next settings poll — a refusal
+// indistinguishable from a genuine misconfiguration, whose diagnostic sends the
+// operator to `relay enrol list`, which shows the record present.
+func TestRemoteServer_AcceptsAnEnrolmentCreatedByAnotherProcess(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+
+	// Enrol through a second store. The running listener's store never sees
+	// this call — only the file does.
+	bundle, err := createEnrolment(f.cliWriter(), enrolmentRequest{
+		ClientID:   "hermes-cli",
+		ProjectIDs: []string{f.project.ID},
+	})
+	assertNoErr(t, err, "createEnrolment through a separate settings writer")
+
+	// Precondition, not decoration: this test is only meaningful while the
+	// listener's own cached view still lags the file. If this ever fails, the
+	// cache stopped lagging and the test no longer exercises issue #21 — read
+	// the fix before deleting the assertion.
+	if f.store.Get().FindEnrolmentByFingerprint(bundle.Enrolment.Fingerprint) != nil {
+		t.Fatal("the listener's cached settings already hold the new enrolment; " +
+			"this test no longer reproduces the cross-process condition it was written for")
+	}
+
+	c := f.dialAddr(f.server.Addr(), bundle)
+	if c == nil {
+		t.Fatal("a client enrolled by another process could not complete the handshake")
+	}
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("an enrolment created by another process was refused: %s %s", resp.Type, resp.Message)
+	}
+	if resp := c.roundTrip(`{"type":"CallTool","name":"mail_search"}`); resp.Type != bridge.RespResult {
+		t.Fatalf("a tool call on a freshly created enrolment was refused: %s %s", resp.Type, resp.Message)
+	}
+}
+
+// The asymmetry the fix had to preserve, from the other side: a record DELETED
+// by another process must stop being honoured on the very next request, on a
+// connection that is already open. The revocation hook cannot help here — it is
+// a process-global, and the process doing the deleting is not the one holding
+// the socket — so this is exactly the guarantee that rests on re-resolving the
+// enrolment from the file on every request.
+func TestRemoteServer_RevocationByAnotherProcessTakesEffectMidSession(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("baseline ListTools failed: %s", resp.Message)
+	}
+
+	// Delete the record through a second store and do NOT fire the hook: this
+	// is the cross-process shape, where the listener is never told.
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		if _, ok := s.RemoveEnrolment("hermes-mail"); !ok {
+			t.Error("the enrolment was not there to remove")
+		}
+	}), "revoke through a separate settings writer")
+
+	resp := c.roundTrip(`{"type":"CallTool","name":"mail_search"}`)
+	if resp.Type != bridge.RespError {
+		t.Fatalf("a revoked certificate was still served on its open connection: %s", resp.Type)
+	}
+	if !strings.Contains(resp.Message, "no longer enrolled") {
+		t.Errorf("refusal message = %q, want it to name the missing enrolment", resp.Message)
+	}
+	if f.mcpCalls.Load() != 0 {
+		t.Error("a revoked certificate reached an MCP")
+	}
+}
+
+// And in-process revocation still severs the live SOCKET rather than merely
+// refusing the next request — the stronger guarantee, unchanged. Kept beside
+// the cross-process test so the difference between the two is visible: one
+// closes the connection, the other refuses on it.
+func TestRemoteServer_InProcessRevocationStillClosesTheConnection(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("baseline ListTools failed: %s", resp.Message)
+	}
+	if _, err := revokeEnrolment(f.store, "hermes-mail"); err != nil {
+		t.Fatalf("revokeEnrolment: %v", err)
+	}
+	assertConnectionStopsAnswering(t, c, "a revoked enrolment's live connection")
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle: enable, disable
+// ---------------------------------------------------------------------------
+
+// Turning the block on binds a listener and turning it off closes it, with no
+// restart in between — and "off" means the port stops answering, not that calls
+// start being refused.
+func TestRemoteSupervisor_EnablingStartsAListenerAndDisablingStopsIt(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{noRemoteBlock: true, skipServe: true})
+	sup := f.supervise()
+
+	assertNoErr(t, sup.Reconcile(), "reconcile with no remote block")
+	if addr := sup.Addr(); addr != "" {
+		t.Fatalf("a listener was opened with no remote block, bound to %s", addr)
+	}
+
+	// Enable it from another process.
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Remote = &RemoteConfig{Enabled: ptr(true), Listen: "127.0.0.1:0"}
+	}), "enable the remote block")
+
+	assertNoErr(t, sup.Reconcile(), "reconcile after enabling")
+	addr := sup.Addr()
+	if addr == "" {
+		t.Fatal("enabling the remote block did not open a listener")
+	}
+	c := f.dialAddr(addr, f.bundle)
+	if c == nil {
+		t.Fatalf("the newly bound listener at %s refused a handshake", addr)
+	}
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("the newly bound listener refused an enrolled client: %s %s", resp.Type, resp.Message)
+	}
+
+	// Disable it again.
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Remote = &RemoteConfig{Enabled: ptr(false), Listen: "127.0.0.1:0"}
+	}), "disable the remote block")
+
+	assertNoErr(t, sup.Reconcile(), "reconcile after disabling")
+	if got := sup.Addr(); got != "" {
+		t.Fatalf("disabling left a listener bound to %s", got)
+	}
+	assertNothingListensAt(t, addr, "after disabling the remote block")
+	assertConnectionStopsAnswering(t, c, "a connection open when the listener was disabled")
+}
+
+// The safe default has to survive reconciliation, which is the one place it
+// could quietly be lost: an absent block and a block that names an address but
+// omits `enabled` must BOTH stay closed, however many times convergence runs.
+// This is deliberately the opposite of AuditConfig's default — a missing audit
+// block keeps recording, a missing remote enable opens nothing — because
+// starting a network listener nobody asked for is the failure ADR-010 exists to
+// avoid.
+func TestRemoteSupervisor_NeverOpensAListenerConfigDoesNotAskFor(t *testing.T) {
+	for name, opts := range map[string]remoteFixtureOpts{
+		"absent block":    {noRemoteBlock: true, skipServe: true},
+		"enabled omitted": {omitEnabled: true, skipServe: true},
+		"explicit false":  {enabled: ptr(false), skipServe: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newRemoteFixture(t, opts)
+			sup := f.supervise()
+			for i := 0; i < 3; i++ {
+				assertNoErr(t, sup.Reconcile(), "reconcile %d", i)
+				if addr := sup.Addr(); addr != "" {
+					t.Fatalf("reconcile %d opened a listener at %s for %q", i, addr, name)
+				}
+			}
+			if owner := enrolmentRevocationHookOwner(); owner != nil {
+				t.Errorf("a revocation hook was installed with no listener running: %v", owner)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle: rebinding
+// ---------------------------------------------------------------------------
+
+// Changing `remote.listen` moves the listener: the new address serves and the
+// old one stops answering. Live connections on the old address are CUT, and
+// that is a decision rather than an accident — `listen` is the reachability
+// control, so a narrowed bind that left established sessions running on the old
+// address would not have narrowed anything for the client that matters most,
+// and this protocol holds persistent connections in a scanner loop, so "they
+// drop eventually" means never. The client reconnects at the new address with
+// its identity and grants untouched.
+func TestRemoteSupervisor_ChangingTheListenAddressMovesTheListener(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{skipServe: true})
+	sup := f.supervise()
+	assertNoErr(t, sup.Reconcile(), "initial reconcile")
+
+	first := sup.Addr()
+	if first == "" {
+		t.Fatal("no listener was bound")
+	}
+	c := f.dialAddr(first, f.bundle)
+	if c == nil {
+		t.Fatal("could not connect to the first listener")
+	}
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("baseline ListTools on the first address failed: %s", resp.Message)
+	}
+
+	moved := freeLoopbackAddr(t)
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Remote = &RemoteConfig{Enabled: ptr(true), Listen: moved}
+	}), "move the listen address")
+
+	assertNoErr(t, sup.Reconcile(), "reconcile after moving the listen address")
+	if got := sup.Addr(); got != moved {
+		t.Fatalf("listener is bound to %q, want the newly configured %q", got, moved)
+	}
+	assertNothingListensAt(t, first, "after the listen address moved")
+	assertConnectionStopsAnswering(t, c, "a connection open on the old address")
+
+	// The move is only real if the new address actually serves.
+	c2 := f.dialAddr(moved, f.bundle)
+	if c2 == nil {
+		t.Fatalf("the moved listener at %s refused a handshake", moved)
+	}
+	if resp := c2.roundTrip(`{"type":"CallTool","name":"mail_search"}`); resp.Type != bridge.RespResult {
+		t.Fatalf("the moved listener refused an enrolled client: %s %s", resp.Type, resp.Message)
+	}
+}
+
+// A reconcile that changes nothing must change nothing: rebinding an unchanged
+// address every poll would cut every live connection every two seconds.
+func TestRemoteSupervisor_RepeatedReconcileLeavesTheListenerAndItsConnectionsAlone(t *testing.T) {
+	addr := freeLoopbackAddr(t)
+	f := newRemoteFixture(t, remoteFixtureOpts{listen: addr, skipServe: true})
+	sup := f.supervise()
+	assertNoErr(t, sup.Reconcile(), "initial reconcile")
+
+	server := sup.Server()
+	c := f.dialAddr(addr, f.bundle)
+	if c == nil {
+		t.Fatal("could not connect to the listener")
+	}
+
+	for i := 0; i < 3; i++ {
+		assertNoErr(t, sup.Reconcile(), "no-op reconcile %d", i)
+		if sup.Server() != server {
+			t.Fatalf("no-op reconcile %d replaced the listener", i)
+		}
+		if got := sup.Addr(); got != addr {
+			t.Fatalf("no-op reconcile %d moved the listener to %s", i, got)
+		}
+		if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+			t.Fatalf("no-op reconcile %d disturbed a live connection: %s %s", i, resp.Type, resp.Message)
+		}
+	}
+}
+
+// A rebind that cannot bind must be LOUD and must leave the old listener
+// serving. The failure this guards against is the quiet one: no listener, no
+// error, and an operator who believes the address change took.
+func TestRemoteSupervisor_FailedRebindKeepsTheOldListenerAndReportsTheError(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{skipServe: true})
+	sup := f.supervise()
+	assertNoErr(t, sup.Reconcile(), "initial reconcile")
+
+	first := sup.Addr()
+	if first == "" {
+		t.Fatal("no listener was bound")
+	}
+
+	taken := occupiedLoopbackAddr(t)
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Remote = &RemoteConfig{Enabled: ptr(true), Listen: taken}
+	}), "point listen at an occupied port")
+
+	err := sup.Reconcile()
+	if err == nil {
+		t.Fatal("binding an occupied port reported no error")
+	}
+	if !strings.Contains(err.Error(), taken) {
+		t.Errorf("the error does not name the address that could not be bound: %v", err)
+	}
+	if got := sup.Addr(); got != first {
+		t.Fatalf("a failed rebind left the listener at %q, want the old %q still serving", got, first)
+	}
+
+	// Still serving, not merely still bound.
+	c := f.dialAddr(first, f.bundle)
+	if c == nil {
+		t.Fatal("the old listener stopped accepting after a failed rebind")
+	}
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("the old listener stopped serving after a failed rebind: %s %s", resp.Type, resp.Message)
+	}
+
+	// And the hook still points at the listener that is actually live.
+	if owner := enrolmentRevocationHookOwner(); owner != sup.Server() {
+		t.Errorf("after a failed rebind the revocation hook owner is %v, want the live listener %v", owner, sup.Server())
+	}
+}
+
+// The same failure from cold: nothing bound, and the operator is told. There is
+// no listener to fall back on, so the error is the whole of the report.
+func TestRemoteSupervisor_FailedFirstBindOpensNothingAndReportsTheError(t *testing.T) {
+	taken := occupiedLoopbackAddr(t)
+	f := newRemoteFixture(t, remoteFixtureOpts{listen: taken, skipServe: true})
+	sup := f.supervise()
+
+	err := sup.Reconcile()
+	if err == nil {
+		t.Fatal("binding an occupied port from cold reported no error")
+	}
+	if got := sup.Addr(); got != "" {
+		t.Fatalf("a failed first bind left a listener at %s", got)
+	}
+
+	// It retries: freeing the address is enough, with no operator action.
+	free := freeLoopbackAddr(t)
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Remote = &RemoteConfig{Enabled: ptr(true), Listen: free}
+	}), "point listen at a free port")
+	assertNoErr(t, sup.Reconcile(), "reconcile after the address became bindable")
+	if got := sup.Addr(); got != free {
+		t.Fatalf("listener is bound to %q, want %q", got, free)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auditing is a hard dependency, at runtime and not only at launch
+// ---------------------------------------------------------------------------
+
+// The case for letting a VM reach host mail rests entirely on the calls being
+// recorded. Turning auditing off therefore has to CLOSE the listener — leaving
+// it serving until the next restart would make the refusal decorative — and it
+// has to cut the connections already established, because a live socket is
+// exactly where an unrecorded call would come from.
+func TestRemoteSupervisor_DisablingAuditingAtRuntimeStopsTheListener(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{skipServe: true})
+	sup := f.supervise()
+	assertNoErr(t, sup.Reconcile(), "initial reconcile")
+
+	addr := sup.Addr()
+	if addr == "" {
+		t.Fatal("no listener was bound")
+	}
+	c := f.dialAddr(addr, f.bundle)
+	if c == nil {
+		t.Fatal("could not connect to the listener")
+	}
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("baseline ListTools failed: %s", resp.Message)
+	}
+
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Audit = &AuditConfig{Enabled: ptr(false)}
+	}), "disable auditing")
+
+	err := sup.Reconcile()
+	if err == nil {
+		t.Fatal("disabling auditing left the listener running and reported nothing")
+	}
+	if !strings.Contains(err.Error(), "audit") {
+		t.Errorf("the refusal does not explain itself to an operator: %v", err)
+	}
+	if got := sup.Addr(); got != "" {
+		t.Fatalf("disabling auditing left a listener bound to %s", got)
+	}
+	assertNothingListensAt(t, addr, "after auditing was disabled")
+	assertConnectionStopsAnswering(t, c, "a connection open when auditing was disabled")
+	if f.mcpCalls.Load() != 0 {
+		t.Error("a tool call ran after auditing was disabled")
+	}
+}
+
+// Between the settings write and the next reconcile there is a window of up to
+// one poll interval, and a request arriving in it must still be refused: the
+// per-request path re-reads the audit setting for the same reason it re-reads
+// the enrolment. Nothing here reconciles — that is the point.
+func TestRemoteServer_RefusesCallsAsSoonAsAuditingIsDisabled(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	c := f.dial()
+
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("baseline ListTools failed: %s", resp.Message)
+	}
+
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Audit = &AuditConfig{Enabled: ptr(false)}
+	}), "disable auditing")
+
+	resp := c.roundTrip(`{"type":"CallTool","name":"mail_search"}`)
+	if resp.Type != bridge.RespError {
+		t.Fatalf("a call ran with auditing disabled: %s", resp.Type)
+	}
+	if !strings.Contains(resp.Message, "audit") {
+		t.Errorf("refusal message = %q, want it to name auditing", resp.Message)
+	}
+	if f.mcpCalls.Load() != 0 {
+		t.Error("a call with auditing disabled reached an MCP")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The revocation hook survives a reconcile cycle
+// ---------------------------------------------------------------------------
+
+// A rebind tears down one listener and builds another, and the revocation hook
+// is a process-global that both of them touch. Get the ordering wrong — clear
+// on teardown after the replacement installed its own — and revocation silently
+// stops severing live connections while every test that only looks at the
+// deleted record still passes. So: exactly one hook, owned by the listener that
+// is actually live, and it still works.
+func TestRemoteSupervisor_RevocationHookIsInstalledOnceAndFollowsTheLiveListener(t *testing.T) {
+	f := newRemoteFixture(t, remoteFixtureOpts{skipServe: true})
+	sup := f.supervise()
+	assertNoErr(t, sup.Reconcile(), "initial reconcile")
+
+	first := sup.Server()
+	if first == nil {
+		t.Fatal("no listener was bound")
+	}
+	if owner := enrolmentRevocationHookOwner(); owner != first {
+		t.Fatalf("revocation hook owner = %v, want the listener just started %v", owner, first)
+	}
+
+	moved := freeLoopbackAddr(t)
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Remote = &RemoteConfig{Enabled: ptr(true), Listen: moved}
+	}), "move the listen address")
+	assertNoErr(t, sup.Reconcile(), "reconcile after moving the listen address")
+
+	second := sup.Server()
+	if second == nil || second == first {
+		t.Fatalf("the rebind did not produce a new listener (got %v, was %v)", second, first)
+	}
+	owner := enrolmentRevocationHookOwner()
+	if owner == nil {
+		t.Fatal("the rebind left NO revocation hook installed: revocation would no longer cut live connections")
+	}
+	if owner != second {
+		t.Fatalf("revocation hook owner = %v, want the live listener %v", owner, second)
+	}
+
+	// Installed is not the same as working. Revoke for real and watch the live
+	// connection on the CURRENT listener go.
+	c := f.dialAddr(moved, f.bundle)
+	if c == nil {
+		t.Fatal("could not connect to the moved listener")
+	}
+	if resp := c.roundTrip(`{"type":"ListTools"}`); resp.Type != bridge.RespTools {
+		t.Fatalf("baseline ListTools on the moved listener failed: %s", resp.Message)
+	}
+	if _, err := revokeEnrolment(f.store, "hermes-mail"); err != nil {
+		t.Fatalf("revokeEnrolment: %v", err)
+	}
+	assertConnectionStopsAnswering(t, c, "a revoked enrolment's connection on the rebound listener")
+
+	// And stopping altogether leaves no hook behind pointing at a dead server.
+	assertNoErr(t, f.cliWriter().With(func(s *Settings) {
+		s.Remote = &RemoteConfig{Enabled: ptr(false)}
+	}), "disable the remote block")
+	assertNoErr(t, sup.Reconcile(), "reconcile after disabling")
+	if owner := enrolmentRevocationHookOwner(); owner != nil {
+		t.Errorf("a stopped listener left its revocation hook installed: %v", owner)
+	}
+}

--- a/remote_server.go
+++ b/remote_server.go
@@ -173,6 +173,12 @@ func handleRemoteCallTool(ctx context.Context, req *bridge.RemoteRequest, router
 type RemoteServer struct {
 	router RemoteToolRouter
 	store  SettingsStore
+	// cfg is the resolved configuration this listener was BUILT from, kept so
+	// RemoteSupervisor can answer "does the live listener still match what
+	// settings ask for?" without re-deriving it. Written once at construction
+	// and never mutated: a listener does not change its address, it is replaced
+	// by one that has the new address.
+	cfg resolvedRemoteConfig
 	// audit is held only to re-assert that recording is live. RemoteServer
 	// never writes an event itself — that happens at appRouter.CallTool, the
 	// chokepoint every transport funnels through.
@@ -189,6 +195,29 @@ type RemoteServer struct {
 	// on a record that has, by the time the hook fires, already been deleted.
 	mu    sync.Mutex
 	conns map[string]map[*remoteConn]struct{}
+}
+
+// currentSettings is the ONLY way this listener may read settings. Every
+// decision here — is this certificate enrolled, does the enrolment still hold
+// this grant, is auditing still on — is an authorization decision, and relay is
+// not one process: `relay enrol create`, `relay enrol revoke` and a hand-edited
+// settings.json all happen outside the tray. See freshSettings for the cost.
+func (s *RemoteServer) currentSettings() *Settings {
+	return freshSettings(s.store)
+}
+
+// remoteAuditingLive reports whether a remote call may run at all: the recorder
+// must be recording AND settings must still ask for it.
+//
+// Both halves are load-bearing and neither implies the other. The recorder can
+// die under a listener that started cleanly (a closed writer, a rotation
+// failure), and settings can be edited to `audit.enabled: false` in another
+// process while a recorder from before the edit is still happily writing. The
+// first is the fail-closed case ADR-010 decision 5 is about; the second is the
+// operator saying remote access is no longer justified, and honouring it only
+// at the next process start would make the setting look decorative.
+func remoteAuditingLive(s *Settings, audit *AuditRecorder) bool {
+	return audit.Enabled() && s.Audit.resolve().Enabled
 }
 
 // remoteConn is one live, authenticated connection.
@@ -216,13 +245,18 @@ type remoteConn struct {
 //   - No CA, or no server certificate → refused, since there is no meaningful
 //     degraded mode for mutual TLS.
 func NewRemoteServer(ctx context.Context, store SettingsStore, router RemoteToolRouter, audit *AuditRecorder) (*RemoteServer, error) {
-	cfg := store.Get().Remote.resolve()
+	// freshSettings, not Get(): the operator who just edited settings.json in a
+	// CLI process is the same operator watching for the listener to come up, and
+	// deciding whether to open a network socket off a snapshot that predates
+	// their edit is the same class of bug as issue #21, one level out.
+	settings := freshSettings(store)
+	cfg := settings.Remote.resolve()
 	if !cfg.Enabled {
 		slog.Debug("remote listener not enabled; no socket opened")
 		return nil, nil
 	}
 
-	if !audit.Enabled() {
+	if !remoteAuditingLive(settings, audit) {
 		return nil, fmt.Errorf("remote listener refuses to start while the tool-call audit log is disabled: " +
 			"a remote grant is justified by the calls it records, so serving remote traffic unrecorded is not a degraded mode — " +
 			"set audit.enabled to true, or remove the remote block from settings.json")
@@ -262,6 +296,7 @@ func NewRemoteServer(ctx context.Context, store SettingsStore, router RemoteTool
 	s := &RemoteServer{
 		router:   router,
 		store:    store,
+		cfg:      cfg,
 		audit:    audit,
 		listener: ln,
 		ctx:      sctx,
@@ -275,7 +310,13 @@ func NewRemoteServer(ctx context.Context, store SettingsStore, router RemoteTool
 	// indefinitely (decision 8). The enrolment code deletes the record and
 	// fires this hook; closing the socket is ours because the connection table
 	// is ours.
-	SetEnrolmentRevocationHook(s.closeEnrolment)
+	//
+	// Installed WITH AN OWNER because this listener can be replaced without the
+	// process restarting (RemoteSupervisor, remote_reconcile.go): a rebind binds
+	// the new address before closing the old listener, so the old one's teardown
+	// has to be able to tell that the hook is no longer its own and leave the
+	// live server's hook alone.
+	SetEnrolmentRevocationHookFor(s, s.closeEnrolment)
 
 	slog.Info("remote listener started", "addr", ln.Addr().String())
 	return s, nil
@@ -348,8 +389,12 @@ func (s *RemoteServer) Close() {
 	s.StopAccepting()
 	// Drop the hook before draining: a revocation arriving mid-shutdown has
 	// nothing left to close, and leaving a closure over a dead server installed
-	// in a process-global would keep it reachable after teardown.
-	SetEnrolmentRevocationHook(nil)
+	// in a process-global would keep it reachable after teardown. Compare-and-
+	// clear, never an unconditional clear: on a rebind the REPLACEMENT listener
+	// already owns the hook by the time this runs, and uninstalling it here
+	// would leave revocation unable to sever a live connection — a security
+	// regression no test that checks only the deleted record would catch.
+	ClearEnrolmentRevocationHookFor(s)
 	s.wg.Wait()
 }
 
@@ -412,7 +457,15 @@ func (s *RemoteServer) handleConn(conn net.Conn) {
 	}
 
 	fingerprint := FingerprintCert(state.PeerCertificates[0])
-	enrolment := s.store.Get().FindEnrolmentByFingerprint(fingerprint)
+	// currentSettings, not Get(): `relay enrol create` runs in a CLI PROCESS
+	// and writes settings.json, so a cached view here refuses a brand-new
+	// enrolment as "not enrolled" until the tray's next settings poll — a
+	// refusal indistinguishable from a genuine misconfiguration, and one whose
+	// diagnostic sends the operator to `relay enrol list`, which shows the
+	// record present (issue #21). Reading the file is what makes creation as
+	// immediate as revocation already was.
+	settings := s.currentSettings()
+	enrolment := settings.FindEnrolmentByFingerprint(fingerprint)
 	if enrolment == nil {
 		// A CA-signed certificate that no enrolment claims. This is the state a
 		// revoked client is in, and it gets no request read and no error frame
@@ -423,9 +476,12 @@ func (s *RemoteServer) handleConn(conn net.Conn) {
 	}
 
 	// Belt and braces against a window the start-up refusal cannot cover: the
-	// recorder could have been closed under us. There must be no path on which
-	// a remote call runs unrecorded.
-	if !s.audit.Enabled() {
+	// recorder could have been closed under us, or auditing could have been
+	// turned off in settings since this listener bound. RemoteSupervisor stops
+	// the listener when that happens, but "on the next reconcile" is not soon
+	// enough for a connection arriving in between — there must be no path on
+	// which a remote call runs unrecorded.
+	if !remoteAuditingLive(settings, s.audit) {
 		slog.Error("remote: closing connection, auditing is not active",
 			"client_id", enrolment.ClientID, "remote_addr", conn.RemoteAddr().String())
 		return
@@ -487,10 +543,17 @@ func (s *RemoteServer) handleRequest(ctx context.Context, fingerprint, line stri
 // resolve cleanly. This is the chain the whole design rests on, so each link
 // is spelled out:
 //
-//  1. Re-resolve the ENROLMENT from current settings on every request, not
-//     once per connection. A revocation that raced the connection table, or a
-//     grant edited while the socket stayed open, must take effect on the next
-//     call rather than at the next reconnect.
+//  0. Re-check that auditing is live, because the answer can change under an
+//     open connection and a remote call that cannot be recorded is refused
+//     rather than served (decision 5). Per REQUEST, not per connection, for the
+//     same reason step 1 is.
+//  1. Re-resolve the ENROLMENT from CURRENT ON-DISK settings on every request,
+//     not once per connection and not from a cached snapshot. A revocation that
+//     raced the connection table, a grant edited while the socket stayed open,
+//     or a record written by a CLI process in another PID must take effect on
+//     the next call rather than at the next reconnect or the next settings
+//     poll. This is the step that already made revocation immediate; reading
+//     through to the file is what extends the same immediacy to creation.
 //  2. Select the project id. An enrolment holding exactly one grant may leave
 //     it off — sending it would be ceremony. An enrolment holding several must
 //     say which, because guessing would make the choice relay's rather than
@@ -510,7 +573,12 @@ func (s *RemoteServer) handleRequest(ctx context.Context, fingerprint, line stri
 //     decision 2 could delete the token from the remote path without changing
 //     anything below the transport.
 func (s *RemoteServer) resolveGrant(fingerprint, projectID string) (string, error) {
-	settings := s.store.Get()
+	settings := s.currentSettings()
+
+	if !remoteAuditingLive(settings, s.audit) {
+		return "", jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized,
+			fmt.Errorf("remote calls are refused while the tool-call audit log is disabled"))
+	}
 
 	enrolment := settings.FindEnrolmentByFingerprint(fingerprint)
 	if enrolment == nil {

--- a/settings_enrolments_ui_test.go
+++ b/settings_enrolments_ui_test.go
@@ -1,0 +1,551 @@
+package main
+
+// Remote Clients tab under goja, using the same bundle + DOM shim as
+// settings_bundle_test.go. ADR-010 decision 8 says enrolments are listed
+// "beside the grants they reach — a credential you cannot see is one you will
+// not revoke", so these tests pin the parts of that sentence a reviewer
+// actually depends on: that a grant reads as a project NAME, that the
+// certificate fingerprint reaches the screen whole, that no key material has
+// any path into the page, and that the three states of the `remote` block are
+// told apart rather than collapsed into "not working".
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+// Two remote projects and one local one. The local project exists so the
+// "only remote projects are offered" test has something to fail against.
+const enrolProjectsFixture = `[
+	{id:'p_mail', name:'Mail', kind:'remote', allowed_mcp_ids:['macmcp'], allowed_models:[], disabled_tools:{}},
+	{id:'p_cal',  name:'Calendar', kind:'remote', allowed_mcp_ids:['macmcp'], allowed_models:[], disabled_tools:{}},
+	{id:'p_work', name:'Workspace', path:'/Users/x/work', allowed_mcp_ids:['*'], allowed_models:['*'], disabled_tools:{}}
+]`
+
+// A full sha256 fingerprint — 64 hex characters after the prefix, which is the
+// length the UI must render without shortening.
+const enrolFingerprint = "sha256:9f2a4c1d6b8e0f37a5c9d2e4b6081f3a7c5e9d1b3f5a7c9e1d3b5f7a9c1e3d5b"
+
+const enrolmentsFixture = `[{
+	client_id: 'hermes-mail',
+	fingerprint: '` + enrolFingerprint + `',
+	project_ids: ['p_mail', 'p_cal'],
+	budget: { window_seconds: 60, max_calls: 60, max_result_bytes: 8388608 },
+	created_at: '2026-08-20T09:14:00Z'
+}]`
+
+const remoteEnabled = `{configured:true, enabled:true, listen:'127.0.0.1:9910', effective:'127.0.0.1:9910', audit_enabled:true}`
+const remoteDisabled = `{configured:true, enabled:false, listen:'127.0.0.1:9910', effective:'127.0.0.1:9910', audit_enabled:true}`
+const remoteAbsent = `{configured:false, enabled:false, listen:'', effective:'127.0.0.1:9910', audit_enabled:true}`
+const remoteAuditOff = `{configured:true, enabled:true, listen:'127.0.0.1:9910', effective:'127.0.0.1:9910', audit_enabled:false}`
+
+// seedRemoteVM loads the app bundle, switches to the Remote Clients tab, and
+// installs the two browser affordances the shim lacks: confirm() (captured, so
+// a test can read the destructive prompt) and the webkit IPC channel (captured,
+// so a test can read what the page actually sent).
+func seedRemoteVM(t *testing.T, projectsJSON, enrolmentsJSON, remoteJSON string) *goja.Runtime {
+	t.Helper()
+	vm := newAppVM(t)
+	script := `(function(){
+		window.__confirmed = [];
+		window.__confirmAnswer = true;
+		window.confirm = function(msg){ window.__confirmed.push(String(msg)); return window.__confirmAnswer; };
+		window.__sent = [];
+		window.webkit = { messageHandlers: { ipc: { postMessage: function(m){ window.__sent.push(String(m)); } } } };
+		window.state.page = 'remote';
+		window.state.projects = ` + projectsJSON + `;
+		window.state.enrolments = ` + enrolmentsJSON + `;
+		window.state.remote = ` + remoteJSON + `;
+		window.state.remoteDraft = null;
+		window.state.enrolForm = null;
+		window.state.enrolBundle = null;
+		window.state.enrolRevoked = null;
+		window.state.enrolmentBudgetDefaults = {window_seconds:60, max_calls:60, max_result_bytes:8388608};
+		return true;
+	})()`
+	if _, err := vm.RunString(script); err != nil {
+		t.Fatalf("seeding remote state: %v", err)
+	}
+	return vm
+}
+
+// ---------------------------------------------------------------------------
+// The list
+// ---------------------------------------------------------------------------
+
+// Grants render as project NAMES. An operator about to revoke has to know what
+// they are cutting; "p_mail, p_cal" is not that. The id survives only as the
+// chip's tooltip, so nothing is lost — it is just not what you read first.
+func TestRemoteTab_GrantsRenderAsProjectNames(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, enrolmentsFixture, remoteEnabled)
+	html := evalString(t, vm, `window.renderEnrolments()`)
+
+	for _, want := range []string{
+		"hermes-mail",                // the enrolment
+		`title="p_mail">Mail</span>`, // name is the text, id is the tooltip
+		`title="p_cal">Calendar</span>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("enrolment card is missing %q\n%s", want, html)
+		}
+	}
+}
+
+// A grant naming a project that no longer exists is SHOWN, marked, not
+// silently dropped: an enrolment holding something relay cannot resolve is
+// exactly the row an operator needs to see before deciding to revoke.
+func TestRemoteTab_DanglingGrantIsShownNotHidden(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[{
+		client_id:'ghost', fingerprint:'`+enrolFingerprint+`',
+		project_ids:['p_deleted'], budget:{window_seconds:60,max_calls:60,max_result_bytes:1024},
+		created_at:'2026-08-20T09:14:00Z'
+	}]`, remoteEnabled)
+	html := evalString(t, vm, `window.renderEnrolments()`)
+
+	if !strings.Contains(html, "p_deleted") || !strings.Contains(html, "unknown project") {
+		t.Errorf("a grant naming a missing project was not surfaced\n%s", html)
+	}
+	if !strings.Contains(html, "enrol-grant dangling") {
+		t.Error("dangling grant did not get its own class, so it reads like a normal grant")
+	}
+}
+
+// The fingerprint prints in full. After the enrolment is deleted it is the only
+// thing that identifies this client's calls in the audit log (which is why the
+// Tool Calls tab prints it whole too), so any truncation here would be the
+// obvious place for someone to copy a short form from.
+func TestRemoteTab_FingerprintRendersInFull(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, enrolmentsFixture, remoteEnabled)
+	html := evalString(t, vm, `window.renderEnrolments()`)
+
+	if !strings.Contains(html, enrolFingerprint) {
+		t.Fatalf("the full fingerprint is not on screen\n%s", html)
+	}
+	// And it is not ALSO rendered shortened somewhere — an ellipsis adjacent
+	// to a fingerprint prefix is the shape a truncation regression takes.
+	for _, bad := range []string{enrolFingerprint[:20] + "…", enrolFingerprint[:20] + "..."} {
+		if strings.Contains(html, bad) {
+			t.Errorf("a truncated fingerprint appears in the page: %q", bad)
+		}
+	}
+}
+
+// The budget is on the card, because a budget nobody can see is a budget
+// nobody will tune — and `throttled` in the audit log is meaningless without
+// the number it was measured against.
+func TestRemoteTab_BudgetIsVisibleOnTheCard(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, enrolmentsFixture, remoteEnabled)
+	html := evalString(t, vm, `window.renderEnrolments()`)
+	for _, want := range []string{"60 calls", "8 MiB", "per 60s"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("budget summary is missing %q", want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Key material
+// ---------------------------------------------------------------------------
+
+// The page holds a bundle DIRECTORY and nothing else. This drives the create
+// event with a hostile payload — one carrying key material the Go side never
+// sends — and proves the page would still not render or retain it: the only
+// field read off the bundle is `dir`.
+func TestRemoteTab_NeverRendersOrRetainsKeyMaterial(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		window.onEnrolmentCreated(
+			{client_id:'hermes-mail', fingerprint:'`+enrolFingerprint+`', project_ids:['p_mail'],
+			 budget:{window_seconds:60,max_calls:60,max_result_bytes:8388608}, created_at:'2026-08-20T09:14:00Z'},
+			{dir:'/tmp/relay/enrolments/hermes-mail',
+			 key_pem:'-----BEGIN PRIVATE KEY-----MIIEvgIBADANBgkq-----END PRIVATE KEY-----',
+			 key_path:'/tmp/relay/enrolments/hermes-mail/client.key'});
+		var html = window.renderEnrolments();
+		return JSON.stringify({
+			bundleKeys: Object.keys(window.state.enrolBundle).sort(),
+			showsDir: html.indexOf('/tmp/relay/enrolments/hermes-mail') >= 0,
+			leaksPem: html.indexOf('BEGIN PRIVATE KEY') >= 0 || html.indexOf('MIIEvgIBADANBgkq') >= 0,
+			stateLeaksPem: JSON.stringify(window.state).indexOf('MIIEvgIBADANBgkq') >= 0
+		});
+	})()`)
+
+	for _, want := range []string{
+		`"bundleKeys":["client_id","dir"]`, // nothing else is kept
+		`"showsDir":true`,
+		`"leaksPem":false`,
+		`"stateLeaksPem":false`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("bundle handling: missing %s in %s", want, got)
+		}
+	}
+}
+
+// The banner tells the operator to MOVE the directory, which is the only
+// mitigation available for a key that travels — the same thing
+// `relay enrol create` says, in the same words.
+func TestRemoteTab_BundleBannerSaysMoveNotCopy(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	html := evalString(t, vm, `(function(){
+		window.state.enrolBundle = {client_id:'hermes-mail', dir:'/tmp/relay/enrolments/hermes-mail'};
+		return window.renderEnrolments();
+	})()`)
+	for _, want := range []string{"Move (don't copy)", "client.key", "ca.crt", "/tmp/relay/enrolments/hermes-mail"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("bundle banner is missing %q", want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+// ValidateEnrolmentGrants refuses a grant naming a local project, so the form
+// must not offer one: a UI that presents a choice the server is about to
+// reject teaches the operator that refusals are arbitrary.
+func TestRemoteTab_OnlyRemoteProjectsAreOffered(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		window.newEnrolment();
+		var html = window.renderEnrolmentForm();
+		return JSON.stringify({
+			offered: window.remoteGrantableProjects().map(function(p){ return p.id; }),
+			showsMail: html.indexOf('p_mail') >= 0,
+			showsCalendar: html.indexOf('p_cal') >= 0,
+			showsLocalProject: html.indexOf('p_work') >= 0 || html.indexOf('Workspace') >= 0
+		});
+	})()`)
+
+	for _, want := range []string{
+		`"offered":["p_mail","p_cal"]`,
+		`"showsMail":true`,
+		`"showsCalendar":true`,
+		`"showsLocalProject":false`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("grant picker: missing %s in %s", want, got)
+		}
+	}
+}
+
+// With no remote project to grant, the form says where to make one rather than
+// showing an empty list that looks broken.
+func TestRemoteTab_NoRemoteProjectsExplainsWhere(t *testing.T) {
+	vm := seedRemoteVM(t, `[{id:'p_work', name:'Workspace', path:'/w', allowed_mcp_ids:['*'], allowed_models:['*'], disabled_tools:{}}]`, `[]`, remoteEnabled)
+	html := evalString(t, vm, `(function(){ window.newEnrolment(); return window.renderEnrolmentForm(); })()`)
+	if !strings.Contains(html, "No remote projects exist yet") || !strings.Contains(html, "Projects") {
+		t.Errorf("empty grant picker does not say where to create a remote project\n%s", html)
+	}
+}
+
+// The create payload carries the chosen grants and sends 0 for a blank budget
+// field — which normalizeEnrolmentBudget reads as "unset, use the conservative
+// default". Zero must never travel as, or be read as, "unlimited".
+func TestRemoteTab_CreatePayloadShape(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		window.newEnrolment();
+		window.toggleEnrolGrant('p_mail', true);
+		document.getElementById('enrolClientId').value = '  hermes-mail  ';
+		document.getElementById('enrolWindow').value = '';
+		document.getElementById('enrolMaxCalls').value = '30';
+		document.getElementById('enrolMaxBytes').value = '';
+		window.saveEnrolment();
+		return window.__sent[window.__sent.length - 1];
+	})()`)
+
+	for _, want := range []string{
+		`"type":"create_enrolment"`,
+		`"client_id":"hermes-mail"`, // trimmed
+		`"project_ids":["p_mail"]`,
+		`"window_seconds":0`, // blank -> unset -> server default
+		`"max_calls":30`,
+		`"max_result_bytes":0`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("create payload missing %s in %s", want, got)
+		}
+	}
+}
+
+// Enrolling with no grant is legal and is the expected "enrol now, widen
+// deliberately later" resting state — but it is said out loud, exactly as
+// `relay enrol create` says it, rather than silently issuing a certificate
+// that reaches nothing.
+func TestRemoteTab_ZeroGrantsIsAllowedAndAnnounced(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	html := evalString(t, vm, `(function(){ window.newEnrolment(); return window.renderEnrolmentForm(); })()`)
+	if !strings.Contains(html, "can reach no project until one is added") {
+		t.Errorf("form does not say what a grantless enrolment means\n%s", html)
+	}
+}
+
+func TestRemoteTab_CreateRequiresClientID(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		window.newEnrolment();
+		document.getElementById('enrolClientId').value = '   ';
+		window.saveEnrolment();
+		return JSON.stringify({ sent: window.__sent.length, err: window.state.enrolmentError });
+	})()`)
+	if !strings.Contains(got, `"sent":0`) {
+		t.Error("a create with no client id was sent to the backend")
+	}
+	if !strings.Contains(got, "client id is required") {
+		t.Errorf("no error shown for a missing client id: %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Revoke
+// ---------------------------------------------------------------------------
+
+// The confirmation NAMES what is being cut. "Are you sure?" over an opaque
+// client id is not a decision anyone can make, and the wording matches
+// `relay enrol revoke`: the certificate is unchanged, no project is touched,
+// and live connections close immediately.
+func TestRemoteTab_RevokeConfirmationNamesTheGrants(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, enrolmentsFixture, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		window.__confirmAnswer = false;   // decline: nothing may be sent
+		window.revokeEnrolment('hermes-mail');
+		return JSON.stringify({ prompt: window.__confirmed[0] || '', sent: window.__sent.length });
+	})()`)
+
+	for _, want := range []string{"hermes-mail", "Mail", "Calendar", "Live connections", "no project is touched"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("revoke confirmation is missing %q: %s", want, got)
+		}
+	}
+	if !strings.Contains(got, `"sent":0`) {
+		t.Error("declining the confirmation still sent a revoke")
+	}
+}
+
+// Accepting sends the revoke; the event handler then removes the row and keeps
+// the fingerprint on screen, because that is now the only thing naming this
+// client's calls in the Tool Calls log.
+func TestRemoteTab_RevokeRemovesTheRowAndKeepsTheFingerprint(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, enrolmentsFixture, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		window.revokeEnrolment('hermes-mail');
+		var sent = window.__sent[window.__sent.length - 1];
+		window.onEnrolmentRevoked('hermes-mail', '`+enrolFingerprint+`');
+		var html = window.renderEnrolments();
+		return JSON.stringify({
+			sent: sent,
+			remaining: window.state.enrolments.length,
+			keepsFingerprint: html.indexOf('`+enrolFingerprint+`') >= 0,
+			showsEmptyState: html.indexOf('No enrolled clients') >= 0
+		});
+	})()`)
+
+	for _, want := range []string{
+		`\"type\":\"revoke_enrolment\"`,
+		`\"client_id\":\"hermes-mail\"`,
+		`"remaining":0`,
+		`"keepsFingerprint":true`,
+		`"showsEmptyState":true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("revoke flow: missing %s in %s", want, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The listener block
+// ---------------------------------------------------------------------------
+
+// Absent, present-but-disabled, and enabled are three different facts about an
+// install, and two of them are surprising. Each gets its own badge and its own
+// sentence — an absent block is NOT a switched-off listener.
+func TestRemoteTab_ListenerStatesRenderDistinctly(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteJSON string
+		wantBadge  string
+		wantCopy   string
+		notWant    string
+	}{
+		{
+			name:       "absent",
+			remoteJSON: remoteAbsent,
+			wantBadge:  `remote-state absent`,
+			wantCopy:   "no listener is opened at all",
+			notWant:    `remote-state on`,
+		},
+		{
+			name:       "present but disabled",
+			remoteJSON: remoteDisabled,
+			wantBadge:  `remote-state off`,
+			wantCopy:   "omits <code>enabled</code> resolves to disabled",
+			notWant:    "no listener is opened at all",
+		},
+		{
+			name:       "enabled",
+			remoteJSON: remoteEnabled,
+			wantBadge:  `remote-state on`,
+			wantCopy:   "127.0.0.1:9910",
+			notWant:    "no listener is opened at all",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, c.remoteJSON)
+			html := evalString(t, vm, `window.renderRemoteListener()`)
+			if !strings.Contains(html, c.wantBadge) {
+				t.Errorf("missing badge %q\n%s", c.wantBadge, html)
+			}
+			if !strings.Contains(html, c.wantCopy) {
+				t.Errorf("missing copy %q\n%s", c.wantCopy, html)
+			}
+			if strings.Contains(html, c.notWant) {
+				t.Errorf("state %q also rendered %q", c.name, c.notWant)
+			}
+		})
+	}
+}
+
+// Auditing is a hard dependency of remote access: the listener refuses to
+// start while it is off. A block that looks configured in that state is dead,
+// and the tab has to say so as a CONSEQUENCE rather than let it read as on.
+func TestRemoteTab_DisabledAuditingReadsAsRemoteOff(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, enrolmentsFixture, remoteAuditOff)
+	html := evalString(t, vm, `window.renderEnrolments()`)
+
+	for _, want := range []string{
+		"Remote access is off because the tool-call audit log is disabled",
+		"refuses to start",
+		"Off &#8212; auditing disabled",
+	} {
+		if !strings.Contains(html, want) && !strings.Contains(html, strings.ReplaceAll(want, "&#8212;", "—")) {
+			t.Errorf("audit-off consequence is missing %q\n%s", want, html)
+		}
+	}
+	if strings.Contains(html, `remote-state on`) {
+		t.Error("the listener still badges as On while auditing is disabled")
+	}
+}
+
+// The restart caveat is honest today and lives in exactly one place. This test
+// exists so that removing it (when the listener picks address changes up live)
+// is a deliberate act with a failing test attached, not a silent drift into
+// telling the operator something untrue.
+func TestRemoteTab_RestartCaveatIsStated(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	html := evalString(t, vm, `window.renderRemoteListener()`)
+	if !strings.Contains(html, "takes effect when Relay restarts") {
+		t.Errorf("the listener section does not say a change needs a restart\n%s", html)
+	}
+}
+
+// The default binds loopback so misconfiguration cannot expose the control
+// plane to a LAN. A wider bind is allowed — it is how you reach relay from a
+// VM — but it is said out loud rather than accepted in silence.
+func TestRemoteTab_NonLoopbackBindIsWarned(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		var quiet = window.renderRemoteListener().indexOf('binds beyond loopback') >= 0;
+		window.remoteDraftSet('listen', '0.0.0.0:9910');
+		var loud = window.renderRemoteListener().indexOf('binds beyond loopback') >= 0;
+		return JSON.stringify({
+			loopbackQuiet: quiet, wideLoud: loud,
+			isLoopback: window.remoteListenIsLoopback('127.0.0.1:9910'),
+			v6Loopback: window.remoteListenIsLoopback('[::1]:9910'),
+			wide: window.remoteListenIsLoopback('0.0.0.0:9910')
+		});
+	})()`)
+
+	for _, want := range []string{
+		`"loopbackQuiet":false`, `"wideLoud":true`,
+		`"isLoopback":true`, `"v6Loopback":true`, `"wide":false`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("loopback warning: missing %s in %s", want, got)
+		}
+	}
+}
+
+// Saving sends the toggle and the address together; removing sends `remove`
+// after a confirmation that says what an absent block means.
+func TestRemoteTab_SaveAndRemovePayloads(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteDisabled)
+	got := evalString(t, vm, `(function(){
+		window.remoteDraftSet('enabled', true);
+		window.remoteDraftSet('listen', '  127.0.0.1:9911  ');
+		window.saveRemoteConfig();
+		var save = window.__sent[window.__sent.length - 1];
+		window.removeRemoteConfig();
+		return JSON.stringify({ save: save, remove: window.__sent[window.__sent.length - 1], prompt: window.__confirmed[0] || '' });
+	})()`)
+
+	for _, want := range []string{
+		`\"type\":\"update_remote_config\"`,
+		`\"enabled\":true`,
+		`\"listen\":\"127.0.0.1:9911\"`, // trimmed
+		`\"remove\":true`,
+		"No listener will be opened at all",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("listener payloads: missing %s in %s", want, got)
+		}
+	}
+}
+
+// A push-sourced reload must not eat an in-flight edit — the same rule the
+// Projects tab follows for its form.
+func TestRemoteTab_PushDoesNotClobberAnEdit(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteDisabled)
+	got := evalString(t, vm, `(function(){
+		window.remoteDraftSet('listen', '10.0.0.4:9910');
+		window.onSettingsReloaded({
+			external_mcps: [], services: [], running_ids: [],
+			projects: `+enrolProjectsFixture+`,
+			remote: `+remoteEnabled+`
+		});
+		return JSON.stringify({ draftListen: window.state.remoteDraft.listen, serverListen: window.state.remote.listen });
+	})()`)
+
+	if !strings.Contains(got, `"draftListen":"10.0.0.4:9910"`) {
+		t.Errorf("a settings push overwrote an uncommitted address: %s", got)
+	}
+	if !strings.Contains(got, `"serverListen":"127.0.0.1:9910"`) {
+		t.Errorf("the pushed server state was not stored: %s", got)
+	}
+}
+
+// An external change (a CLI `relay enrol` while the window is open) reaches
+// the list through the same full-settings push every other tab uses.
+func TestRemoteTab_SettingsPushUpdatesEnrolments(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
+	got := evalString(t, vm, `(function(){
+		window.onSettingsReloaded({
+			external_mcps: [], services: [], running_ids: [],
+			projects: `+enrolProjectsFixture+`,
+			enrolments: `+enrolmentsFixture+`,
+			remote: `+remoteEnabled+`
+		});
+		var html = window.renderEnrolments();
+		return JSON.stringify({ count: window.state.enrolments.length, showsName: html.indexOf('hermes-mail') >= 0 });
+	})()`)
+	if !strings.Contains(got, `"count":1`) || !strings.Contains(got, `"showsName":true`) {
+		t.Errorf("a full-settings push did not reach the Remote Clients tab: %s", got)
+	}
+}
+
+// The tab is reachable from the sidebar, and switching to it renders without
+// throwing — the same smoke property settings_bundle_test.go pins for the
+// other tabs, which is what catches an un-globalized inline handler.
+func TestRemoteTab_ShowPageRendersWithoutThrowing(t *testing.T) {
+	vm := seedRemoteVM(t, enrolProjectsFixture, enrolmentsFixture, remoteEnabled)
+	if got := evalString(t, vm, `(function(){
+		window.showPage('remote');
+		return window.state.page + ':' + (document.getElementById('content').innerHTML.indexOf('Remote Clients') >= 0);
+	})()`); got != "remote:true" {
+		t.Errorf("showPage('remote') = %q, want remote:true", got)
+	}
+}

--- a/settings_enrolments_ui_test.go
+++ b/settings_enrolments_ui_test.go
@@ -435,11 +435,17 @@ func TestRemoteTab_DisabledAuditingReadsAsRemoteOff(t *testing.T) {
 // exists so that removing it (when the listener picks address changes up live)
 // is a deliberate act with a failing test attached, not a silent drift into
 // telling the operator something untrue.
-func TestRemoteTab_RestartCaveatIsStated(t *testing.T) {
+func TestRemoteTab_StatesWhatIsLiveAndWhatIsNot(t *testing.T) {
 	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
 	html := evalString(t, vm, `window.renderRemoteListener()`)
-	if !strings.Contains(html, "takes effect when Relay restarts") {
-		t.Errorf("the listener section does not say a change needs a restart\n%s", html)
+	// The listener reconciles, so a blanket "restart required" would be false
+	// for everything a user is likely to change. The one genuine exception is
+	// re-enabling auditing, and that must still be stated.
+	if !strings.Contains(html, "no restart needed") {
+		t.Errorf("the listener section does not say reconfiguration is live\n%s", html)
+	}
+	if !strings.Contains(html, "Re-enabling auditing") {
+		t.Errorf("the listener section does not state the one case that still needs a relaunch\n%s", html)
 	}
 }
 

--- a/settings_html.go
+++ b/settings_html.go
@@ -43,11 +43,28 @@ func renderSettingsHTML(settings *Settings, runningIDs []string, toolCache map[s
 	if projects == nil {
 		projects = []Project{}
 	}
+	// Enrolments are seeded like projects rather than fetched on tab switch:
+	// the list is small (one row per enrolled certificate), and a credential
+	// you cannot see is one you will not revoke — it should be on screen the
+	// moment the tab is, with no loading state to fail into.
+	enrolments := settings.Enrolments
+	if enrolments == nil {
+		enrolments = []Enrolment{}
+	}
+	// The first paint has no *AuditRecorder to consult, so the remote view's
+	// audit state comes from the configuration. That is what the operator
+	// edits and what NewRemoteServer's refusal is phrased in terms of; the IPC
+	// handlers, which do hold the recorder, pass its live answer instead (see
+	// remoteConfigViewOf).
+	remote := remoteConfigViewOf(settings, settings.Audit.resolve().Enabled)
 	return strings.NewReplacer(
 		"__EXTERNAL_MCPS_JSON__", mustMarshalJSON("external_mcps", settings.ExternalMcps),
 		"__SERVICES_JSON__", mustMarshalJSON("services", settings.Services),
 		"__RUNNING_IDS_JSON__", mustMarshalJSON("running_ids", runningIDs),
 		"__PROJECTS_JSON__", mustMarshalJSON("projects", projects),
 		"__MCP_TOOL_CACHE_JSON__", mustMarshalJSON("mcp_tool_cache", toolCache),
+		"__ENROLMENTS_JSON__", mustMarshalJSON("enrolments", enrolments),
+		"__REMOTE_JSON__", mustMarshalJSON("remote", remote),
+		"__ENROLMENT_BUDGET_DEFAULTS_JSON__", mustMarshalJSON("enrolment_budget_defaults", enrolmentBudgetDefaults()),
 	).Replace(settingsHTML)
 }

--- a/settings_store.go
+++ b/settings_store.go
@@ -242,6 +242,30 @@ func (ss *FileSettingsStore) EnsureInitialized() error {
 // FileSettingsStore methods
 // ---------------------------------------------------------------------------
 
+// freshSettings returns settings that reflect the FILE, not whatever snapshot
+// this process happened to load earlier.
+//
+// Get() answers from an in-memory cache that only two things refresh: a
+// mutation made by this process (With, which writes the cache through), and the
+// tray's 2s settings poll (ReloadIfChanged). That is fine for a menu and wrong
+// for an authorization decision, because relay is not one process: `relay enrol
+// create` runs in a CLI process and writes settings.json, and until the tray's
+// next poll its listener resolves certificates against a settings view that
+// predates the record — so a brand-new enrolment is refused as "not enrolled"
+// for up to a poll interval, which is indistinguishable from a genuine
+// misconfiguration (issue #21).
+//
+// The cost of closing that window is one stat() per decision: ReloadIfChanged
+// re-reads only when the modtime moved, so the steady state is a stat and a
+// deep copy of a small struct. Anything on the remote path that decides whether
+// a caller may act MUST go through here rather than Get().
+func freshSettings(store SettingsStore) *Settings {
+	if s := store.ReloadIfChanged(); s != nil {
+		return s
+	}
+	return store.Get()
+}
+
 // Get returns a deep copy of the cached settings (or reads from disk on first
 // call). The returned *Settings is safe for concurrent read and mutation.
 func (ss *FileSettingsStore) Get() *Settings {

--- a/trayapp.go
+++ b/trayapp.go
@@ -30,10 +30,12 @@ type App struct {
 	extMgr       *ExternalMcpManager
 	registry     ServiceManager
 	bridgeServer *bridge.BridgeServer
-	// remoteServer is the mTLS listener remote clients reach relay through.
-	// Nil whenever no remote block is configured, which is the overwhelmingly
+	// remote supervises the mTLS listener remote clients reach relay through:
+	// it binds, rebinds and stops as `remote.enabled` / `remote.listen` change,
+	// so neither needs a restart to take effect. Holds no listener at all
+	// whenever no remote block is configured, which is the overwhelmingly
 	// common case; every method on it is nil-safe so nothing branches here.
-	remoteServer   *RemoteServer
+	remote         *RemoteSupervisor
 	frontendServer *FrontendServer
 	ipcCtx         *IPCContext // pre-built once, reused on every IPC call
 	// audit is the tool-call recorder. Nil when auditing is disabled or failed
@@ -257,14 +259,15 @@ func runTrayApp() {
 	// relay without a remote listener is relay as it has always been, whereas
 	// a remote listener that started anyway despite (say) disabled auditing is
 	// exactly the system ADR-010 exists to prevent.
-	rs, err := NewRemoteServer(ctx, store, router, audit)
-	if err != nil {
-		slog.Error("remote listener not started", "error", err)
-	}
-	app.remoteServer = rs
-	if rs != nil {
-		app.goFunc(func() { rs.Serve() })
-	}
+	//
+	// Started through the supervisor rather than bound directly, so the same
+	// code path that opens it at launch is the one that moves or closes it when
+	// settings change — a listener whose configuration only applied at startup
+	// made `remote.listen` the one setting in relay that needed a quit, and
+	// made `audit.enabled: false` a refusal that only held until the next
+	// launch. statusPoller drives the convergence from here on.
+	app.remote = NewRemoteSupervisor(ctx, store, router, audit, app.goFunc)
+	app.remote.Reconcile() // logs its own failure; a listener is never fatal to the tray
 
 	// Set up tray icon.
 	slog.Info("setting up tray icon")
@@ -312,6 +315,13 @@ func runTrayApp() {
 // changes (bridge reconcile, reload). Centralizes the "push settings + update
 // menu" pattern so the router doesn't reach into platform dispatch directly.
 func (a *App) onExternalChange() {
+	// A bridge-driven reconcile means "settings changed underneath you", which
+	// is true of the remote block as much as of the MCP list. Waiting for the
+	// next poll would work, but this is the one path where relay has already
+	// been TOLD, so acting on it costs nothing. In a tracked goroutine because
+	// a bind must not run on the main thread, and because the caller is a
+	// bridge handler that should not wait on a socket.
+	a.goFunc(func() { a.remote.Reconcile() })
 	a.platform.DispatchToMain(func() {
 		a.pushFullSettings()
 		a.updateMenu()
@@ -355,6 +365,15 @@ func (a *App) statusPoller() {
 		a.rssByID.Store(&rssByID)
 
 		s := a.store.ReloadIfChanged()
+
+		// Converge the remote listener on the same tick that picks up settings
+		// changes, and off the main thread because it may bind a socket. This
+		// is the trigger for every out-of-process edit — `relay enrol`, a
+		// hand-edited settings.json, the Settings UI — for the same reason the
+		// poll exists at all: relay is not one process, and the tray is not the
+		// only writer. Cheap and silent when nothing changed; see
+		// RemoteSupervisor.Reconcile for what "nothing changed" means.
+		a.remote.Reconcile()
 
 		a.platform.DispatchToMain(func() {
 			// store.Get() deep-copies, so prefer the already-loaded snapshot
@@ -509,7 +528,7 @@ func (a *App) cleanup() {
 		if a.bridgeServer != nil {
 			a.bridgeServer.StopAccepting()
 		}
-		a.remoteServer.StopAccepting()
+		a.remote.StopAccepting()
 		a.extMgr.StopAll()
 		if a.bridgeServer != nil {
 			a.bridgeServer.Close()
@@ -518,7 +537,7 @@ func (a *App) cleanup() {
 		// CallTool fails fast rather than holding the drain open, and its
 		// completion record is still written because the audit log is closed
 		// last of all.
-		a.remoteServer.Close()
+		a.remote.Close()
 		// Stop the frontend server before the children that proxy to relayLLM
 		// — once relayLLM dies, in-flight proxied requests fail with 502
 		// rather than hanging.

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -1871,7 +1871,7 @@ window.__RELAY_INIT__ = {
     state.projectFormError = msg;
     if (state.page === "projects") render("push");
   };
-  var REMOTE_RESTART_NOTE = "Enabling, disabling, or moving the listener takes effect when Relay restarts \u2014 it binds its address at startup.";
+  var REMOTE_NOTE = "Enabling, disabling and moving the listener take effect within a few seconds \u2014 no restart needed. Re-enabling auditing after turning it off is the exception: that still needs Relay to relaunch.";
   function remoteGrantableProjects() {
     return (state.projects || []).filter(isRemoteProject);
   }
@@ -2106,7 +2106,7 @@ window.__RELAY_INIT__ = {
     html += "</div>";
     html += "<label>Listen address</label>";
     html += '<input type="text" id="remoteListen" value="' + esc(d.listen) + '" placeholder="' + esc(r.effective || "") + `" oninput="remoteDraftSet('listen', this.value)" />`;
-    html += '<p class="proj-section-help">Leave blank for the default, <code>' + esc(r.effective || "") + "</code>. " + esc(REMOTE_RESTART_NOTE) + "</p>";
+    html += '<p class="proj-section-help">Leave blank for the default, <code>' + esc(r.effective || "") + "</code>. " + esc(REMOTE_NOTE) + "</p>";
     const effective = (d.listen || "").trim() || r.effective || "";
     if (effective && !remoteListenIsLoopback(effective)) {
       html += '<div class="remote-note warn">' + esc(effective) + " binds beyond loopback: every machine that can reach that address can attempt a TLS handshake. Only a certificate relay signed gets past it, and an unenrolled one is closed before a single request is read \u2014 but the default binds loopback precisely so that reaching relay from another machine is a deliberate act. A tunnel is a network path, never an identity: never forward the bridge socket in its place.</div>";

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -396,12 +396,44 @@ textarea:focus {
 .audit-kv dd { margin: 0; font-family: var(--mono); word-break: break-all; }
 .audit-args { margin-top: 8px; padding: 8px; background: var(--bg-field); border: 1px solid var(--border); border-radius: var(--radius-sm); font-family: var(--mono); font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 260px; overflow: auto; }
 .audit-empty { color: var(--text-2); font-size: 13px; padding: 24px 0; text-align: center; }
+
+/* ---- Remote Clients (enrolments + the mTLS listener) ---- */
+.enrol-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; margin-bottom: 10px; }
+.enrol-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
+.enrol-card-name { font-weight: 600; font-size: 13px; color: var(--text); }
+.enrol-grants { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 2px; }
+.enrol-grant { display: inline-block; padding: 1px 7px; font-size: 11px; border-radius: 9px; background: var(--bg-control); color: var(--text); }
+/* A grant whose project no longer exists. Shown, never hidden: an operator
+   deciding whether to revoke needs to see that a grant points at nothing. */
+.enrol-grant.dangling { color: var(--warn); border: 1px solid var(--warn); }
+.enrol-grant.none { color: var(--text-3); background: transparent; border: 1px dashed var(--border); }
+.enrol-meta { color: var(--text-3); font-size: 11px; margin-top: 6px; display: flex; gap: 12px; flex-wrap: wrap; }
+/* The fingerprint prints in FULL — never ellipsized, never width-clipped.
+   After an enrolment is deleted it is the only thing that identifies that
+   client's calls in the audit log (ADR-010 decision 6), and a UI that
+   shortened it would be the obvious place for someone to copy a short form
+   from. break-all wraps it instead of truncating it. */
+.enrol-fp { font-family: var(--mono); font-size: 11px; color: var(--text-2); margin-top: 6px; word-break: break-all; overflow-wrap: anywhere; white-space: normal; }
+.enrol-fp-label { color: var(--text-3); }
+.enrol-bundle { background: var(--bg-control); background: color-mix(in srgb, var(--accent) 14%, var(--bg-card)); border: 1px solid var(--accent); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 12px; font-size: 12px; color: var(--text); }
+.enrol-bundle code { background: var(--bg-control); padding: 2px 6px; border-radius: 3px; font-family: var(--mono); word-break: break-all; }
+.enrol-bundle ul { margin: 6px 0 6px 18px; }
+.enrol-bundle li { font-size: 11px; color: var(--text-2); }
+.enrol-bundle strong { color: var(--text); }
+.remote-state { display: inline-block; padding: 1px 7px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; border-radius: 4px; }
+.remote-state.on { color: var(--ok); border: 1px solid var(--ok); }
+.remote-state.off { color: var(--text-2); border: 1px solid var(--border); }
+.remote-state.absent { color: var(--text-3); border: 1px dashed var(--border); }
+.remote-note { font-size: 11px; color: var(--text-2); margin-top: 8px; }
+.remote-note.warn { color: var(--warn); }
+.remote-note.danger { color: var(--danger); }
 </style></head>
 <body>
 <div class="sidebar">
     <div class="sidebar-item active" onclick="showPage('services')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>Services</div>
     <div class="sidebar-item" onclick="showPage('mcps')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>MCP Servers</div>
     <div class="sidebar-item" onclick="showPage('projects')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Projects</div>
+    <div class="sidebar-item" onclick="showPage('remote')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/><circle cx="12" cy="10" r="2.5"/></svg>Remote Clients</div>
     <div class="sidebar-item" onclick="showPage('inspector')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>Service Inspector</div>
     <div class="sidebar-item" onclick="showPage('audit')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Tool Calls</div>
 </div>
@@ -413,7 +445,10 @@ window.__RELAY_INIT__ = {
   services: __SERVICES_JSON__,
   runningIds: __RUNNING_IDS_JSON__,
   projects: __PROJECTS_JSON__,
-  mcpToolCache: __MCP_TOOL_CACHE_JSON__
+  mcpToolCache: __MCP_TOOL_CACHE_JSON__,
+  enrolments: __ENROLMENTS_JSON__,
+  remote: __REMOTE_JSON__,
+  enrolmentBudgetDefaults: __ENROLMENT_BUDGET_DEFAULTS_JSON__
 };
 </script>
 <script>
@@ -624,6 +659,9 @@ window.__RELAY_INIT__ = {
   var RUNNING_IDS_INIT = window.__RELAY_INIT__.runningIds;
   var PROJECTS_INIT = window.__RELAY_INIT__.projects;
   var MCP_TOOL_CACHE_INIT = window.__RELAY_INIT__.mcpToolCache;
+  var ENROLMENTS_INIT = window.__RELAY_INIT__.enrolments || [];
+  var REMOTE_INIT = window.__RELAY_INIT__.remote || null;
+  var ENROLMENT_BUDGET_DEFAULTS_INIT = window.__RELAY_INIT__.enrolmentBudgetDefaults || {};
   function ipc(msg) {
     if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.ipc)
       window.webkit.messageHandlers.ipc.postMessage(msg);
@@ -698,6 +736,25 @@ window.__RELAY_INIT__ = {
     // id -> { ok, message, t } (last regen result)
     projectError: null,
     rotatingProjectId: null,
+    // Remote Clients tab. Enrolments and the remote block are seeded by the
+    // initial payload like projects are — the list is one row per enrolled
+    // certificate, and a credential you cannot see is one you will not revoke,
+    // so it should be on screen the moment the tab is.
+    enrolments: ENROLMENTS_INIT,
+    remote: REMOTE_INIT,
+    // remoteConfigView from Go, or null
+    enrolmentBudgetDefaults: ENROLMENT_BUDGET_DEFAULTS_INIT,
+    enrolForm: null,
+    // null = list, object = create form
+    enrolmentError: null,
+    enrolBundle: null,
+    // {client_id, dir} — DIRECTORY only, never key material
+    enrolRevoked: null,
+    // {client_id, fingerprint} shown after a revoke
+    remoteDraft: null,
+    // uncommitted edit of the remote block
+    remoteDirty: false,
+    remoteError: null,
     // Tool Calls tab. Events arrive newest-first from the recorder's ring (or
     // from a deep query over the log file); `auditFilter` mirrors AuditQuery
     // on the Go side so it can be sent verbatim.
@@ -716,7 +773,7 @@ window.__RELAY_INIT__ = {
   var AUDIT_MAX_ROWS = 500;
   function showPage(page) {
     state.page = page;
-    const pages = ["services", "mcps", "projects", "inspector", "audit"];
+    const pages = ["services", "mcps", "projects", "remote", "inspector", "audit"];
     document.querySelectorAll(".sidebar-item").forEach((el, i) => {
       el.classList.toggle("active", pages[i] === page);
     });
@@ -736,6 +793,9 @@ window.__RELAY_INIT__ = {
     } else if (state.page === "projects") {
       if (fromPush && state.editingProjectId) return;
       el.innerHTML = renderProjects();
+    } else if (state.page === "remote") {
+      if (fromPush && (state.enrolForm || state.remoteDirty)) return;
+      el.innerHTML = renderEnrolments();
     } else if (state.page === "audit") {
       el.innerHTML = renderAudit();
       restoreAuditFocus();
@@ -1247,6 +1307,11 @@ window.__RELAY_INIT__ = {
     }, {});
     if (data.projects) state.projects = data.projects;
     if (data.mcp_tool_cache) state.mcpToolCache = data.mcp_tool_cache;
+    if (data.enrolments) state.enrolments = data.enrolments;
+    if (data.remote) {
+      state.remote = data.remote;
+      if (!state.remoteDirty) state.remoteDraft = null;
+    }
     render("push");
   };
   window.onProjectsReloaded = function(projects) {
@@ -1805,6 +1870,301 @@ window.__RELAY_INIT__ = {
     state.projectError = msg;
     state.projectFormError = msg;
     if (state.page === "projects") render("push");
+  };
+  var REMOTE_RESTART_NOTE = "Enabling, disabling, or moving the listener takes effect when Relay restarts \u2014 it binds its address at startup.";
+  function remoteGrantableProjects() {
+    return (state.projects || []).filter(isRemoteProject);
+  }
+  function enrolGrantNames(e) {
+    return (e && e.project_ids || []).map(function(id) {
+      const p = (state.projects || []).find((x) => x.id === id);
+      return { id, name: p ? p.name : null };
+    });
+  }
+  function enrolGrantSummary(e) {
+    const names = enrolGrantNames(e).map((g) => g.name || g.id + " (unknown project)");
+    if (!names.length) return "no projects \u2014 this enrolment grants nothing today";
+    return names.join(", ");
+  }
+  function enrolBytes(n) {
+    n = Number(n) || 0;
+    if (n >= 1048576 && n % 1048576 === 0) return n / 1048576 + " MiB";
+    if (n >= 1024 && n % 1024 === 0) return n / 1024 + " KiB";
+    return n + " bytes";
+  }
+  function enrolBudgetText(b) {
+    b = b || {};
+    return (b.max_calls || 0) + " calls / " + enrolBytes(b.max_result_bytes) + " per " + (b.window_seconds || 0) + "s";
+  }
+  function renderEnrolments() {
+    if (state.enrolForm) return renderEnrolmentForm();
+    let html = '<div class="page-header"><h2>Remote Clients</h2>';
+    html += '<button class="btn btn-primary" onclick="newEnrolment()">+ New Enrolment</button></div>';
+    html += '<p class="page-intro">An enrolment binds one client certificate to the remote projects it may use. The certificate <em>is</em> the identity \u2014 there is no bearer token on this path, so a copy of <code>settings.json</code> grants no remote access at all. Enrolments are keyed by certificate, not by machine: several agents on one VM each hold their own, granted and revoked independently.</p>';
+    if (state.enrolBundle) html += renderEnrolBundleBanner(state.enrolBundle);
+    if (state.enrolRevoked) {
+      html += '<div class="audit-note">Revoked <strong>' + esc(state.enrolRevoked.client_id) + "</strong>. Its calls remain in the Tool Calls log under fingerprint <code>" + esc(state.enrolRevoked.fingerprint) + "</code> \u2014 now the only thing that names them.</div>";
+    }
+    if (state.enrolmentError) html += '<div class="proj-error">' + esc(state.enrolmentError) + "</div>";
+    const list = state.enrolments || [];
+    if (!list.length) {
+      html += '<div class="empty-state">No enrolled clients. Click <strong>+ New Enrolment</strong>, or run <code>relay enrol create</code>.</div>';
+    }
+    for (const e of list) {
+      html += '<div class="enrol-card">';
+      html += '<div class="enrol-card-header">';
+      html += '<span class="enrol-card-name">' + esc(e.client_id) + "</span>";
+      html += `<button class="btn btn-sm btn-danger" onclick="revokeEnrolment('` + esc(e.client_id) + `')">Revoke</button>`;
+      html += "</div>";
+      html += '<div class="enrol-grants">';
+      const grants = enrolGrantNames(e);
+      if (!grants.length) {
+        html += '<span class="enrol-grant none">no projects granted</span>';
+      }
+      for (const g of grants) {
+        if (g.name) {
+          html += '<span class="enrol-grant" title="' + esc(g.id) + '">' + esc(g.name) + "</span>";
+        } else {
+          html += '<span class="enrol-grant dangling" title="No project carries this id">' + esc(g.id) + " \u2014 unknown project</span>";
+        }
+      }
+      html += "</div>";
+      html += '<div class="enrol-meta">';
+      html += "<span>Budget: <strong>" + esc(enrolBudgetText(e.budget)) + "</strong></span>";
+      html += "<span>Enrolled: <strong>" + esc(e.created_at || "\u2014") + "</strong></span>";
+      html += "</div>";
+      html += '<div class="enrol-fp"><span class="enrol-fp-label">Certificate: </span>' + esc(e.fingerprint || "(none)") + "</div>";
+      html += "</div>";
+    }
+    html += renderRemoteListener();
+    return html;
+  }
+  function renderEnrolBundleBanner(b) {
+    let html = '<div class="enrol-bundle">';
+    html += "Enrolled <strong>" + esc(b.client_id) + "</strong>. Bundle written to <code>" + esc(b.dir) + "</code>";
+    html += "<ul>";
+    html += "<li><code>client.key</code> \u2014 client private key (0600)</li>";
+    html += "<li><code>client.crt</code> \u2014 client certificate</li>";
+    html += "<li><code>ca.crt</code> \u2014 relay's CA certificate, for verifying the server</li>";
+    html += "</ul>";
+    html += "<strong>Move (don't copy) this directory to the client machine.</strong> The private key travels exactly once; every copy left behind is a credential nobody is tracking.";
+    html += '<div style="margin-top:8px"><button class="btn btn-sm" onclick="dismissEnrolBundle()">Done</button></div>';
+    html += "</div>";
+    return html;
+  }
+  function renderEnrolmentForm() {
+    const f = state.enrolForm;
+    const d = state.enrolmentBudgetDefaults || {};
+    let html = "<h2>New Enrolment</h2>";
+    if (state.enrolmentError) html += '<div class="proj-error">' + esc(state.enrolmentError) + "</div>";
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Identity</div>';
+    html += `<p class="proj-section-help">The client id is the certificate's Common Name and the bundle's directory name, so it is limited to letters, digits, <code>.</code>, <code>_</code> and <code>-</code>. It must be unique: to re-issue a certificate, revoke the existing enrolment first.</p>`;
+    html += "<label>Client id</label>";
+    html += '<input type="text" id="enrolClientId" value="' + esc(f.client_id) + '" placeholder="hermes-mail" />';
+    html += "</div>";
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Granted Projects</div>';
+    html += `<p class="proj-section-help">Only <strong>remote</strong> projects can be granted. A remote client granted a local project would inherit that project's host-directory scope, so the grant is refused outright \u2014 this list offers nothing that would be refused.</p>`;
+    const grantable = remoteGrantableProjects();
+    if (!grantable.length) {
+      html += '<div class="proj-tool-empty">No remote projects exist yet. Create one in the <strong>Projects</strong> tab (Kind \u2192 Remote) first.</div>';
+    }
+    for (const p of grantable) {
+      const checked = f.project_ids.indexOf(p.id) >= 0;
+      html += '<label class="proj-tool-row">';
+      html += '<input type="checkbox" ' + (checked ? "checked" : "") + ` onchange="toggleEnrolGrant('` + esc(p.id) + `', this.checked)" />`;
+      html += "<div><div>" + esc(p.name) + '</div><div class="desc">' + esc(p.id) + "</div></div>";
+      html += "</label>";
+    }
+    if (grantable.length && f.project_ids.length === 0) {
+      html += '<p class="proj-section-help">No grant selected: this client will be enrolled but can reach no project until one is added.</p>';
+    }
+    html += "</div>";
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Budget</div>';
+    html += '<p class="proj-section-help">The enrolment is the unit of compromise, so it is the unit that carries the cap. Rate and volume are capped together because they fail differently \u2014 a call limit alone does not stop a slow drain. Leave a field blank for the conservative default; <strong>zero is never unlimited</strong>, there is no way to switch a budget off.</p>';
+    html += "<label>Window (seconds)</label>";
+    html += '<input type="number" id="enrolWindow" value="' + esc(f.window_seconds) + '" placeholder="' + esc(d.window_seconds || "") + '" />';
+    html += "<label>Max tool calls per window</label>";
+    html += '<input type="number" id="enrolMaxCalls" value="' + esc(f.max_calls) + '" placeholder="' + esc(d.max_calls || "") + '" />';
+    html += "<label>Max cumulative result bytes per window</label>";
+    html += '<input type="number" id="enrolMaxBytes" value="' + esc(f.max_result_bytes) + '" placeholder="' + esc(d.max_result_bytes || "") + '" />';
+    html += "</div>";
+    html += '<div class="proj-form-actions">';
+    html += '<button class="btn btn-primary" onclick="saveEnrolment()">Create &amp; issue certificate</button>';
+    html += '<button class="btn btn-danger" onclick="cancelEnrolment()">Cancel</button>';
+    html += "</div>";
+    return html;
+  }
+  function newEnrolment() {
+    state.enrolForm = { client_id: "", project_ids: [], window_seconds: "", max_calls: "", max_result_bytes: "" };
+    state.enrolmentError = null;
+    state.enrolBundle = null;
+    state.enrolRevoked = null;
+    render();
+  }
+  function cancelEnrolment() {
+    state.enrolForm = null;
+    state.enrolmentError = null;
+    render();
+  }
+  function toggleEnrolGrant(projectID, checked) {
+    const f = state.enrolForm;
+    if (!f) return;
+    const i = f.project_ids.indexOf(projectID);
+    if (checked && i < 0) f.project_ids.push(projectID);
+    if (!checked && i >= 0) f.project_ids.splice(i, 1);
+    render();
+  }
+  function saveEnrolment() {
+    const f = state.enrolForm;
+    if (!f) return;
+    const clientID = ((document.getElementById("enrolClientId") || {}).value || "").trim();
+    if (!clientID) {
+      state.enrolmentError = "client id is required";
+      render();
+      return;
+    }
+    f.client_id = clientID;
+    const num = function(id) {
+      const raw = ((document.getElementById(id) || {}).value || "").trim();
+      const n = parseInt(raw, 10);
+      return raw === "" || isNaN(n) || n < 0 ? 0 : n;
+    };
+    state.enrolmentError = null;
+    ipc(JSON.stringify({
+      type: "create_enrolment",
+      client_id: clientID,
+      project_ids: f.project_ids,
+      budget: {
+        window_seconds: num("enrolWindow"),
+        max_calls: num("enrolMaxCalls"),
+        max_result_bytes: num("enrolMaxBytes")
+      }
+    }));
+  }
+  function revokeEnrolment(clientID) {
+    const e = (state.enrolments || []).find((x) => x.client_id === clientID);
+    if (!e) return;
+    const msg = 'Revoke enrolment "' + clientID + '"?\n\nThis cuts its access to: ' + enrolGrantSummary(e) + "\n\nLive connections holding its certificate are closed immediately. The certificate itself is unchanged and no project is touched \u2014 the record is what granted it access.";
+    if (!confirm(msg)) return;
+    ipc(JSON.stringify({ type: "revoke_enrolment", client_id: clientID }));
+  }
+  function dismissEnrolBundle() {
+    state.enrolBundle = null;
+    render();
+  }
+  function remoteDraft() {
+    if (!state.remoteDraft) {
+      const r = state.remote || {};
+      state.remoteDraft = { enabled: !!r.enabled, listen: r.listen || "" };
+    }
+    return state.remoteDraft;
+  }
+  function remoteDraftSet(key, value) {
+    const d = remoteDraft();
+    d[key] = value;
+    state.remoteDirty = true;
+    if (key === "enabled") render();
+  }
+  function remoteListenIsLoopback(addr) {
+    addr = String(addr || "");
+    const i = addr.lastIndexOf(":");
+    if (i < 0) return false;
+    const host = addr.slice(0, i).replace(/^\[/, "").replace(/\]$/, "");
+    return host === "127.0.0.1" || host === "localhost" || host === "::1";
+  }
+  function renderRemoteListener() {
+    const r = state.remote || { configured: false, enabled: false, listen: "", effective: "", audit_enabled: true };
+    const d = remoteDraft();
+    const live = r.enabled && r.audit_enabled;
+    let html = '<div class="proj-section" style="margin-top:24px">';
+    html += '<div class="proj-section-title">Remote Listener';
+    if (!r.configured) {
+      html += ' <span class="remote-state absent">No block</span>';
+    } else if (live) {
+      html += ' <span class="remote-state on">On</span>';
+    } else if (r.enabled) {
+      html += ' <span class="remote-state off">Off \u2014 auditing disabled</span>';
+    } else {
+      html += ' <span class="remote-state off">Off</span>';
+    }
+    html += "</div>";
+    if (state.remoteError) html += '<div class="proj-error">' + esc(state.remoteError) + "</div>";
+    if (!r.configured) {
+      html += '<p class="proj-section-help">There is no <code>remote</code> block in <code>settings.json</code>, which means <strong>no listener is opened at all</strong> \u2014 not a listener bound to nothing, not one that refuses every call. This is the default, and it is not the same state as a listener that is switched off.</p>';
+    } else if (!r.enabled) {
+      html += '<p class="proj-section-help">The <code>remote</code> block exists but the listener is <strong>off</strong>. A block that omits <code>enabled</code> resolves to disabled \u2014 the opposite default to auditing, deliberately, so a network listener is never opened by omission.</p>';
+    }
+    if (r.enabled && !r.audit_enabled) {
+      html += '<div class="remote-note danger"><strong>Remote access is off because the tool-call audit log is disabled.</strong> The listener refuses to start while auditing is off: a remote grant is justified by the calls it records, so serving remote traffic unrecorded is not a degraded mode. Re-enable <code>audit.enabled</code> to restore remote access \u2014 this block is configured but dead until then.</div>';
+    }
+    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+    html += "<span>Accept remote clients on an mTLS listener</span>";
+    html += '<label class="switch"><input type="checkbox" ' + (d.enabled ? "checked" : "") + ` onchange="remoteDraftSet('enabled', this.checked)" /><span class="slider"></span></label>`;
+    html += "</div>";
+    html += "<label>Listen address</label>";
+    html += '<input type="text" id="remoteListen" value="' + esc(d.listen) + '" placeholder="' + esc(r.effective || "") + `" oninput="remoteDraftSet('listen', this.value)" />`;
+    html += '<p class="proj-section-help">Leave blank for the default, <code>' + esc(r.effective || "") + "</code>. " + esc(REMOTE_RESTART_NOTE) + "</p>";
+    const effective = (d.listen || "").trim() || r.effective || "";
+    if (effective && !remoteListenIsLoopback(effective)) {
+      html += '<div class="remote-note warn">' + esc(effective) + " binds beyond loopback: every machine that can reach that address can attempt a TLS handshake. Only a certificate relay signed gets past it, and an unenrolled one is closed before a single request is read \u2014 but the default binds loopback precisely so that reaching relay from another machine is a deliberate act. A tunnel is a network path, never an identity: never forward the bridge socket in its place.</div>";
+    }
+    html += '<div class="proj-form-actions">';
+    html += '<button class="btn btn-primary" onclick="saveRemoteConfig()">Save</button>';
+    if (r.configured) {
+      html += '<button class="btn btn-danger" onclick="removeRemoteConfig()">Remove block</button>';
+    }
+    html += "</div>";
+    html += "</div>";
+    return html;
+  }
+  function saveRemoteConfig() {
+    const d = remoteDraft();
+    state.remoteError = null;
+    ipc(JSON.stringify({
+      type: "update_remote_config",
+      enabled: !!d.enabled,
+      listen: String(d.listen || "").trim()
+    }));
+  }
+  function removeRemoteConfig() {
+    const msg = "Remove the remote block from settings.json?\n\nNo listener will be opened at all. Enrolments are not touched \u2014 they stay listed here and can still be revoked, but nothing can connect until a listener is configured again.";
+    if (!confirm(msg)) return;
+    state.remoteError = null;
+    ipc(JSON.stringify({ type: "update_remote_config", remove: true }));
+  }
+  window.onEnrolmentCreated = function(e, bundle) {
+    if (!e || !e.client_id) return;
+    state.enrolments = (state.enrolments || []).filter((x) => x.client_id !== e.client_id).concat(e);
+    state.enrolForm = null;
+    state.enrolmentError = null;
+    state.enrolRevoked = null;
+    state.enrolBundle = { client_id: e.client_id, dir: bundle && bundle.dir || "" };
+    if (state.page === "remote") render("push");
+  };
+  window.onEnrolmentRevoked = function(clientID, fingerprint) {
+    state.enrolments = (state.enrolments || []).filter((x) => x.client_id !== clientID);
+    state.enrolmentError = null;
+    if (state.enrolBundle && state.enrolBundle.client_id === clientID) state.enrolBundle = null;
+    state.enrolRevoked = { client_id: clientID, fingerprint: fingerprint || "" };
+    if (state.page === "remote") render("push");
+  };
+  window.onEnrolmentError = function(msg) {
+    state.enrolmentError = msg || "enrolment failed";
+    if (state.page === "remote") render("push");
+  };
+  window.onRemoteConfigUpdated = function(view) {
+    state.remote = view || state.remote;
+    state.remoteDraft = null;
+    state.remoteDirty = false;
+    state.remoteError = null;
+    if (state.page === "remote") render("push");
+  };
+  window.onRemoteConfigError = function(msg) {
+    state.remoteError = msg || "could not save the remote block";
+    if (state.page === "remote") render("push");
   };
   function renderServiceInspector() {
     state._cfgBind = [];
@@ -2878,6 +3238,26 @@ window.__RELAY_INIT__ = {
     setAuditFilter,
     toggleAuditFollow,
     toggleAuditRow,
+    cancelEnrolment,
+    dismissEnrolBundle,
+    enrolBudgetText,
+    enrolBytes,
+    enrolGrantNames,
+    enrolGrantSummary,
+    newEnrolment,
+    remoteDraft,
+    remoteDraftSet,
+    remoteGrantableProjects,
+    remoteListenIsLoopback,
+    removeRemoteConfig,
+    renderEnrolBundleBanner,
+    renderEnrolmentForm,
+    renderEnrolments,
+    renderRemoteListener,
+    revokeEnrolment,
+    saveEnrolment,
+    saveRemoteConfig,
+    toggleEnrolGrant,
     addExternalMcp,
     addExternalMcpFromJson,
     addExternalMcpHttp,

--- a/web/shell.html
+++ b/web/shell.html
@@ -396,12 +396,44 @@ textarea:focus {
 .audit-kv dd { margin: 0; font-family: var(--mono); word-break: break-all; }
 .audit-args { margin-top: 8px; padding: 8px; background: var(--bg-field); border: 1px solid var(--border); border-radius: var(--radius-sm); font-family: var(--mono); font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 260px; overflow: auto; }
 .audit-empty { color: var(--text-2); font-size: 13px; padding: 24px 0; text-align: center; }
+
+/* ---- Remote Clients (enrolments + the mTLS listener) ---- */
+.enrol-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; margin-bottom: 10px; }
+.enrol-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
+.enrol-card-name { font-weight: 600; font-size: 13px; color: var(--text); }
+.enrol-grants { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 2px; }
+.enrol-grant { display: inline-block; padding: 1px 7px; font-size: 11px; border-radius: 9px; background: var(--bg-control); color: var(--text); }
+/* A grant whose project no longer exists. Shown, never hidden: an operator
+   deciding whether to revoke needs to see that a grant points at nothing. */
+.enrol-grant.dangling { color: var(--warn); border: 1px solid var(--warn); }
+.enrol-grant.none { color: var(--text-3); background: transparent; border: 1px dashed var(--border); }
+.enrol-meta { color: var(--text-3); font-size: 11px; margin-top: 6px; display: flex; gap: 12px; flex-wrap: wrap; }
+/* The fingerprint prints in FULL — never ellipsized, never width-clipped.
+   After an enrolment is deleted it is the only thing that identifies that
+   client's calls in the audit log (ADR-010 decision 6), and a UI that
+   shortened it would be the obvious place for someone to copy a short form
+   from. break-all wraps it instead of truncating it. */
+.enrol-fp { font-family: var(--mono); font-size: 11px; color: var(--text-2); margin-top: 6px; word-break: break-all; overflow-wrap: anywhere; white-space: normal; }
+.enrol-fp-label { color: var(--text-3); }
+.enrol-bundle { background: var(--bg-control); background: color-mix(in srgb, var(--accent) 14%, var(--bg-card)); border: 1px solid var(--accent); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 12px; font-size: 12px; color: var(--text); }
+.enrol-bundle code { background: var(--bg-control); padding: 2px 6px; border-radius: 3px; font-family: var(--mono); word-break: break-all; }
+.enrol-bundle ul { margin: 6px 0 6px 18px; }
+.enrol-bundle li { font-size: 11px; color: var(--text-2); }
+.enrol-bundle strong { color: var(--text); }
+.remote-state { display: inline-block; padding: 1px 7px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; border-radius: 4px; }
+.remote-state.on { color: var(--ok); border: 1px solid var(--ok); }
+.remote-state.off { color: var(--text-2); border: 1px solid var(--border); }
+.remote-state.absent { color: var(--text-3); border: 1px dashed var(--border); }
+.remote-note { font-size: 11px; color: var(--text-2); margin-top: 8px; }
+.remote-note.warn { color: var(--warn); }
+.remote-note.danger { color: var(--danger); }
 </style></head>
 <body>
 <div class="sidebar">
     <div class="sidebar-item active" onclick="showPage('services')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>Services</div>
     <div class="sidebar-item" onclick="showPage('mcps')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>MCP Servers</div>
     <div class="sidebar-item" onclick="showPage('projects')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Projects</div>
+    <div class="sidebar-item" onclick="showPage('remote')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/><circle cx="12" cy="10" r="2.5"/></svg>Remote Clients</div>
     <div class="sidebar-item" onclick="showPage('inspector')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>Service Inspector</div>
     <div class="sidebar-item" onclick="showPage('audit')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Tool Calls</div>
 </div>
@@ -413,7 +445,10 @@ window.__RELAY_INIT__ = {
   services: __SERVICES_JSON__,
   runningIds: __RUNNING_IDS_JSON__,
   projects: __PROJECTS_JSON__,
-  mcpToolCache: __MCP_TOOL_CACHE_JSON__
+  mcpToolCache: __MCP_TOOL_CACHE_JSON__,
+  enrolments: __ENROLMENTS_JSON__,
+  remote: __REMOTE_JSON__,
+  enrolmentBudgetDefaults: __ENROLMENT_BUDGET_DEFAULTS_JSON__
 };
 </script>
 <!--RELAY_BUNDLE-->

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -11,6 +11,12 @@ const SERVICES_INIT = window.__RELAY_INIT__.services;
 const RUNNING_IDS_INIT = window.__RELAY_INIT__.runningIds;
 const PROJECTS_INIT = window.__RELAY_INIT__.projects;
 const MCP_TOOL_CACHE_INIT = window.__RELAY_INIT__.mcpToolCache;
+const ENROLMENTS_INIT = window.__RELAY_INIT__.enrolments || [];
+const REMOTE_INIT = window.__RELAY_INIT__.remote || null;
+// The conservative per-enrolment budget defaults, shipped from Go so the
+// create form's placeholders name the real numbers instead of a second copy
+// of them that can rot apart from normalizeEnrolmentBudget.
+const ENROLMENT_BUDGET_DEFAULTS_INIT = window.__RELAY_INIT__.enrolmentBudgetDefaults || {};
 
 function ipc(msg) {
     if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.ipc)
@@ -68,6 +74,21 @@ let state = {
     projectError: null,
     rotatingProjectId: null,
 
+    // Remote Clients tab. Enrolments and the remote block are seeded by the
+    // initial payload like projects are — the list is one row per enrolled
+    // certificate, and a credential you cannot see is one you will not revoke,
+    // so it should be on screen the moment the tab is.
+    enrolments: ENROLMENTS_INIT,
+    remote: REMOTE_INIT,                    // remoteConfigView from Go, or null
+    enrolmentBudgetDefaults: ENROLMENT_BUDGET_DEFAULTS_INIT,
+    enrolForm: null,                        // null = list, object = create form
+    enrolmentError: null,
+    enrolBundle: null,                      // {client_id, dir} — DIRECTORY only, never key material
+    enrolRevoked: null,                     // {client_id, fingerprint} shown after a revoke
+    remoteDraft: null,                      // uncommitted edit of the remote block
+    remoteDirty: false,
+    remoteError: null,
+
     // Tool Calls tab. Events arrive newest-first from the recorder's ring (or
     // from a deep query over the log file); `auditFilter` mirrors AuditQuery
     // on the Go side so it can be sent verbatim.
@@ -87,7 +108,7 @@ const AUDIT_MAX_ROWS = 500;
 
 function showPage(page) {
     state.page = page;
-    const pages = ['services', 'mcps', 'projects', 'inspector', 'audit'];
+    const pages = ['services', 'mcps', 'projects', 'remote', 'inspector', 'audit'];
     document.querySelectorAll('.sidebar-item').forEach((el, i) => {
         el.classList.toggle('active', pages[i] === page);
     });
@@ -120,6 +141,12 @@ function render(source) {
     } else if (state.page === 'projects') {
         if (fromPush && state.editingProjectId) return;
         el.innerHTML = renderProjects();
+    } else if (state.page === 'remote') {
+        // Skip a push-sourced repaint while the create form is open or the
+        // listener block has uncommitted edits, for the same reason the
+        // Projects tab does: an external change must not eat keystrokes.
+        if (fromPush && (state.enrolForm || state.remoteDirty)) return;
+        el.innerHTML = renderEnrolments();
     } else if (state.page === 'audit') {
         el.innerHTML = renderAudit();
         restoreAuditFocus();
@@ -724,6 +751,14 @@ window.onSettingsReloaded = function(data) {
     state.runningServices = data.running_ids.reduce(function(m, id) { m[id] = true; return m; }, {});
     if (data.projects) state.projects = data.projects;
     if (data.mcp_tool_cache) state.mcpToolCache = data.mcp_tool_cache;
+    if (data.enrolments) state.enrolments = data.enrolments;
+    if (data.remote) {
+        state.remote = data.remote;
+        // Re-seed the listener draft from the server's answer unless the user
+        // is mid-edit; clobbering a half-typed address would be the same bug
+        // render('push') avoids for the project form.
+        if (!state.remoteDirty) state.remoteDraft = null;
+    }
     // Push-sourced repaint of the currently visible tab; render() itself
     // skips if a form is mid-edit. Other tabs pick up the fresh state on
     // next switch — no need to repaint them now.
@@ -1424,6 +1459,440 @@ window.onProjectError = function(msg) {
     state.projectError = msg;
     state.projectFormError = msg;
     if (state.page === 'projects') render('push');
+};
+
+// ---------------------------------------------------------------------------
+// Remote Clients tab — the enrolments, then the listener they arrive on.
+//
+// ADR-010 decision 8 ends "enrolments are listed in the Settings UI beside the
+// grants they reach — a credential you cannot see is one you will not revoke",
+// and that sentence is this tab's whole specification. Two consequences shape
+// everything below:
+//
+//   * Grants render as project NAMES. An operator deciding whether to revoke
+//     needs to know what they are cutting, not which opaque id it was stored
+//     under. A grant naming a project that no longer exists still renders — as
+//     the raw id, marked — because hiding it would hide the fact that the
+//     enrolment is holding something relay cannot resolve.
+//   * The certificate fingerprint renders IN FULL. After an enrolment is
+//     deleted the fingerprint is the only thing that identifies that client's
+//     calls in the audit log, which is why the Tool Calls tab prints it
+//     untruncated too (see renderAuditDetail). A UI that shortened it would be
+//     the obvious place for someone to copy a short form from.
+//
+// The listener section below the list is the other half: an enrolment reaches
+// nothing if no listener is running, and the reasons a listener is not running
+// are surprising enough (an absent block, an omitted `enabled`, auditing
+// switched off) that each is stated rather than left to be inferred from an
+// empty log.
+// ---------------------------------------------------------------------------
+
+// The listener binds its address once, at startup. SINGLE SOURCE FOR THAT
+// CLAIM: this constant has exactly one use site (renderRemoteListener, under
+// the listen field). When the listener picks up address changes live, narrow
+// this string to the enable/disable case — or delete the constant and its one
+// use if that goes live too.
+const REMOTE_RESTART_NOTE = 'Enabling, disabling, or moving the listener takes effect when Relay restarts — it binds its address at startup.';
+
+// remoteGrantableProjects is the only set the create form offers.
+// ValidateEnrolmentGrants refuses a grant naming a local project outright, so
+// presenting one would be offering a choice relay is about to reject. This is
+// a courtesy, not the enforcement — the server validates regardless, inside
+// the same store.With that claims the client id.
+function remoteGrantableProjects() {
+    return (state.projects || []).filter(isRemoteProject);
+}
+
+// enrolGrantNames resolves an enrolment's grant ids to {id, name} pairs. name
+// is null when no project carries that id — a dangling grant, which the card
+// shows rather than silently drops.
+function enrolGrantNames(e) {
+    return ((e && e.project_ids) || []).map(function(id) {
+        const p = (state.projects || []).find(x => x.id === id);
+        return { id: id, name: p ? p.name : null };
+    });
+}
+
+// enrolGrantSummary is the plain-text form used in the revoke confirmation.
+// The confirmation names what is being cut; "are you sure?" over an opaque id
+// is not a decision anyone can make.
+function enrolGrantSummary(e) {
+    const names = enrolGrantNames(e).map(g => g.name || (g.id + ' (unknown project)'));
+    if (!names.length) return 'no projects — this enrolment grants nothing today';
+    return names.join(', ');
+}
+
+// enrolBytes renders a byte budget. Only exact multiples get a friendly unit,
+// so a number the operator typed always reads back as the number they typed
+// rather than as a rounded approximation of it.
+function enrolBytes(n) {
+    n = Number(n) || 0;
+    if (n >= 1048576 && n % 1048576 === 0) return (n / 1048576) + ' MiB';
+    if (n >= 1024 && n % 1024 === 0) return (n / 1024) + ' KiB';
+    return n + ' bytes';
+}
+
+function enrolBudgetText(b) {
+    b = b || {};
+    return (b.max_calls || 0) + ' calls / ' + enrolBytes(b.max_result_bytes) + ' per ' + (b.window_seconds || 0) + 's';
+}
+
+function renderEnrolments() {
+    if (state.enrolForm) return renderEnrolmentForm();
+
+    let html = '<div class="page-header"><h2>Remote Clients</h2>';
+    html += '<button class="btn btn-primary" onclick="newEnrolment()">+ New Enrolment</button></div>';
+    html += '<p class="page-intro">An enrolment binds one client certificate to the remote projects it may use. The certificate <em>is</em> the identity — there is no bearer token on this path, so a copy of <code>settings.json</code> grants no remote access at all. Enrolments are keyed by certificate, not by machine: several agents on one VM each hold their own, granted and revoked independently.</p>';
+
+    if (state.enrolBundle) html += renderEnrolBundleBanner(state.enrolBundle);
+    if (state.enrolRevoked) {
+        html += '<div class="audit-note">Revoked <strong>' + esc(state.enrolRevoked.client_id) + '</strong>. Its calls remain in the Tool Calls log under fingerprint <code>' + esc(state.enrolRevoked.fingerprint) + '</code> — now the only thing that names them.</div>';
+    }
+    if (state.enrolmentError) html += '<div class="proj-error">' + esc(state.enrolmentError) + '</div>';
+
+    const list = state.enrolments || [];
+    if (!list.length) {
+        html += '<div class="empty-state">No enrolled clients. Click <strong>+ New Enrolment</strong>, or run <code>relay enrol create</code>.</div>';
+    }
+    for (const e of list) {
+        html += '<div class="enrol-card">';
+        html += '<div class="enrol-card-header">';
+        html += '<span class="enrol-card-name">' + esc(e.client_id) + '</span>';
+        html += '<button class="btn btn-sm btn-danger" onclick="revokeEnrolment(\'' + esc(e.client_id) + '\')">Revoke</button>';
+        html += '</div>';
+
+        // Grants, by name. A card that showed ids would make the revoke
+        // decision unanswerable without a second tab open beside it.
+        html += '<div class="enrol-grants">';
+        const grants = enrolGrantNames(e);
+        if (!grants.length) {
+            html += '<span class="enrol-grant none">no projects granted</span>';
+        }
+        for (const g of grants) {
+            if (g.name) {
+                html += '<span class="enrol-grant" title="' + esc(g.id) + '">' + esc(g.name) + '</span>';
+            } else {
+                html += '<span class="enrol-grant dangling" title="No project carries this id">' + esc(g.id) + ' — unknown project</span>';
+            }
+        }
+        html += '</div>';
+
+        html += '<div class="enrol-meta">';
+        html += '<span>Budget: <strong>' + esc(enrolBudgetText(e.budget)) + '</strong></span>';
+        html += '<span>Enrolled: <strong>' + esc(e.created_at || '—') + '</strong></span>';
+        html += '</div>';
+        // Full fingerprint, never truncated — see the file header.
+        html += '<div class="enrol-fp"><span class="enrol-fp-label">Certificate: </span>' + esc(e.fingerprint || '(none)') + '</div>';
+        html += '</div>';
+    }
+
+    html += renderRemoteListener();
+    return html;
+}
+
+// renderEnrolBundleBanner names the emitted directory and tells the operator to
+// MOVE it. The private key is inside that directory and is never rendered,
+// previewed, or fetched over IPC — the settings WebView is a rendering surface,
+// and key material that reaches it has been copied somewhere nobody will think
+// to wipe. The filenames below are static copy, matching `relay enrol create`.
+function renderEnrolBundleBanner(b) {
+    let html = '<div class="enrol-bundle">';
+    html += 'Enrolled <strong>' + esc(b.client_id) + '</strong>. Bundle written to <code>' + esc(b.dir) + '</code>';
+    html += '<ul>';
+    html += '<li><code>client.key</code> — client private key (0600)</li>';
+    html += '<li><code>client.crt</code> — client certificate</li>';
+    html += '<li><code>ca.crt</code> — relay\'s CA certificate, for verifying the server</li>';
+    html += '</ul>';
+    html += '<strong>Move (don\'t copy) this directory to the client machine.</strong> The private key travels exactly once; every copy left behind is a credential nobody is tracking.';
+    html += '<div style="margin-top:8px"><button class="btn btn-sm" onclick="dismissEnrolBundle()">Done</button></div>';
+    html += '</div>';
+    return html;
+}
+
+function renderEnrolmentForm() {
+    const f = state.enrolForm;
+    const d = state.enrolmentBudgetDefaults || {};
+    let html = '<h2>New Enrolment</h2>';
+    if (state.enrolmentError) html += '<div class="proj-error">' + esc(state.enrolmentError) + '</div>';
+
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Identity</div>';
+    html += '<p class="proj-section-help">The client id is the certificate\'s Common Name and the bundle\'s directory name, so it is limited to letters, digits, <code>.</code>, <code>_</code> and <code>-</code>. It must be unique: to re-issue a certificate, revoke the existing enrolment first.</p>';
+    html += '<label>Client id</label>';
+    html += '<input type="text" id="enrolClientId" value="' + esc(f.client_id) + '" placeholder="hermes-mail" />';
+    html += '</div>';
+
+    // ---- Grants ----
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Granted Projects</div>';
+    html += '<p class="proj-section-help">Only <strong>remote</strong> projects can be granted. A remote client granted a local project would inherit that project\'s host-directory scope, so the grant is refused outright — this list offers nothing that would be refused.</p>';
+    const grantable = remoteGrantableProjects();
+    if (!grantable.length) {
+        html += '<div class="proj-tool-empty">No remote projects exist yet. Create one in the <strong>Projects</strong> tab (Kind → Remote) first.</div>';
+    }
+    for (const p of grantable) {
+        const checked = f.project_ids.indexOf(p.id) >= 0;
+        html += '<label class="proj-tool-row">';
+        html += '<input type="checkbox" ' + (checked ? 'checked' : '') + ' onchange="toggleEnrolGrant(\'' + esc(p.id) + '\', this.checked)" />';
+        html += '<div><div>' + esc(p.name) + '</div><div class="desc">' + esc(p.id) + '</div></div>';
+        html += '</label>';
+    }
+    if (grantable.length && f.project_ids.length === 0) {
+        // Same note `relay enrol create` prints: enrolling with nothing is
+        // legal and is the expected "enrol now, widen deliberately later"
+        // resting state. Say so rather than emitting a certificate that
+        // silently reaches nothing.
+        html += '<p class="proj-section-help">No grant selected: this client will be enrolled but can reach no project until one is added.</p>';
+    }
+    html += '</div>';
+
+    // ---- Budget ----
+    html += '<div class="proj-section">';
+    html += '<div class="proj-section-title">Budget</div>';
+    html += '<p class="proj-section-help">The enrolment is the unit of compromise, so it is the unit that carries the cap. Rate and volume are capped together because they fail differently — a call limit alone does not stop a slow drain. Leave a field blank for the conservative default; <strong>zero is never unlimited</strong>, there is no way to switch a budget off.</p>';
+    html += '<label>Window (seconds)</label>';
+    html += '<input type="number" id="enrolWindow" value="' + esc(f.window_seconds) + '" placeholder="' + esc(d.window_seconds || '') + '" />';
+    html += '<label>Max tool calls per window</label>';
+    html += '<input type="number" id="enrolMaxCalls" value="' + esc(f.max_calls) + '" placeholder="' + esc(d.max_calls || '') + '" />';
+    html += '<label>Max cumulative result bytes per window</label>';
+    html += '<input type="number" id="enrolMaxBytes" value="' + esc(f.max_result_bytes) + '" placeholder="' + esc(d.max_result_bytes || '') + '" />';
+    html += '</div>';
+
+    html += '<div class="proj-form-actions">';
+    html += '<button class="btn btn-primary" onclick="saveEnrolment()">Create &amp; issue certificate</button>';
+    html += '<button class="btn btn-danger" onclick="cancelEnrolment()">Cancel</button>';
+    html += '</div>';
+    return html;
+}
+
+function newEnrolment() {
+    state.enrolForm = { client_id: '', project_ids: [], window_seconds: '', max_calls: '', max_result_bytes: '' };
+    state.enrolmentError = null;
+    state.enrolBundle = null;
+    state.enrolRevoked = null;
+    render();
+}
+
+function cancelEnrolment() {
+    state.enrolForm = null;
+    state.enrolmentError = null;
+    render();
+}
+
+function toggleEnrolGrant(projectID, checked) {
+    const f = state.enrolForm;
+    if (!f) return;
+    const i = f.project_ids.indexOf(projectID);
+    if (checked && i < 0) f.project_ids.push(projectID);
+    if (!checked && i >= 0) f.project_ids.splice(i, 1);
+    render();
+}
+
+function saveEnrolment() {
+    const f = state.enrolForm;
+    if (!f) return;
+    const clientID = (((document.getElementById('enrolClientId') || {}).value) || '').trim();
+    if (!clientID) {
+        state.enrolmentError = 'client id is required';
+        render();
+        return;
+    }
+    f.client_id = clientID;
+    // A blank or unparseable field sends 0, which normalizeEnrolmentBudget
+    // reads as "unset" and fills with the conservative default. Zero never
+    // means unlimited anywhere on this path.
+    const num = function(id) {
+        const raw = (((document.getElementById(id) || {}).value) || '').trim();
+        const n = parseInt(raw, 10);
+        return (raw === '' || isNaN(n) || n < 0) ? 0 : n;
+    };
+    state.enrolmentError = null;
+    ipc(JSON.stringify({
+        type: 'create_enrolment',
+        client_id: clientID,
+        project_ids: f.project_ids,
+        budget: {
+            window_seconds: num('enrolWindow'),
+            max_calls: num('enrolMaxCalls'),
+            max_result_bytes: num('enrolMaxBytes'),
+        },
+    }));
+}
+
+// revokeEnrolment names what is being cut before it cuts it. The wording
+// matches `relay enrol revoke`: the certificate is unchanged and no project is
+// touched — the record is what granted access, and deleting it also severs the
+// client's live connections rather than waiting for it to reconnect.
+function revokeEnrolment(clientID) {
+    const e = (state.enrolments || []).find(x => x.client_id === clientID);
+    if (!e) return;
+    const msg = 'Revoke enrolment "' + clientID + '"?\n\n'
+        + 'This cuts its access to: ' + enrolGrantSummary(e) + '\n\n'
+        + 'Live connections holding its certificate are closed immediately. The certificate itself is unchanged and no project is touched — the record is what granted it access.';
+    if (!confirm(msg)) return;
+    ipc(JSON.stringify({ type: 'revoke_enrolment', client_id: clientID }));
+}
+
+function dismissEnrolBundle() {
+    state.enrolBundle = null;
+    render();
+}
+
+// ---- The listener ----
+
+// remoteDraft is the uncommitted edit of the `remote` block, lazily seeded
+// from the server's view. Kept out of state.remote so a push-sourced reload
+// can't half-apply someone's typing.
+function remoteDraft() {
+    if (!state.remoteDraft) {
+        const r = state.remote || {};
+        state.remoteDraft = { enabled: !!r.enabled, listen: r.listen || '' };
+    }
+    return state.remoteDraft;
+}
+
+function remoteDraftSet(key, value) {
+    const d = remoteDraft();
+    d[key] = value;
+    state.remoteDirty = true;
+    // The address field re-renders nothing (a repaint on every keystroke would
+    // fight the caret); the toggle does, because the consequence text below it
+    // changes with it.
+    if (key === 'enabled') render();
+}
+
+// remoteListenIsLoopback reports whether an address binds only this machine.
+// The default binds loopback so that misconfiguration cannot expose the
+// control plane to a LAN — widening it is a legitimate act, and this is what
+// lets the UI say so out loud instead of refusing it.
+function remoteListenIsLoopback(addr) {
+    addr = String(addr || '');
+    const i = addr.lastIndexOf(':');
+    if (i < 0) return false;
+    const host = addr.slice(0, i).replace(/^\[/, '').replace(/\]$/, '');
+    return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+}
+
+function renderRemoteListener() {
+    const r = state.remote || { configured: false, enabled: false, listen: '', effective: '', audit_enabled: true };
+    const d = remoteDraft();
+    // Auditing is a hard dependency, not a preference: NewRemoteServer refuses
+    // to start while it is off, so an enabled block in that state is
+    // configured and dead. The badge reports the truth, not the setting.
+    const live = r.enabled && r.audit_enabled;
+
+    let html = '<div class="proj-section" style="margin-top:24px">';
+    html += '<div class="proj-section-title">Remote Listener';
+    if (!r.configured) {
+        html += ' <span class="remote-state absent">No block</span>';
+    } else if (live) {
+        html += ' <span class="remote-state on">On</span>';
+    } else if (r.enabled) {
+        html += ' <span class="remote-state off">Off — auditing disabled</span>';
+    } else {
+        html += ' <span class="remote-state off">Off</span>';
+    }
+    html += '</div>';
+
+    if (state.remoteError) html += '<div class="proj-error">' + esc(state.remoteError) + '</div>';
+
+    // The three states are spelled out because two of them are surprising.
+    if (!r.configured) {
+        html += '<p class="proj-section-help">There is no <code>remote</code> block in <code>settings.json</code>, which means <strong>no listener is opened at all</strong> — not a listener bound to nothing, not one that refuses every call. This is the default, and it is not the same state as a listener that is switched off.</p>';
+    } else if (!r.enabled) {
+        html += '<p class="proj-section-help">The <code>remote</code> block exists but the listener is <strong>off</strong>. A block that omits <code>enabled</code> resolves to disabled — the opposite default to auditing, deliberately, so a network listener is never opened by omission.</p>';
+    }
+
+    if (r.enabled && !r.audit_enabled) {
+        html += '<div class="remote-note danger"><strong>Remote access is off because the tool-call audit log is disabled.</strong> The listener refuses to start while auditing is off: a remote grant is justified by the calls it records, so serving remote traffic unrecorded is not a degraded mode. Re-enable <code>audit.enabled</code> to restore remote access — this block is configured but dead until then.</div>';
+    }
+
+    html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
+    html += '<span>Accept remote clients on an mTLS listener</span>';
+    html += '<label class="switch"><input type="checkbox" ' + (d.enabled ? 'checked' : '') + ' onchange="remoteDraftSet(\'enabled\', this.checked)" /><span class="slider"></span></label>';
+    html += '</div>';
+
+    html += '<label>Listen address</label>';
+    html += '<input type="text" id="remoteListen" value="' + esc(d.listen) + '" placeholder="' + esc(r.effective || '') + '" oninput="remoteDraftSet(\'listen\', this.value)" />';
+    html += '<p class="proj-section-help">Leave blank for the default, <code>' + esc(r.effective || '') + '</code>. ' + esc(REMOTE_RESTART_NOTE) + '</p>';
+
+    const effective = (d.listen || '').trim() || r.effective || '';
+    if (effective && !remoteListenIsLoopback(effective)) {
+        html += '<div class="remote-note warn">' + esc(effective) + ' binds beyond loopback: every machine that can reach that address can attempt a TLS handshake. Only a certificate relay signed gets past it, and an unenrolled one is closed before a single request is read — but the default binds loopback precisely so that reaching relay from another machine is a deliberate act. A tunnel is a network path, never an identity: never forward the bridge socket in its place.</div>';
+    }
+
+    html += '<div class="proj-form-actions">';
+    html += '<button class="btn btn-primary" onclick="saveRemoteConfig()">Save</button>';
+    if (r.configured) {
+        html += '<button class="btn btn-danger" onclick="removeRemoteConfig()">Remove block</button>';
+    }
+    html += '</div>';
+    html += '</div>';
+    return html;
+}
+
+function saveRemoteConfig() {
+    const d = remoteDraft();
+    state.remoteError = null;
+    ipc(JSON.stringify({
+        type: 'update_remote_config',
+        enabled: !!d.enabled,
+        listen: String(d.listen || '').trim(),
+    }));
+}
+
+// removeRemoteConfig returns the install to "no block at all" — the one state
+// an operator could otherwise never get back to once they had touched this
+// form, and the one that means no socket is opened.
+function removeRemoteConfig() {
+    const msg = 'Remove the remote block from settings.json?\n\n'
+        + 'No listener will be opened at all. Enrolments are not touched — they stay listed here and can still be revoked, but nothing can connect until a listener is configured again.';
+    if (!confirm(msg)) return;
+    state.remoteError = null;
+    ipc(JSON.stringify({ type: 'update_remote_config', remove: true }));
+}
+
+// ---- Remote Clients IPC event handlers ----
+
+window.onEnrolmentCreated = function(e, bundle) {
+    if (!e || !e.client_id) return;
+    state.enrolments = (state.enrolments || []).filter(x => x.client_id !== e.client_id).concat(e);
+    state.enrolForm = null;
+    state.enrolmentError = null;
+    state.enrolRevoked = null;
+    // Only the bundle DIRECTORY is ever held here. The private key inside it
+    // does not cross the IPC boundary and has no representation in this state.
+    state.enrolBundle = { client_id: e.client_id, dir: (bundle && bundle.dir) || '' };
+    if (state.page === 'remote') render('push');
+};
+
+window.onEnrolmentRevoked = function(clientID, fingerprint) {
+    state.enrolments = (state.enrolments || []).filter(x => x.client_id !== clientID);
+    state.enrolmentError = null;
+    if (state.enrolBundle && state.enrolBundle.client_id === clientID) state.enrolBundle = null;
+    // The fingerprint outlives the record on purpose: it is what identifies
+    // this client's past calls in the Tool Calls tab now that nothing else
+    // names it.
+    state.enrolRevoked = { client_id: clientID, fingerprint: fingerprint || '' };
+    if (state.page === 'remote') render('push');
+};
+
+window.onEnrolmentError = function(msg) {
+    state.enrolmentError = msg || 'enrolment failed';
+    if (state.page === 'remote') render('push');
+};
+
+window.onRemoteConfigUpdated = function(view) {
+    state.remote = view || state.remote;
+    state.remoteDraft = null;
+    state.remoteDirty = false;
+    state.remoteError = null;
+    if (state.page === 'remote') render('push');
+};
+
+window.onRemoteConfigError = function(msg) {
+    state.remoteError = msg || 'could not save the remote block';
+    if (state.page === 'remote') render('push');
 };
 
 // Service Inspector — generic renderer driven by each service's manifest
@@ -2725,5 +3194,6 @@ render();
 // classic <script> had.
 Object.assign(window, {
     auditCaller, auditDetail, auditFmtTime, auditMatches, auditPretty, auditSelect, auditVisible, exportAudit, queryAudit, renderAudit, renderAuditDetail, renderAuditRow, restoreAuditFocus, revealAuditLog, setAuditFilter, toggleAuditFollow, toggleAuditRow,
+    cancelEnrolment, dismissEnrolBundle, enrolBudgetText, enrolBytes, enrolGrantNames, enrolGrantSummary, newEnrolment, remoteDraft, remoteDraftSet, remoteGrantableProjects, remoteListenIsLoopback, removeRemoteConfig, renderEnrolBundleBanner, renderEnrolmentForm, renderEnrolments, renderRemoteListener, revokeEnrolment, saveEnrolment, saveRemoteConfig, toggleEnrolGrant,
     addExternalMcp, addExternalMcpFromJson, addExternalMcpHttp, addService, authenticateMcp, blankProjectForm, cancelMcpEdit, cancelProjectEdit, cancelServiceEdit, cfgArrayAdd, cfgArrayRemove, cfgBind, cfgChevron, cfgDirty, cfgEdit, cfgEditJson, cfgExpandKey, cfgFieldAt, cfgFirstMissingRequired, cfgGetDraft, cfgHasBadJson, cfgIsExpanded, cfgKvAdd, cfgKvRemove, cfgKvRename, cfgKvSetVal, cfgKvState, cfgMapAdd, cfgMapRemove, cfgMapRename, cfgNodeLabel, cfgRefreshChrome, cfgRerender, cfgSetExpanded, cfgToggleExpand, copyProjectToken, dispatchConfigOp, dispatchServiceAction, editProject, editService, harvestProjectForm, ipc, isAnyActionPending, isProjMcpWildcard, isProjModelsWildcard, isRemoteForm, isRemoteProject, newMcp, newProject, newService, projMcpState, projectFormFromExisting, pruneStaleDisabledTool, regenProjectSkill, removeExternalMcp, removeProject, removeService, render, renderActionButton, renderArrayBlock, renderConfigArray, renderConfigItem, renderConfigKeyValue, renderConfigLeaf, renderConfigMap, renderConfigNode, renderConfigObject, renderConfigSection, renderMcpForm, renderMcpPush, renderMcpServers, renderObjectFields, renderProjToolPicker, renderProjectForm, renderProjects, renderServiceForm, renderServiceInspector, renderServicePanel, renderServiceStatus, renderServices, renderStatusPayload, resetMcpPermissions, revertConfig, rotateProjectToken, saveConfig, saveProjectForm, saveServiceEdit, serviceBadgeHTML, setMcpAddMode, setMcpTransport, setProjKind, setProjMcpState, setProjMcpWildcard, setProjModelsWildcard, setsEqual, showPage, svcFormValues, toggleConfigSection, toggleProjTool, toggleProjectTokenVisible, toggleServiceRunning, updateServiceAutostart, updateServiceStatusDOM});
 window.state = state;

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -1487,12 +1487,15 @@ window.onProjectError = function(msg) {
 // empty log.
 // ---------------------------------------------------------------------------
 
-// The listener binds its address once, at startup. SINGLE SOURCE FOR THAT
-// CLAIM: this constant has exactly one use site (renderRemoteListener, under
-// the listen field). When the listener picks up address changes live, narrow
-// this string to the enable/disable case — or delete the constant and its one
-// use if that goes live too.
-const REMOTE_RESTART_NOTE = 'Enabling, disabling, or moving the listener takes effect when Relay restarts — it binds its address at startup.';
+// The listener now reconciles: RemoteSupervisor converges on the configured
+// state from the settings poll, so enabling, disabling and moving the address
+// all take effect without a relaunch. One thing still does not — turning
+// auditing back ON — because AuditRecorder is built once at startup and nothing
+// reconciles it. Auditing OFF does take effect, and stops the listener, so the
+// asymmetry only bites in the recovering direction. Say that rather than a
+// blanket "restart required", which would be false for everything a user is
+// actually likely to change here.
+const REMOTE_NOTE = 'Enabling, disabling and moving the listener take effect within a few seconds — no restart needed. Re-enabling auditing after turning it off is the exception: that still needs Relay to relaunch.';
 
 // remoteGrantableProjects is the only set the create form offers.
 // ValidateEnrolmentGrants refuses a grant naming a local project outright, so
@@ -1814,7 +1817,7 @@ function renderRemoteListener() {
 
     html += '<label>Listen address</label>';
     html += '<input type="text" id="remoteListen" value="' + esc(d.listen) + '" placeholder="' + esc(r.effective || '') + '" oninput="remoteDraftSet(\'listen\', this.value)" />';
-    html += '<p class="proj-section-help">Leave blank for the default, <code>' + esc(r.effective || '') + '</code>. ' + esc(REMOTE_RESTART_NOTE) + '</p>';
+    html += '<p class="proj-section-help">Leave blank for the default, <code>' + esc(r.effective || '') + '</code>. ' + esc(REMOTE_NOTE) + '</p>';
 
     const effective = (d.listen || '').trim() || r.effective || '';
     if (effective && !remoteListenIsLoopback(effective)) {


### PR DESCRIPTION
Closes #21. Completes the last unbuilt item ADR-010 specified.

## Settings UI (ADR-010 decision 8)

The ADR ends decision 8 with *"Enrolments are listed in the Settings UI beside the grants they reach — a credential you cannot see is one you will not revoke."* Until now the CLI was the only way to see or revoke one.

A **Remote Clients** tab lists each enrolment with the project **names** it grants (not bare ids — an operator revoking access needs to know what they are cutting), its budget, and the full untruncated fingerprint, which after deletion is the only way to identify that client in the audit log. Create and revoke go through `createEnrolment`/`revokeEnrolment` rather than reimplementing validation, so refusal wording matches the CLI and revocation still fires the hook that severs live connections.

**The bundle contains a private key**, so the create response carries the directory path and nothing else — no key bytes, no key path, no filenames. Three tests hold that line, including one that feeds the UI a *hostile* bundle carrying `key_pem`/`key_path` and asserts the page retains only `client_id` and `dir`.

Only remote-kind projects are offered, since `ValidateEnrolmentGrants` refuses the rest and a UI should not present a choice relay is about to reject. Dangling grants render marked rather than vanishing.

## Live reconfiguration (#21)

**The reported symptom understated the bug.** The cause was not per-request re-resolution — that was already right. It was *which* settings object was re-resolved: `store.Get()` answers from `FileSettingsStore.cache`, refreshed only by `With()` (a mutation by *this* process) or the tray poll. `relay enrol create` is a different process, so the cache never moved.

That means **CLI revocation had the same lag, in the dangerous direction.** In-tray revocation only looked immediate because it goes through `With()` on the tray's own store. Both are closed by `currentSettings()` — a `ReloadIfChanged` with a `Get` fallback, one `stat` per decision. Revocation is not made lazier; it keeps per-request refusal *and* live-socket severing.

`RemoteSupervisor` converges rather than commands — deliberately no `Start`/`Stop` a caller could use to open a listener the config does not describe. It binds the new address before tearing down the old, so a failed rebind leaves the old listener serving rather than nothing. The revocation hook now carries an owner, so a rebind cannot have the old server's teardown uninstall the new server's hook.

## Verified live, not just in the suite

```
$ relay enrol create --client-id nolag2 --grant <proj>
$ relayremote call --tool calendars_list        # immediately, no restart, no wait
  exit 0, 274 bytes of real Calendar data
$ relay enrol revoke --client-id nolag2
$ relayremote call --tool calendars_list        # immediately
  refused
```

The Remote Clients tab renders correctly against the live app, with the grant shown as a name and the fingerprint in full.

`go vet` clean · `go test ./...` green · `-race` green on the new tests · `web/dist/settings.html` byte-identical after regen.

## Integration fix neither agent could make

Built in parallel, so the UI still said moving the listener needs a restart. Two of those three are now live and the third never needed one. The note is narrowed to what remains true: **re-enabling auditing** still needs a relaunch, because `AuditRecorder` is built once at startup and nothing reconciles it. Turning auditing *off* does take effect and stops the listener, so the asymmetry only bites in the recovering direction.

## Surfaced, not fixed

Deleting a project is not guarded against enrolments — `Settings.RemoveProject` has no `ValidateProjectEnrolments` equivalent, so deleting a remote project leaves enrolments holding a grant id that resolves to nothing. ADR-010 decision 3 refuses the remote→local *conversion* for exactly this reason. It fails closed at call time, so it is a hygiene bug rather than an authz hole; the UI marks dangling grants. Worth its own issue.