### PR TITLE
ADR-011: a client is an identity, an access profile, and a resource scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ tokens.go                hashToken, auth sentinel errors
 project.go               Project + token creation
 project_routes.go        HTTP project routes; shares Settings mutators with ipc_projects.go
 project_dto.go           projectView DTO — strips the token from every response except rotate
-router.go                Bridge auth (service vs project tokens), tool filtering, _meta injection
+context_schema.go        MCP contextSchema vocabulary (scope/source/applies_to), McpSurface, the tool-name matcher
+router.go                Bridge auth (service vs project tokens), tool filtering, access mode, scope presence, _meta injection
 audit.go                 Tool-call audit log: event model, async writer, ring, redaction, query
 audit_call.go            Nil-safe per-call event builder used by the router instrumentation
 audit_cmd.go             `relay audit` CLI
@@ -77,11 +78,37 @@ and context.
 - `allowed_mcp_ids: ["*"]` = all registered MCPs; explicit IDs to restrict.
 - `allowed_models: ["*"]` = all models; explicit IDs to restrict.
 - Permissions are derived at auth time from `allowed_mcp_ids` — not stored separately.
-- `fs_bash` auto-disabled for filesystem MCPs; `allowed_dirs` auto-set to the project path.
+- `fs_bash` auto-disabled for filesystem MCPs; any `source: "project_path"` field
+  in the MCP's context schema is auto-set to the project path.
 
 Auth flow: `AuthenticateProject(plaintext)` → find project by token hash → derive
 permissions from `allowed_mcp_ids` + registered MCPs → return a `StoredToken`
-view with permissions + disabled_tools + context.
+view with permissions + allowed_tools + access + disabled_tools + context.
+
+### Four allowlists, each failing closed (ADR-011)
+
+A grant answers four questions, and none of the four may widen another:
+
+| question | field | notes |
+|---|---|---|
+| which MCP | `allowed_mcp_ids` | `["*"]` refused for a remote record |
+| which tools | `allowed_tools` (MCP id → patterns) | anchored globs; `"*"` refused for a remote record; **absent means none for a remote record, all for a local project** |
+| which operations | `access` (MCP id → `read`\|`write`) | admitted to `read` only on an explicit `annotations.readOnlyHint: true`; **absent means read for a remote record, write for a local project** |
+| which resources | `context` → injected `_meta` | the MCP enforces it; relay cannot verify it |
+
+The two asymmetric defaults are deliberate — the threat model differs, and a
+local project written before these fields existed must keep working. The
+resource scope is **not** given a default in either direction: a mode has a safe
+wrong answer and a scope does not, so a `scope: "restrict"` field with no value
+denies every call it governs, local projects included.
+
+`disabled_tools` stays a **local-project** control and is refused on a remote
+record, naming `allowed_tools` — an inert control reads on the screen as a
+boundary and is not one. `checkToolAccess` still honours one that reaches it by
+another route, because ignoring a denylist is the only direction that widens.
+
+What each MCP may be narrowed by is read from its `contextSchema`:
+[`docs/context-schema.md`](docs/context-schema.md).
 
 `allow_cwd_auth` (default false, per project) opts into a token-less fallback:
 a caller with no token whose working directory is inside the project path
@@ -104,11 +131,13 @@ directory — `AllowCwdAuth`, `GenerateSkill`, `ShellTemplates`, and the
 `allowed_mcp_ids: ["*"]` wildcard are all refused by `validateProjectShape`
 (`project.go`), as is a non-empty `allowed_models` (an empty allowlist is the
 only value `modelAllowedForProject` won't misread as "unrestricted"). A
-filesystem-scoped MCP (schema declares `allowed_dirs`) can't be granted to a
-remote project either (`ValidateProjectGrants`) — and `SyncProjectToken`
-independently refuses to derive `allowed_dirs` for one regardless, since an
-MCP's schema is discovered at runtime and could gain that field after a
-grant was already validated. Sessions (`refuseRemoteSession`) and PTY
+MCP whose every tool needs the project path can't be granted to a remote
+project either (`ValidateProjectGrants`) — and `SyncProjectToken`
+independently refuses to derive any `source: "project_path"` field for one
+regardless, since an MCP's schema is discovered at runtime and could gain
+such a field after a grant was already validated. `appRouter.CallTool`
+re-checks scope presence against the MCP's *live* schema, which is the only
+one of the three defences that catches that upgrade. Sessions (`refuseRemoteSession`) and PTY
 launches (`refuseRemotePty`) are refused at the point of use too, not just
 at validation — see ADR-009 for why each of these is defended twice rather
 than once.

--- a/audit.go
+++ b/audit.go
@@ -157,6 +157,37 @@ type AuditEvent struct {
 	ResultIsError bool   `json:"result_is_error,omitempty"`
 	ResultPreview string `json:"result_preview,omitempty"`
 
+	// Access and Scope record the AUTHORITY the call ran with, not just the
+	// grant it ran under (ADR-011 decision 7). ADR-008's property is that the
+	// log answers what was attempted with what authority, and the authority is
+	// the grant PLUS the mode PLUS the injected scope. A record carrying the
+	// tool and the args but not these cannot answer "was this call confined?"
+	// once an operator has since edited the profile, and re-reading
+	// settings.json at query time answers a different question.
+	//
+	// Scope carries ONLY the fields the MCP declared as scope: "restrict",
+	// never the whole per-MCP context map — _meta is a general channel and a
+	// future MCP may pass an API key through it, so logging it wholesale would
+	// make this file the place credentials go to be archived (see
+	// scopeFromMeta). Both are set on the single record a local call produces
+	// and on the INTENT record of a remote one, which is the record written
+	// before the MCP runs.
+	Access string                     `json:"access,omitempty"`
+	Scope  map[string]json.RawMessage `json:"scope,omitempty"`
+
+	// ScopeViolation marks a tool_error the MCP labelled as a scope refusal
+	// (see scopeViolationMarker). It is a FIELD and not an outcome on purpose:
+	// ADR-008 already places this case — tool_error means the call completed
+	// and the MCP answered no, i.e. a boundary was probed and held. `throttled`
+	// earned its own slot in ADR-010 because a budget refusal is a decision
+	// RELAY makes with relay's numbers; a scope violation is made inside the
+	// MCP and relay is only relaying it. Promoting it would inflate a small
+	// enum that --outcome, the CLI table and the UI pill all key on, in
+	// exchange for a signal a boolean gives alerting just as well. A `denied`
+	// from the mode or presence check is a different thing and is already
+	// correctly `denied`, because relay decided it.
+	ScopeViolation bool `json:"scope_violation,omitempty"`
+
 	// ToolCount is set on list events: how many tools the credential could see.
 	ToolCount int `json:"tool_count,omitempty"`
 }

--- a/audit_call.go
+++ b/audit_call.go
@@ -163,6 +163,19 @@ func (a *auditCall) setUnauthenticated(ctx context.Context, token string) {
 	}
 }
 
+// setAuthority records the access mode in force and the scope actually
+// injected. Called at the point CallTool assembles _meta, which is before
+// intent() writes the pre-call record, so a remote call's intent line carries
+// the authority it is about to run with rather than only the completion doing
+// so.
+func (a *auditCall) setAuthority(access string, scope map[string]json.RawMessage) {
+	if a == nil {
+		return
+	}
+	a.ev.Access = access
+	a.ev.Scope = scope
+}
+
 // setToolCount records how many tools a list call exposed.
 func (a *auditCall) setToolCount(n int) {
 	if a == nil {
@@ -240,6 +253,7 @@ func (a *auditCall) doneResult(result json.RawMessage, err error) {
 	}
 	a.ev.ResultBytes = len(result)
 	a.ev.ResultIsError = resultIsError(result)
+	a.ev.ScopeViolation = a.ev.ResultIsError && resultIsScopeViolation(result)
 	if n := a.rec.cfg.MaxResultPreviewBytes; n > 0 && len(result) > 0 {
 		a.ev.ResultPreview = truncateRunes(string(result), n)
 	}
@@ -270,6 +284,62 @@ func resultIsError(result json.RawMessage) bool {
 		return false
 	}
 	return probe.IsError
+}
+
+// scopeViolationMarker is the _meta key an MCP sets on an error result to say
+// that the refusal was a resource-scope refusal rather than any other kind.
+//
+// The wire shape, which is the whole of the contract:
+//
+//	{"content": [...], "isError": true,
+//	 "_meta": {"scope_violation": true}}
+//
+// _meta on a result is the symmetric channel to the _meta relay injects on a
+// request. It is honoured ONLY when isError is true — a successful call cannot
+// claim to have refused anything — and only when the value is boolean true.
+// Everything else (absent, a string, a number, a malformed blob) leaves the
+// flag off, because this is an optional signal an MCP volunteers and a garbled
+// one must degrade to "an ordinary tool_error", never to an error about the
+// marker.
+//
+// It is deliberately a marker relay TRUSTS rather than a message relay parses.
+// Distinguishing a scope refusal from any other isError by reading the error
+// text would be the ADR-006 line — domain knowledge inside relay — and this
+// stays honest about which it is: the flag is what the MCP said about itself,
+// and it changes no outcome and gates no decision. It exists so alerting has
+// something to select on.
+const scopeViolationMarker = "scope_violation"
+
+// scopeViolationMarkerNamespaced is the same signal under MCP's convention for
+// a namespaced _meta key. Both spellings are accepted because the cost of
+// accepting two is nil — the flag gates nothing — and the cost of accepting
+// the wrong one is a signal that silently never appears.
+const scopeViolationMarkerNamespaced = "relay/scope_violation"
+
+// resultIsScopeViolation reports whether an MCP error result carries the
+// marker. Nil-safe and malformed-safe by construction: every failure to decode
+// answers false.
+func resultIsScopeViolation(result json.RawMessage) bool {
+	if len(result) == 0 {
+		return false
+	}
+	var probe struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(result, &probe); err != nil {
+		return false
+	}
+	raw, ok := probe.Meta[scopeViolationMarker]
+	if !ok {
+		if raw, ok = probe.Meta[scopeViolationMarkerNamespaced]; !ok {
+			return false
+		}
+	}
+	var flag bool
+	if err := json.Unmarshal(raw, &flag); err != nil {
+		return false
+	}
+	return flag
 }
 
 // projectNameFor resolves a display name for the audited project. Prefers the

--- a/audit_cmd.go
+++ b/audit_cmd.go
@@ -19,12 +19,14 @@ import (
 func runAuditCommand(args []string) {
 	fs := flag.NewFlagSet("audit", flag.ExitOnError)
 	tail := fs.Int("tail", 50, "show the most recent N events")
-	project := fs.String("project", "", "filter by project id")
+	// A remote actor's project_id names an ACCESS PROFILE (ADR-011 decision 1);
+	// it is the same field and the same ids, so one flag serves both.
+	project := fs.String("project", "", "filter by project / access profile id")
 	mcpID := fs.String("mcp", "", "filter by MCP id")
 	outcome := fs.String("outcome", "", "filter by outcome: ok, error, tool_error, denied, unauthorized, throttled, pending")
 	kind := fs.String("kind", "", "filter by actor kind: project, service, remote, unknown")
 	event := fs.String("event", "", "filter by event kind: call_tool, list_tools, list_skills")
-	text := fs.String("grep", "", "substring match over tool, MCP, error, project, caller, args")
+	text := fs.String("grep", "", "substring match over tool, MCP, error, project / access profile, caller, args")
 	asJSON := fs.Bool("json", false, "emit raw JSONL instead of a table")
 	pathOnly := fs.Bool("path", false, "print the log file path and exit")
 	fs.Parse(args)

--- a/cmd/devui/main.go
+++ b/cmd/devui/main.go
@@ -140,7 +140,7 @@ const fixtureMcpScopeFields = `{
   "macmcp":[
     {"name":"mail_accounts","type":"array","item_type":"string","description":"Mail accounts this client may read from or send as","source":"operator","applies_to":["mail_*"],"enumerable":true},
     {"name":"mail_mailboxes","type":"array","item_type":"string","description":"Mailbox paths within those accounts this client may reach","source":"operator","applies_to":["mail_*"],"enumerable":true,"depends_on":["mail_accounts"]},
-    {"name":"write_dirs","type":"array","item_type":"string","description":"Directories this client may write files into","source":"project_path","applies_to":["mail_save_attachment","mail_get_source"]}
+    {"name":"file_dirs","type":"array","item_type":"string","description":"Directories this client may write files into","source":"project_path","applies_to":["mail_save_attachment","mail_get_source"]}
   ],
   "krisp":[]
 }`

--- a/cmd/devui/main.go
+++ b/cmd/devui/main.go
@@ -174,6 +174,7 @@ var mockBridgeScript = `<script>
         else if (msg.op === 'save') { window.onServiceConfigResult({ serviceId: msg.serviceId, op: 'save', ok: true }); window.onServiceConfigApplied({ serviceId: msg.serviceId, mode: 'restarting' }); }
         break;
       case 'list_mcp_tools': window.onMcpToolsListed(msg.mcp_id, FIXTURE_TOOLS[msg.mcp_id] || []); break;
+      case 'enumerate_scope_field': window.onScopeFieldEnumerated(enumerate(msg)); break;
       case 'service_action': window.onServiceActionResult({ serviceId: msg.serviceId, actionId: msg.actionId, row: msg.row, ok: true }); break;
       case 'query_audit': window.onAuditEvents(FIXTURE_AUDIT, FIXTURE_AUDIT_STATUS); break;
       case 'export_audit': window.onAuditExported('/Users/you/Library/Application Support/relay/logs/audit/toolcalls-export-20260819-150000.jsonl'); break;
@@ -197,6 +198,32 @@ var mockBridgeScript = `<script>
         break;
       // add/update/remove/start/stop etc. — no-op in the harness, just logged above
     }
+  }
+  // enumerate answers context/enumerate the way a v2 MCP does, including the
+  // degraded shapes — those are the ones worth eyeballing, because each has to
+  // read differently and none of them may look like an empty list. Force one
+  // by asking for a field named after the status you want to see.
+  function enumerate(msg) {
+    var res = { mcp_id: msg.mcp_id, field: msg.field, status: 'ok', values: null };
+    if (msg.mcp_id !== 'macmcp') { res.status = 'unsupported'; res.error = msg.mcp_id + ' does not implement context/enumerate'; return res; }
+    if (msg.field === 'mail_accounts') {
+      res.values = [{ value: 'Alice', label: 'Alice <alice@example.com>' }, { value: 'Bob', label: 'Bob <bob@example.com>' }];
+      return res;
+    }
+    if (msg.field === 'mail_mailboxes') {
+      // Read WITHIN the accounts already chosen; unchosen means all of them.
+      var accounts = (msg.values && msg.values.mail_accounts) || ['Alice', 'Bob'];
+      res.values = [];
+      for (var i = 0; i < accounts.length; i++) {
+        res.values.push({ value: 'INBOX', label: 'INBOX (' + accounts[i] + ')' });
+        res.values.push({ value: 'Projects/Archive', label: 'Projects/Archive (' + accounts[i] + ')' });
+      }
+      return res;
+    }
+    res.status = 'invalid_field';
+    res.error = 'no enumerable field named ' + msg.field;
+    res.values = null;
+    return res;
   }
 })();
 </script>`

--- a/cmd/devui/main.go
+++ b/cmd/devui/main.go
@@ -70,6 +70,7 @@ func buildPage(html string) string {
 		"__RUNNING_IDS_JSON__", fixtureRunningIDs,
 		"__PROJECTS_JSON__", fixtureProjects,
 		"__MCP_TOOL_CACHE_JSON__", fixtureMcpToolCache,
+		"__MCP_SCOPE_FIELDS_JSON__", fixtureMcpScopeFields,
 		"__ENROLMENTS_JSON__", fixtureEnrolments,
 		"__REMOTE_JSON__", fixtureRemote,
 		"__ENROLMENT_BUDGET_DEFAULTS_JSON__", fixtureEnrolmentBudgetDefaults,
@@ -127,6 +128,22 @@ const fixtureEnrolments = `[
 const fixtureRemote = `{"configured":true,"enabled":true,"listen":"127.0.0.1:9910","effective":"127.0.0.1:9910","audit_enabled":true}`
 
 const fixtureEnrolmentBudgetDefaults = `{"window_seconds":60,"max_calls":60,"max_result_bytes":8388608}`
+
+// fixtureMcpScopeFields mirrors what a v2 contextSchema projects to
+// (ScopeFieldView): macMCP's worked example from ADR-011, so the per-MCP
+// permission panel has an operator-set field, a dependent one, and a
+// project_path-derived one to render read-only.
+const fixtureMcpScopeFields = `{
+  "fsmcp":[
+    {"name":"allowed_dirs","type":"array","item_type":"string","description":"Directories this client may reach","source":"project_path"}
+  ],
+  "macmcp":[
+    {"name":"mail_accounts","type":"array","item_type":"string","description":"Mail accounts this client may read from or send as","source":"operator","applies_to":["mail_*"],"enumerable":true},
+    {"name":"mail_mailboxes","type":"array","item_type":"string","description":"Mailbox paths within those accounts this client may reach","source":"operator","applies_to":["mail_*"],"enumerable":true,"depends_on":["mail_accounts"]},
+    {"name":"write_dirs","type":"array","item_type":"string","description":"Directories this client may write files into","source":"project_path","applies_to":["mail_save_attachment","mail_get_source"]}
+  ],
+  "krisp":[]
+}`
 
 const fixtureMcpToolCache = `{
   "fsmcp":[

--- a/cmd/testmcp/main.go
+++ b/cmd/testmcp/main.go
@@ -58,7 +58,7 @@ const enumSchema = `{
     "description":"Mailbox paths within those accounts this client may reach",
     "scope":"restrict","source":"operator","applies_to":["mail_*"],"enumerable":true,
     "depends_on":["mail_accounts"]},
-  "write_dirs": {"type":"array","items":{"type":"string"},
+  "file_dirs": {"type":"array","items":{"type":"string"},
     "description":"Directories this client may write files into",
     "scope":"restrict","source":"project_path","applies_to":["mail_save_attachment"]}
 }`

--- a/cmd/testmcp/main.go
+++ b/cmd/testmcp/main.go
@@ -6,7 +6,14 @@
 // on stdout. Behavior is selected by the request method so one binary covers
 // every transport test:
 //
-//	initialize           respond with a minimal MCP initialize result
+//	initialize           respond with a minimal MCP initialize result (plus a
+//	                     v2 contextSchema when RELAY_TESTMCP_CONTEXT is set)
+//	context/enumerate    ADR-011 decision 6. Behaviour is selected by the
+//	                     RELAY_TESTMCP_CONTEXT env var: unset or "off" answers
+//	                     -32601 (the shape of an MCP that does not implement
+//	                     it), "v2" declares the schema and answers real values,
+//	                     "unsupported" declares the schema and still answers
+//	                     -32601.
 //	tools/list           respond with one stub tool (so mcpHandshake succeeds)
 //	echo                 respond with result == the request params (honors an
 //	                     optional {"delayMs":N} to force out-of-order replies)
@@ -33,6 +40,80 @@ import (
 	"relaygo/jsonrpc"
 )
 
+// contextMode selects the context/enumerate behaviour. Off by default so every
+// test that predates ADR-011 sees exactly the peer it always saw — including
+// declaring no contextSchema at all, which is what makes "relay has never seen
+// a schema for this MCP" reachable.
+func contextMode() string { return os.Getenv("RELAY_TESTMCP_CONTEXT") }
+
+// enumSchema is macMCP's worked example from ADR-011, which is what relay's
+// operator surfaces are built against: two operator-set enumerable fields, the
+// second depending on the first, plus one relay derives from the project path
+// and therefore never enumerates.
+const enumSchema = `{
+  "mail_accounts": {"type":"array","items":{"type":"string"},
+    "description":"Mail accounts this client may read from or send as",
+    "scope":"restrict","source":"operator","applies_to":["mail_*"],"enumerable":true},
+  "mail_mailboxes": {"type":"array","items":{"type":"string"},
+    "description":"Mailbox paths within those accounts this client may reach",
+    "scope":"restrict","source":"operator","applies_to":["mail_*"],"enumerable":true,
+    "depends_on":["mail_accounts"]},
+  "write_dirs": {"type":"array","items":{"type":"string"},
+    "description":"Directories this client may write files into",
+    "scope":"restrict","source":"project_path","applies_to":["mail_save_attachment"]}
+}`
+
+// allAccounts is what the peer holds. mail_mailboxes enumerates ONE entry per
+// account in scope, so a test can tell "listed within Bob" from "listed across
+// every account" by counting.
+var allAccounts = []string{"Alice", "Bob"}
+
+// enumerate answers a context/enumerate request, or returns a JSON-RPC error.
+func enumerate(params json.RawMessage) (json.RawMessage, *jsonrpc.Error) {
+	var req struct {
+		Field  string              `json:"field"`
+		Values map[string][]string `json:"values"`
+	}
+	_ = json.Unmarshal(params, &req)
+
+	type value struct {
+		Value string `json:"value"`
+		Label string `json:"label,omitempty"`
+	}
+	out := struct {
+		Field  string  `json:"field"`
+		Values []value `json:"values"`
+	}{Field: req.Field, Values: []value{}}
+
+	switch req.Field {
+	case "mail_accounts":
+		for _, a := range allAccounts {
+			out.Values = append(out.Values, value{Value: a, Label: a})
+		}
+	case "mail_mailboxes":
+		// An absent OR EMPTY dependency means "across everything". Reading an
+		// empty list as "match nothing" is the bug that shows an empty picker
+		// in exactly the state an operator opens one in.
+		accounts := req.Values["mail_accounts"]
+		if len(accounts) == 0 {
+			accounts = allAccounts
+		}
+		for _, a := range accounts {
+			// One distinct value per account in scope, so a test can tell
+			// "listed within Bob" from "listed across every account" by what
+			// came back rather than by trusting the request it sent.
+			out.Values = append(out.Values, value{Value: a + "/INBOX", Label: "INBOX (" + a + ")"})
+		}
+	case "no_such_mailbox_field":
+		// A field this peer holds nothing for: a real, empty answer.
+	default:
+		return nil, &jsonrpc.Error{Code: jsonrpc.CodeInvalidParams,
+			Message: "no enumerable field named " + req.Field}
+	}
+	b, _ := json.Marshal(out)
+	return b, nil
+}
+
 func main() {
 	in := bufio.NewScanner(os.Stdin)
 	in.Buffer(make([]byte, 0, 64*1024), 1<<20)
@@ -49,6 +130,11 @@ func main() {
 	}
 	writeResp := func(id interface{}, result json.RawMessage) {
 		b, _ := json.Marshal(jsonrpc.Response{JSONRPC: jsonrpc.Version, ID: id, Result: result})
+		writeLine(b)
+	}
+	writeErr := func(id interface{}, code int, msg string) {
+		b, _ := json.Marshal(jsonrpc.Response{JSONRPC: jsonrpc.Version, ID: id,
+			Error: &jsonrpc.Error{Code: code, Message: msg}})
 		writeLine(b)
 	}
 
@@ -68,7 +154,22 @@ func main() {
 
 		switch req.Method {
 		case "initialize":
-			writeResp(req.ID, json.RawMessage(`{"protocolVersion":"2024-11-05","serverInfo":{"name":"testmcp"},"capabilities":{}}`))
+			if contextMode() == "v2" || contextMode() == "unsupported" {
+				writeResp(req.ID, json.RawMessage(`{"protocolVersion":"2024-11-05","serverInfo":{"name":"testmcp","contextSchemaVersion":2,"contextSchema":`+enumSchema+`},"capabilities":{}}`))
+			} else {
+				writeResp(req.ID, json.RawMessage(`{"protocolVersion":"2024-11-05","serverInfo":{"name":"testmcp"},"capabilities":{}}`))
+			}
+		case "context/enumerate":
+			if contextMode() != "v2" {
+				writeErr(req.ID, jsonrpc.CodeMethodNotFound, "method not found: context/enumerate")
+				break
+			}
+			result, rpcErr := enumerate(req.Params)
+			if rpcErr != nil {
+				writeErr(req.ID, rpcErr.Code, rpcErr.Message)
+				break
+			}
+			writeResp(req.ID, result)
 		case "tools/list":
 			writeResp(req.ID, json.RawMessage(`{"tools":[{"name":"testmcp_ping","description":"ping","inputSchema":{"type":"object"}}]}`))
 		case "hang":

--- a/context_enumerate.go
+++ b/context_enumerate.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"relaygo/jsonrpc"
+	"relaygo/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// context/enumerate — asking an MCP what a scope field's values are
+// (ADR-011 decision 6)
+// ---------------------------------------------------------------------------
+//
+// Constraint 2 is the reason this exists. Typing "INBOX" by hand is the
+// error-prone step, and under decision 4 a typo fails CLOSED — the agent
+// silently gets nothing, which is safe and baffling. So for a field the MCP
+// says it can enumerate, the editor offers the real values instead of a box.
+//
+// It is a SEPARATE JSON-RPC method, not a tool call, and that is decided
+// rather than incidental. Routing an operator-UI read through
+// appRouter.CallTool would land it in the audit log as a tool call nobody
+// made, consume ADR-010 budget, and run with relay's own unscoped authority
+// through the chokepoint that exists to constrain agents. It would also make
+// relay extract values from a free-form tool result — a path expression per
+// MCP, which is domain knowledge by the back door.
+//
+// The request relay sends:
+//
+//	{"jsonrpc":"2.0","id":7,"method":"context/enumerate",
+//	 "params":{"field":"mail_mailboxes","values":{"mail_accounts":["Bob"]}}}
+//
+// `values` carries the already-chosen values of the fields THIS field declares
+// in depends_on, and nothing else. Absent or empty means "across everything".
+//
+// The success answer:
+//
+//	{"result":{"field":"mail_mailboxes",
+//	           "values":[{"value":"INBOX","label":"INBOX"},
+//	                     {"value":"Projects/Archive","label":"Projects/Archive (Bob)"}]}}
+//
+// `value` is what goes into _meta verbatim; `label` is display only. An empty
+// list is a valid answer and means there are none.
+//
+// Enumeration is itself DISCLOSURE — the list of every mail account on the
+// machine — so this is a new read path and it is guarded like every other
+// project route: the frontend Unix socket at 0600 behind the frontend bearer
+// token, and the tray's own IPC channel. It is deliberately NOT reachable from
+// the remote listener, whose dispatch table holds exactly ListTools and
+// CallTool (remote_server.go, TestRemoteDispatchTable_HoldsExactlyListToolsAndCallTool).
+
+// ContextEnumStatus values. There are six because a caller must act
+// differently on each, and collapsing any two of them produces a UI that lies:
+// the whole hazard here is an empty list rendered as "there are none" when the
+// call actually failed.
+const (
+	// EnumStatusOK — the MCP answered. Values is non-nil, and an EMPTY
+	// Values is a real answer meaning "there are none".
+	EnumStatusOK = "ok"
+
+	// EnumStatusUnsupported — the MCP answered -32601. It does not implement
+	// enumeration at all. The caller degrades to text entry, silently and
+	// permanently: relay latches it for the life of the connection so a
+	// picker cannot re-ask on every open, and a reconnect re-asks once.
+	EnumStatusUnsupported = "unsupported"
+
+	// EnumStatusInvalidField — the MCP answered -32602. Relay asked for a
+	// field the MCP will not enumerate, which is a RELAY bug (relay is meant
+	// to ask only for fields declaring enumerable: true). It is surfaced, not
+	// degraded — degrading would hide the bug behind a working-looking box.
+	EnumStatusInvalidField = "invalid_field"
+
+	// EnumStatusUnavailable — anything else: another JSON-RPC error, a
+	// malformed answer, a dead connection, a timeout. The MCP could not
+	// answer RIGHT NOW. The caller says "could not list — try again" and
+	// keeps text entry available, so an operator is never blocked.
+	EnumStatusUnavailable = "unavailable"
+
+	// EnumStatusUnknownMcp — relay has never connected to this MCP, so it
+	// cannot say what the field even is. Relay's own refusal; no call made.
+	EnumStatusUnknownMcp = "unknown_mcp"
+
+	// EnumStatusNotEnumerable — the field is not one this MCP declares as
+	// enumerable (or is not a restrict field, or is derived by relay). Relay's
+	// own refusal, made BEFORE any call: decision 6 honours enumeration for
+	// fields declaring enumerable: true and for no others.
+	EnumStatusNotEnumerable = "not_enumerable"
+)
+
+// ContextEnumValue is one offered value for a scope field.
+//
+// Value stays json.RawMessage rather than being decoded to a string because
+// the contract is that it goes into _meta VERBATIM. Relay does not know what a
+// mailbox is (decision 3) and it does not need to know what shape one is
+// either; the declared fragment is what the value is validated against on save.
+type ContextEnumValue struct {
+	Value json.RawMessage `json:"value"`
+	Label string          `json:"label,omitempty"`
+}
+
+// ContextEnumResult is one enumeration answer, in the one shape both operator
+// surfaces return — the HTTP route eve calls and the tray's IPC event.
+//
+// Values has NO omitempty, and that is the load-bearing detail: `"values": []`
+// means the MCP answered and there are none, while `"values": null` means
+// nobody could look. A caller that renders the second as the first is asserting
+// a fact about the host it does not have.
+type ContextEnumResult struct {
+	McpID  string             `json:"mcp_id"`
+	Field  string             `json:"field"`
+	Status string             `json:"status"`
+	Values []ContextEnumValue `json:"values"`
+	Error  string             `json:"error,omitempty"`
+}
+
+// OK reports whether the answer carries a value list that may be rendered.
+func (r ContextEnumResult) OK() bool { return r.Status == EnumStatusOK }
+
+// ContextEnumerator asks a live MCP to enumerate one of its scope fields.
+// Implemented by *ExternalMcpManager; taken as an interface by the surfaces so
+// a test can supply an MCP that answers -32601, one that answers -32602, and
+// one whose transport is dead, without spawning three processes.
+type ContextEnumerator interface {
+	EnumerateContextField(ctx context.Context, mcpID, field string, values map[string]json.RawMessage) ContextEnumResult
+}
+
+// enumerateScopeField is THE entry point for both operator surfaces. Every
+// check relay makes on its own — is this an MCP relay knows, is this a field
+// it declares, is it one the MCP said it can enumerate, which dependency
+// values may be sent — happens here, exactly once, so the HTTP route and the
+// IPC handler cannot drift into asking different questions.
+//
+// chosen is what the operator has already picked in the form. It is FILTERED
+// to the field's own depends_on before it leaves relay: a surface that sent
+// the whole form would be telling the MCP about fields it never said this one
+// depended on, and the request shape is pinned.
+func enumerateScopeField(ctx context.Context, surfaces McpSurfaces, enum ContextEnumerator, mcpID, field string, chosen map[string]json.RawMessage) ContextEnumResult {
+	res := ContextEnumResult{McpID: mcpID, Field: field}
+
+	if mcpID == "" || field == "" {
+		res.Status = EnumStatusNotEnumerable
+		res.Error = "both mcp_id and field are required"
+		return res
+	}
+	if _, known := surfaces[mcpID]; !known {
+		res.Status = EnumStatusUnknownMcp
+		res.Error = fmt.Sprintf("MCP %q is not registered or not connected, so relay cannot say what it scopes", mcpID)
+		return res
+	}
+
+	schema := surfaces.Schema(mcpID)
+	declared, ok := schema.Field(field)
+	if !ok || !declared.Restricts() {
+		res.Status = EnumStatusNotEnumerable
+		res.Error = fmt.Sprintf("%s does not declare %q as a scope: %q field", mcpID, field, ContextScopeRestrict)
+		return res
+	}
+	if declared.FromProjectPath() {
+		// Nothing to pick: relay derives the value from the project's path
+		// and refuses an operator-supplied one outright.
+		res.Status = EnumStatusNotEnumerable
+		res.Error = fmt.Sprintf("%s.%s is derived by relay from the project path, not chosen by an operator", mcpID, field)
+		return res
+	}
+	if !declared.Enumerable {
+		res.Status = EnumStatusNotEnumerable
+		res.Error = fmt.Sprintf("%s does not declare %s as enumerable", mcpID, field)
+		return res
+	}
+
+	send := dependencyValues(declared, chosen)
+
+	if enum == nil {
+		res.Status = EnumStatusUnavailable
+		res.Error = "enumeration is not available in this mode"
+		return res
+	}
+	return enum.EnumerateContextField(ctx, mcpID, field, send)
+}
+
+// dependencyValues picks out of the operator's already-chosen values exactly
+// the fields this one declares in depends_on, dropping any that are absent or
+// empty — for which the contract is "across everything", spelled by leaving
+// the key out rather than by sending an empty list. hasScopeValue is the same
+// emptiness rule the rest of ADR-011 uses, so an empty choice cannot arrive
+// here reading as a narrowing.
+//
+// That dropping is the important half, not a tidy-up. The picker's NORMAL
+// initial state is a dependency nobody has chosen yet — the panel opens on
+// mail_mailboxes with mail_accounts still empty — and a request carrying
+// {"mail_accounts": []} invites the server to read it as "match nothing" and
+// answer with an empty list. An empty picker at exactly the moment an operator
+// opens one is indistinguishable from a host with no mailboxes. macMCP hit the
+// server-side half of this before shipping and now reads empty as absent; not
+// sending it at all is the half that belongs here.
+func dependencyValues(f ContextField, chosen map[string]json.RawMessage) map[string]json.RawMessage {
+	if len(f.DependsOn) == 0 || len(chosen) == 0 {
+		return nil
+	}
+	out := make(map[string]json.RawMessage, len(f.DependsOn))
+	for _, name := range f.DependsOn {
+		if hasScopeValue(chosen, name) {
+			out[name] = chosen[name]
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// The client
+// ---------------------------------------------------------------------------
+
+// EnumerateContextField sends one context/enumerate request to a connected MCP
+// and classifies the answer. It never returns an error: every outcome is one of
+// the six statuses, because the caller is a picker whose job is to degrade
+// correctly rather than to propagate.
+func (m *ExternalMcpManager) EnumerateContextField(ctx context.Context, mcpID, field string, values map[string]json.RawMessage) ContextEnumResult {
+	res := ContextEnumResult{McpID: mcpID, Field: field}
+
+	m.mu.RLock()
+	conn, connected := m.conns[mcpID]
+	latched := m.enumUnsupported[mcpID]
+	m.mu.RUnlock()
+
+	if latched {
+		// Answered once, remembered for the life of this connection. Asking
+		// again on every field, every time a panel opens, would spend a round
+		// trip per open to learn a fact that cannot change without a restart.
+		res.Status = EnumStatusUnsupported
+		res.Error = fmt.Sprintf("%s does not implement context/enumerate", mcpID)
+		return res
+	}
+	if !connected {
+		res.Status = EnumStatusUnavailable
+		res.Error = fmt.Sprintf("%s is not connected", mcpID)
+		return res
+	}
+
+	params := map[string]interface{}{"field": field}
+	if len(values) > 0 {
+		params["values"] = values
+	}
+
+	// An operator is waiting on a control. MCPRequestTimeout is five minutes
+	// because a tool call can be an LLM inference; a dropdown that spins for
+	// five minutes is worse than one that says "could not list — try again"
+	// with the text box still there.
+	callCtx, cancel := context.WithTimeout(ctx, MCPEnumerateTimeout)
+	defer cancel()
+
+	raw, err := conn.SendRequest(callCtx, mcp.MethodContextEnumerate, params)
+	if err != nil {
+		return m.classifyEnumError(res, mcpID, err)
+	}
+
+	var payload struct {
+		Field  string             `json:"field"`
+		Values []ContextEnumValue `json:"values"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		res.Status = EnumStatusUnavailable
+		res.Error = fmt.Sprintf("%s answered context/enumerate with something that is not an enumeration: %v", mcpID, err)
+		return res
+	}
+	// An answer about a different field is not this field's answer. Rendering
+	// it would put one field's values in another field's picker, which is a
+	// confinement the operator did not choose.
+	if payload.Field != "" && payload.Field != field {
+		res.Status = EnumStatusUnavailable
+		res.Error = fmt.Sprintf("%s was asked about %q and answered about %q", mcpID, field, payload.Field)
+		return res
+	}
+	for i, v := range payload.Values {
+		if !hasEnumValue(v.Value) {
+			// An option with nothing to store cannot be offered, and dropping
+			// it silently would shorten a list an operator reads as complete.
+			res.Status = EnumStatusUnavailable
+			res.Error = fmt.Sprintf("%s offered an entry with no value at index %d", mcpID, i)
+			return res
+		}
+	}
+
+	// Non-nil even when empty: "there are none" is an answer, and it must not
+	// share a rendering with "nobody could look".
+	if payload.Values == nil {
+		payload.Values = []ContextEnumValue{}
+	}
+	res.Status = EnumStatusOK
+	res.Values = payload.Values
+	return res
+}
+
+// classifyEnumError turns a SendRequest failure into the status a picker acts
+// on. The three cases are kept apart deliberately — collapsing -32601 into
+// "could not list" would put a retry button in front of an MCP that will never
+// answer, and collapsing -32602 into "does not implement" would hide a relay
+// bug behind a working-looking text box.
+//
+// EXACTLY TWO codes are recognised, and everything else — every other JSON-RPC
+// code, a malformed answer, a dead pipe, a timeout — is "could not answer right
+// now". That is the fail-safe direction and it is the one the range JSON-RPC
+// reserves for implementation-defined server errors (-32000..-32099) needs:
+// macMCP answers -32000 when Mail itself will not answer, which is a transient
+// condition an operator retries, not a fact about whether the method exists.
+// Matching a specific code there would make the default the wrong branch for
+// every server that picks a different number in the same range.
+func (m *ExternalMcpManager) classifyEnumError(res ContextEnumResult, mcpID string, err error) ContextEnumResult {
+	var rpcErr *mcpRPCError
+	if errors.As(err, &rpcErr) {
+		switch rpcErr.Code {
+		case jsonrpc.CodeMethodNotFound:
+			m.latchEnumUnsupported(mcpID)
+			res.Status = EnumStatusUnsupported
+			res.Error = fmt.Sprintf("%s does not implement context/enumerate", mcpID)
+			return res
+		case jsonrpc.CodeInvalidParams:
+			res.Status = EnumStatusInvalidField
+			res.Error = fmt.Sprintf("%s refused the enumeration request for %q: %s", mcpID, res.Field, rpcErr.Message)
+			return res
+		}
+	}
+	res.Status = EnumStatusUnavailable
+	res.Error = err.Error()
+	return res
+}
+
+// latchEnumUnsupported records that an MCP answered -32601, so no further
+// request is sent to it. Cleared on Stop/StopAll and on a fresh handshake — a
+// reconnect is a new process and may be a new build, so the fact is scoped to
+// the connection that asserted it and never to the settings entry.
+func (m *ExternalMcpManager) latchEnumUnsupported(mcpID string) {
+	m.mu.Lock()
+	if m.enumUnsupported == nil {
+		m.enumUnsupported = make(map[string]bool)
+	}
+	already := m.enumUnsupported[mcpID]
+	m.enumUnsupported[mcpID] = true
+	m.mu.Unlock()
+	if !already {
+		slog.Info("MCP does not implement context/enumerate; scope values stay free text",
+			"id", mcpID, "method", mcp.MethodContextEnumerate)
+	}
+}
+
+// hasEnumValue reports whether an offered value is something that could be
+// stored. Same emptiness rule as hasScopeValue, one level down: an option that
+// stores nothing is an option that confines nothing.
+func hasEnumValue(raw json.RawMessage) bool {
+	return hasScopeValue(map[string]json.RawMessage{"v": raw}, "v")
+}

--- a/context_enumerate_test.go
+++ b/context_enumerate_test.go
@@ -39,7 +39,7 @@ func enumSurfaces() McpSurfaces {
 				"scope":"restrict","source":"operator","applies_to":["mail_*"],"enumerable":true,
 				"depends_on":["mail_accounts"]},
 			"mail_note": {"type":"string","scope":"restrict","source":"operator","applies_to":["mail_*"]},
-			"write_dirs": {"type":"array","items":{"type":"string"},
+			"file_dirs": {"type":"array","items":{"type":"string"},
 				"scope":"restrict","source":"project_path","applies_to":["mail_save_attachment"]}
 		}`),
 	}}
@@ -90,7 +90,7 @@ func TestEnumerate_RelaysOwnRefusalsNeverReachTheMcp(t *testing.T) {
 		{"an MCP relay has never connected to", "ghostmcp", "mail_accounts", EnumStatusUnknownMcp},
 		{"a field the MCP does not declare", "macmcp", "nosuch", EnumStatusNotEnumerable},
 		{"a declared field that is not enumerable", "macmcp", "mail_note", EnumStatusNotEnumerable},
-		{"a field relay derives from the project path", "macmcp", "write_dirs", EnumStatusNotEnumerable},
+		{"a field relay derives from the project path", "macmcp", "file_dirs", EnumStatusNotEnumerable},
 		{"no field at all", "macmcp", "", EnumStatusNotEnumerable},
 	}
 	for _, c := range cases {
@@ -532,7 +532,7 @@ func TestEnumerateRoute_HTTP(t *testing.T) {
 		},
 		{
 			name: "a field the MCP never said it could enumerate", mcpID: "macmcp",
-			body: `{"field":"write_dirs"}`, enum: okEnum("Alice"),
+			body: `{"field":"file_dirs"}`, enum: okEnum("Alice"),
 			wantCode: http.StatusBadRequest, wantStatus: EnumStatusNotEnumerable, wantValues: `"values":null`,
 		},
 	}

--- a/context_enumerate_test.go
+++ b/context_enumerate_test.go
@@ -1,0 +1,679 @@
+//go:build !windows
+
+package main
+
+// ADR-011 decision 6, relay's half: asking a connected MCP what a scope
+// field's real values are, and — the part that actually matters — behaving
+// differently for each way that can fail.
+//
+// The failure modes are the subject of most of this file because the hazard is
+// asymmetric. A picker that renders an empty list when the call FAILED tells an
+// operator there are no mailboxes on a machine full of them, and the profile
+// they then save confines nothing they intended. So every non-ok status must
+// arrive with a nil Values, and each must be distinguishable from the others.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"relaygo/jsonrpc"
+	"relaygo/mcp"
+)
+
+// enumSurfaces is what relay knows about the MCP in these tests: macMCP's
+// worked example, the same declaration cmd/testmcp publishes.
+func enumSurfaces() McpSurfaces {
+	return McpSurfaces{"macmcp": {
+		SchemaVersion: contextSchemaV2,
+		Tools:         []string{"mail_search", "mail_save_attachment"},
+		Schema: json.RawMessage(`{
+			"mail_accounts": {"type":"array","items":{"type":"string"},
+				"scope":"restrict","source":"operator","applies_to":["mail_*"],"enumerable":true},
+			"mail_mailboxes": {"type":"array","items":{"type":"string"},
+				"scope":"restrict","source":"operator","applies_to":["mail_*"],"enumerable":true,
+				"depends_on":["mail_accounts"]},
+			"mail_note": {"type":"string","scope":"restrict","source":"operator","applies_to":["mail_*"]},
+			"write_dirs": {"type":"array","items":{"type":"string"},
+				"scope":"restrict","source":"project_path","applies_to":["mail_save_attachment"]}
+		}`),
+	}}
+}
+
+// fakeEnumerator records what relay actually sent and answers with whatever the
+// test wants back. The recording is half the point: the request shape is pinned
+// with macMCP, and a client that quietly sent the whole form or an empty
+// dependency list would still look correct from the outside.
+type fakeEnumerator struct {
+	calls  []fakeEnumCall
+	result ContextEnumResult
+}
+
+type fakeEnumCall struct {
+	mcpID  string
+	field  string
+	values map[string]json.RawMessage
+}
+
+func (f *fakeEnumerator) EnumerateContextField(_ context.Context, mcpID, field string, values map[string]json.RawMessage) ContextEnumResult {
+	f.calls = append(f.calls, fakeEnumCall{mcpID: mcpID, field: field, values: values})
+	res := f.result
+	res.McpID, res.Field = mcpID, field
+	return res
+}
+
+func okEnum(values ...string) *fakeEnumerator {
+	out := make([]ContextEnumValue, 0, len(values))
+	for _, v := range values {
+		raw, _ := json.Marshal(v)
+		out = append(out, ContextEnumValue{Value: raw, Label: v})
+	}
+	return &fakeEnumerator{result: ContextEnumResult{Status: EnumStatusOK, Values: out}}
+}
+
+// ---------------------------------------------------------------------------
+// What relay refuses on its own, before any MCP is asked
+// ---------------------------------------------------------------------------
+
+// Decision 6 honours enumeration "for those fields only" — the ones declaring
+// enumerable: true. Everything else is refused here, and the MCP is never
+// contacted, so a field that is merely typed into a URL cannot become a probe.
+func TestEnumerate_RelaysOwnRefusalsNeverReachTheMcp(t *testing.T) {
+	cases := []struct {
+		name, mcpID, field, wantStatus string
+	}{
+		{"an MCP relay has never connected to", "ghostmcp", "mail_accounts", EnumStatusUnknownMcp},
+		{"a field the MCP does not declare", "macmcp", "nosuch", EnumStatusNotEnumerable},
+		{"a declared field that is not enumerable", "macmcp", "mail_note", EnumStatusNotEnumerable},
+		{"a field relay derives from the project path", "macmcp", "write_dirs", EnumStatusNotEnumerable},
+		{"no field at all", "macmcp", "", EnumStatusNotEnumerable},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			enum := okEnum("Alice")
+			res := enumerateScopeField(context.Background(), enumSurfaces(), enum, c.mcpID, c.field, nil)
+			if res.Status != c.wantStatus {
+				t.Errorf("status = %q, want %q (%s)", res.Status, c.wantStatus, res.Error)
+			}
+			if len(enum.calls) != 0 {
+				t.Errorf("relay asked the MCP anyway: %+v", enum.calls)
+			}
+			if res.Values != nil {
+				t.Errorf("a refusal carried a value list, which renders as 'there are none': %v", res.Values)
+			}
+			if res.Error == "" {
+				t.Error("a refusal with no reason is one an operator answers by guessing")
+			}
+		})
+	}
+}
+
+// No enumerator wired (a test context, or a build without the MCP manager) is
+// "could not answer right now", not "there are none" and not a 404: the field
+// still exists and the editor's fallback is still the text box.
+func TestEnumerate_NoProviderIsUnavailableNotEmpty(t *testing.T) {
+	res := enumerateScopeField(context.Background(), enumSurfaces(), nil, "macmcp", "mail_accounts", nil)
+	if res.Status != EnumStatusUnavailable || res.Values != nil {
+		t.Fatalf("got %q values=%v, want unavailable with no list", res.Status, res.Values)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The request shape, which is pinned with macMCP
+// ---------------------------------------------------------------------------
+
+// Only the fields THIS field declares in depends_on are sent, and an empty
+// choice is not sent at all.
+//
+// The second half is the one with teeth. The picker's normal initial state is
+// mail_mailboxes open with mail_accounts still unchosen, and a request carrying
+// {"mail_accounts": []} invites the server to read it as "match nothing" —
+// which is an empty picker at exactly the moment an operator opens one, and
+// indistinguishable from a host with no mailboxes. macMCP fixed the server side
+// of this before shipping; omitting it is the client side.
+func TestEnumerate_SendsOnlyDeclaredDependenciesAndDropsEmptyOnes(t *testing.T) {
+	chosen := map[string]json.RawMessage{
+		"mail_accounts":   json.RawMessage(`["Bob"]`),
+		"mail_note":       json.RawMessage(`"not a dependency of this field"`),
+		"unrelated_field": json.RawMessage(`["x"]`),
+	}
+	enum := okEnum("INBOX")
+	enumerateScopeField(context.Background(), enumSurfaces(), enum, "macmcp", "mail_mailboxes", chosen)
+	if len(enum.calls) != 1 {
+		t.Fatalf("want one call, got %d", len(enum.calls))
+	}
+	got := enum.calls[0].values
+	if len(got) != 1 || string(got["mail_accounts"]) != `["Bob"]` {
+		t.Fatalf("relay sent %v, want exactly the declared dependency", got)
+	}
+
+	// Every shape of "unchosen" is the same request: no values at all.
+	for _, empty := range []string{`[]`, `null`, `""`, `{}`} {
+		t.Run("unchosen "+empty, func(t *testing.T) {
+			enum := okEnum("INBOX")
+			enumerateScopeField(context.Background(), enumSurfaces(), enum, "macmcp", "mail_mailboxes",
+				map[string]json.RawMessage{"mail_accounts": json.RawMessage(empty)})
+			if v := enum.calls[0].values; len(v) != 0 {
+				t.Fatalf("an unchosen dependency was sent as %v; the server may read that as 'match nothing'", v)
+			}
+		})
+	}
+
+	// A field with no depends_on is never told about anything, whatever the
+	// operator has already picked elsewhere.
+	enum = okEnum("Alice", "Bob")
+	enumerateScopeField(context.Background(), enumSurfaces(), enum, "macmcp", "mail_accounts", chosen)
+	if v := enum.calls[0].values; len(v) != 0 {
+		t.Fatalf("a field declaring no depends_on was sent %v", v)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Classifying what the MCP answers
+// ---------------------------------------------------------------------------
+
+// mgrWithConn wires a mock connection into a real manager so the classification
+// runs against ExternalMcpManager.EnumerateContextField itself — the latch and
+// the parse live there, not in the seam above it.
+func mgrWithConn(t *testing.T, sendFn func(context.Context, string, interface{}) (json.RawMessage, error)) (*ExternalMcpManager, *int) {
+	t.Helper()
+	calls := 0
+	m := NewExternalMcpManager(nil)
+	t.Cleanup(m.StopAll)
+	addMockConn(m, "macmcp", newMockConn("macmcp", nil, func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+		calls++
+		return sendFn(ctx, method, params)
+	}))
+	return m, &calls
+}
+
+func rpcErrConn(code int, msg string) func(context.Context, string, interface{}) (json.RawMessage, error) {
+	return func(context.Context, string, interface{}) (json.RawMessage, error) {
+		return nil, formatJSONRPCError(&jsonrpc.Error{Code: code, Message: msg})
+	}
+}
+
+// -32601: the MCP does not implement enumeration. Degrade to text entry, and
+// stop asking — silently and permanently, for the life of the connection.
+func TestEnumerate_MethodNotFoundDegradesAndLatches(t *testing.T) {
+	m, calls := mgrWithConn(t, rpcErrConn(jsonrpc.CodeMethodNotFound, "method not found"))
+
+	res := m.EnumerateContextField(context.Background(), "macmcp", "mail_accounts", nil)
+	if res.Status != EnumStatusUnsupported {
+		t.Fatalf("status = %q, want %q", res.Status, EnumStatusUnsupported)
+	}
+	if res.Values != nil {
+		t.Error("an MCP that does not enumerate was reported as having no values")
+	}
+	if *calls != 1 {
+		t.Fatalf("want one request, got %d", *calls)
+	}
+
+	// Asked again — for a different field, which is how a panel opens — and
+	// answered from the latch without a second round trip.
+	res = m.EnumerateContextField(context.Background(), "macmcp", "mail_mailboxes", nil)
+	if res.Status != EnumStatusUnsupported {
+		t.Fatalf("second call status = %q", res.Status)
+	}
+	if *calls != 1 {
+		t.Fatalf("relay re-asked an MCP that already said it does not implement the method (%d requests)", *calls)
+	}
+
+	// The latch belongs to the CONNECTION, not to the MCP's id: a reconnect is
+	// a new process and possibly a new build.
+	m.Stop("macmcp")
+	m.mu.RLock()
+	latched := m.enumUnsupported["macmcp"]
+	m.mu.RUnlock()
+	if latched {
+		t.Error("the -32601 latch survived the connection that asserted it")
+	}
+}
+
+// -32602: relay asked for a field the MCP will not enumerate. That is a RELAY
+// bug — relay is meant to ask only for fields declaring enumerable: true — and
+// it is surfaced rather than degraded, because degrading hides it behind a
+// text box that looks like it was meant to be there.
+func TestEnumerate_InvalidParamsIsSurfacedNotDegraded(t *testing.T) {
+	m, _ := mgrWithConn(t, rpcErrConn(jsonrpc.CodeInvalidParams, "no enumerable field named mail_mailboxes"))
+	res := m.EnumerateContextField(context.Background(), "macmcp", "mail_mailboxes", nil)
+
+	if res.Status != EnumStatusInvalidField {
+		t.Fatalf("status = %q, want %q", res.Status, EnumStatusInvalidField)
+	}
+	if !strings.Contains(res.Error, "no enumerable field named mail_mailboxes") {
+		t.Errorf("the MCP's own reason was thrown away: %q", res.Error)
+	}
+	// It must NOT latch: this says nothing about whether the MCP implements
+	// the method, only that relay asked it the wrong question.
+	m.mu.RLock()
+	latched := m.enumUnsupported["macmcp"]
+	m.mu.RUnlock()
+	if latched {
+		t.Error("a bad request from relay was recorded as the MCP not implementing enumeration")
+	}
+}
+
+// Everything else is "could not answer right now": keep text entry, offer a
+// retry, never claim there are none.
+//
+// The -32000 row is not hypothetical. macMCP answers in JSON-RPC's
+// implementation-defined server-error range when Mail itself will not answer,
+// which is exactly the transient condition a retry fixes — so relay recognises
+// exactly two codes and treats every other one this way, rather than listing
+// the ones it has seen.
+func TestEnumerate_EverythingElseIsRetryable(t *testing.T) {
+	cases := []struct {
+		name string
+		send func(context.Context, string, interface{}) (json.RawMessage, error)
+	}{
+		{"-32000, the server-error range macMCP uses for a mail read that failed",
+			rpcErrConn(-32000, "could not read mailboxes: Mail timed out")},
+		{"-32099, the other end of that range", rpcErrConn(-32099, "server error")},
+		{"-32603 internal error", rpcErrConn(jsonrpc.CodeInternalError, "internal error")},
+		{"-32700 parse error", rpcErrConn(jsonrpc.CodeParseError, "parse error")},
+		{"a transport failure with no JSON-RPC error at all", func(context.Context, string, interface{}) (json.RawMessage, error) {
+			return nil, errors.New("read response: EOF")
+		}},
+		{"an answer that is not an enumeration", func(context.Context, string, interface{}) (json.RawMessage, error) {
+			return json.RawMessage(`"suddenly a string"`), nil
+		}},
+		{"an answer about a different field", func(context.Context, string, interface{}) (json.RawMessage, error) {
+			return json.RawMessage(`{"field":"mail_accounts","values":[{"value":"Bob"}]}`), nil
+		}},
+		{"an offered entry with nothing to store", func(context.Context, string, interface{}) (json.RawMessage, error) {
+			return json.RawMessage(`{"field":"mail_mailboxes","values":[{"value":"INBOX"},{"label":"orphan"}]}`), nil
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m, _ := mgrWithConn(t, c.send)
+			res := m.EnumerateContextField(context.Background(), "macmcp", "mail_mailboxes", nil)
+			if res.Status != EnumStatusUnavailable {
+				t.Fatalf("status = %q, want %q (%s)", res.Status, EnumStatusUnavailable, res.Error)
+			}
+			if res.Values != nil {
+				t.Fatalf("a failed call came back with a value list: %v", res.Values)
+			}
+			if res.Error == "" {
+				t.Error("a failure with no message leaves the operator nothing to act on")
+			}
+			m.mu.RLock()
+			latched := m.enumUnsupported["macmcp"]
+			m.mu.RUnlock()
+			if latched {
+				t.Error("a transient failure permanently disabled the picker for this MCP")
+			}
+		})
+	}
+}
+
+// An MCP that is registered but not connected cannot answer, and saying so is
+// not the same as saying there is nothing to list.
+func TestEnumerate_DisconnectedMcpIsUnavailable(t *testing.T) {
+	m := NewExternalMcpManager(nil)
+	t.Cleanup(m.StopAll)
+	res := m.EnumerateContextField(context.Background(), "macmcp", "mail_accounts", nil)
+	if res.Status != EnumStatusUnavailable || res.Values != nil {
+		t.Fatalf("got %q values=%v", res.Status, res.Values)
+	}
+}
+
+// An empty list IS an answer, and it is the one case where rendering "there
+// are none" is correct — so it must be representable, and distinguishable in
+// the JSON from every failure above.
+func TestEnumerate_EmptyListIsAnAnswerAndSerializesApartFromAFailure(t *testing.T) {
+	m, _ := mgrWithConn(t, func(context.Context, string, interface{}) (json.RawMessage, error) {
+		return json.RawMessage(`{"field":"mail_mailboxes","values":[]}`), nil
+	})
+	res := m.EnumerateContextField(context.Background(), "macmcp", "mail_mailboxes", nil)
+	if !res.OK() {
+		t.Fatalf("status = %q, want ok", res.Status)
+	}
+	if res.Values == nil || len(res.Values) != 0 {
+		t.Fatalf("an empty answer did not survive as an empty list: %v", res.Values)
+	}
+	body, _ := json.Marshal(res)
+	if !strings.Contains(string(body), `"values":[]`) {
+		t.Errorf(`"there are none" must serialize as [] : %s`, body)
+	}
+
+	failed := ContextEnumResult{McpID: "macmcp", Field: "mail_mailboxes", Status: EnumStatusUnavailable}
+	body, _ = json.Marshal(failed)
+	if !strings.Contains(string(body), `"values":null`) {
+		t.Errorf(`"nobody could look" must serialize as null, not []: %s`, body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Against the real stdio peer
+// ---------------------------------------------------------------------------
+
+// The whole path — spawn, handshake, a declared v2 schema read off serverInfo,
+// a context/enumerate over the wire, the answer parsed back — with nothing
+// mocked. The mocks above pin the classification; this pins that relay and an
+// MCP agree on the request and the result shape at all.
+func startEnumPeer(t *testing.T, mode string) *ExternalMcpManager {
+	t.Helper()
+	bin := buildTestMcpBinary(t)
+	m := NewExternalMcpManager(nil)
+	t.Cleanup(m.StopAll)
+	cfg := stdioMcp("macmcp", bin)
+	cfg.Env = map[string]string{"RELAY_TESTMCP_CONTEXT": mode}
+	if err := m.startOne(context.Background(), &cfg); err != nil {
+		t.Fatalf("start testmcp: %v", err)
+	}
+	return m
+}
+
+func enumValueStrings(t *testing.T, res ContextEnumResult) []string {
+	t.Helper()
+	out := make([]string, 0, len(res.Values))
+	for _, v := range res.Values {
+		var s string
+		if err := json.Unmarshal(v.Value, &s); err != nil {
+			t.Fatalf("value %s is not a string: %v", v.Value, err)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func TestEnumerate_LiveStdioPeer(t *testing.T) {
+	m := startEnumPeer(t, "v2")
+	surfaces := m.AllMcpSurfaces()
+
+	// The schema arrived off the wire, and relay reads the two enumerable
+	// fields out of it without knowing what either one means.
+	views := surfaces.Schema("macmcp").ScopeFieldViews()
+	if len(views) != 3 {
+		t.Fatalf("want 3 restrict fields from the peer's serverInfo, got %d", len(views))
+	}
+
+	accounts := enumerateScopeField(context.Background(), surfaces, m, "macmcp", "mail_accounts", nil)
+	if !accounts.OK() {
+		t.Fatalf("mail_accounts: %q %s", accounts.Status, accounts.Error)
+	}
+	if got := fmt.Sprint(enumValueStrings(t, accounts)); got != "[Alice Bob]" {
+		t.Errorf("mail_accounts = %s, want [Alice Bob]", got)
+	}
+	if accounts.Values[0].Label == "" {
+		t.Error("the label the MCP sent for display did not survive")
+	}
+
+	// Dependency order: the mailbox list is read WITHIN the chosen accounts.
+	within := enumerateScopeField(context.Background(), surfaces, m, "macmcp", "mail_mailboxes",
+		map[string]json.RawMessage{"mail_accounts": json.RawMessage(`["Bob"]`)})
+	if !within.OK() {
+		t.Fatalf("mail_mailboxes within Bob: %q %s", within.Status, within.Error)
+	}
+	if got := fmt.Sprint(enumValueStrings(t, within)); got != "[Bob/INBOX]" {
+		t.Errorf("mail_mailboxes within Bob = %s, want [Bob/INBOX]", got)
+	}
+
+	// And with the dependency UNSET it lists across every account rather than
+	// coming back empty — the picker's opening state must not look like a host
+	// with no mailboxes.
+	for _, unset := range []map[string]json.RawMessage{
+		nil,
+		{"mail_accounts": json.RawMessage(`[]`)},
+	} {
+		across := enumerateScopeField(context.Background(), surfaces, m, "macmcp", "mail_mailboxes", unset)
+		if !across.OK() {
+			t.Fatalf("mail_mailboxes across all: %q %s", across.Status, across.Error)
+		}
+		if got := fmt.Sprint(enumValueStrings(t, across)); got != "[Alice/INBOX Bob/INBOX]" {
+			t.Errorf("with the dependency unset (%v) the list was %s, want every account's", unset, got)
+		}
+	}
+}
+
+// The same peer built without the method: relay asks once, is told -32601, and
+// the operator surface degrades to the text box it always had.
+func TestEnumerate_LiveStdioPeerWithoutTheMethod(t *testing.T) {
+	m := startEnumPeer(t, "unsupported")
+	res := enumerateScopeField(context.Background(), m.AllMcpSurfaces(), m, "macmcp", "mail_accounts", nil)
+	if res.Status != EnumStatusUnsupported {
+		t.Fatalf("status = %q, want %q (%s)", res.Status, EnumStatusUnsupported, res.Error)
+	}
+	if res.Values != nil {
+		t.Error("an MCP without the method was reported as having no accounts")
+	}
+}
+
+// A live peer asked about a field it does not enumerate answers -32602, and
+// that reaches the surface as a relay bug rather than as an empty picker.
+// Called on the manager directly because enumerateScopeField would (correctly)
+// refuse first — this is the belt behind that brace.
+func TestEnumerate_LiveStdioPeerRefusesAnUndeclaredField(t *testing.T) {
+	m := startEnumPeer(t, "v2")
+	res := m.EnumerateContextField(context.Background(), "macmcp", "invented_field", nil)
+	if res.Status != EnumStatusInvalidField {
+		t.Fatalf("status = %q, want %q (%s)", res.Status, EnumStatusInvalidField, res.Error)
+	}
+	if res.Values != nil {
+		t.Error("a refused request came back with a value list")
+	}
+}
+
+// A peer that dies mid-request is a transport failure, not an empty mailbox
+// list. This is the one path where nothing answers at all.
+func TestEnumerate_LiveStdioPeerThatDies(t *testing.T) {
+	m := startEnumPeer(t, "v2")
+	m.mu.RLock()
+	conn := m.conns["macmcp"]
+	m.mu.RUnlock()
+	conn.Close()
+
+	res := m.EnumerateContextField(context.Background(), "macmcp", "mail_accounts", nil)
+	if res.Status != EnumStatusUnavailable {
+		t.Fatalf("status = %q, want %q (%s)", res.Status, EnumStatusUnavailable, res.Error)
+	}
+	if res.Values != nil {
+		t.Error("a dead connection was reported as an empty account list")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The wire: HTTP and IPC, which ADR-004 keeps co-equal
+// ---------------------------------------------------------------------------
+
+func TestEnumerateRoute_HTTP(t *testing.T) {
+	cases := []struct {
+		name       string
+		mcpID      string
+		body       string
+		enum       ContextEnumerator
+		wantCode   int
+		wantStatus string
+		wantValues string // the raw JSON of the values field
+	}{
+		{
+			name: "a real answer", mcpID: "macmcp",
+			body: `{"field":"mail_accounts"}`, enum: okEnum("Alice", "Bob"),
+			wantCode: http.StatusOK, wantStatus: EnumStatusOK,
+			wantValues: `"values":[{"value":"Alice","label":"Alice"},{"value":"Bob","label":"Bob"}]`,
+		},
+		{
+			name: "an answer with nothing in it", mcpID: "macmcp",
+			body: `{"field":"mail_accounts"}`, enum: okEnum(),
+			wantCode: http.StatusOK, wantStatus: EnumStatusOK, wantValues: `"values":[]`,
+		},
+		{
+			name: "an MCP that does not implement enumeration", mcpID: "macmcp",
+			body: `{"field":"mail_accounts"}`,
+			enum: &fakeEnumerator{result: ContextEnumResult{Status: EnumStatusUnsupported, Error: "no such method"}},
+			// 200: a true, final answer ABOUT the MCP. The caller renders a
+			// text box, permanently.
+			wantCode: http.StatusOK, wantStatus: EnumStatusUnsupported, wantValues: `"values":null`,
+		},
+		{
+			name: "the MCP refusing the request relay built", mcpID: "macmcp",
+			body: `{"field":"mail_accounts"}`,
+			enum: &fakeEnumerator{result: ContextEnumResult{Status: EnumStatusInvalidField, Error: "not enumerable"}},
+			// 502: the failure is on relay's side of the operator.
+			wantCode: http.StatusBadGateway, wantStatus: EnumStatusInvalidField, wantValues: `"values":null`,
+		},
+		{
+			name: "the MCP not answering right now", mcpID: "macmcp",
+			body:     `{"field":"mail_accounts"}`,
+			enum:     &fakeEnumerator{result: ContextEnumResult{Status: EnumStatusUnavailable, Error: "Mail timed out"}},
+			wantCode: http.StatusServiceUnavailable, wantStatus: EnumStatusUnavailable, wantValues: `"values":null`,
+		},
+		{
+			name: "an MCP relay has never connected to", mcpID: "ghostmcp",
+			body: `{"field":"mail_accounts"}`, enum: okEnum("Alice"),
+			wantCode: http.StatusNotFound, wantStatus: EnumStatusUnknownMcp, wantValues: `"values":null`,
+		},
+		{
+			name: "a field the MCP never said it could enumerate", mcpID: "macmcp",
+			body: `{"field":"write_dirs"}`, enum: okEnum("Alice"),
+			wantCode: http.StatusBadRequest, wantStatus: EnumStatusNotEnumerable, wantValues: `"values":null`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			store := NewSettingsStoreAt(mkEmptySandboxRelayHome(t))
+			if err := store.EnsureInitialized(); err != nil {
+				t.Fatalf("EnsureInitialized: %v", err)
+			}
+			mux := http.NewServeMux()
+			RegisterProjectRoutes(mux, store, schemaProviderFunc(enumSurfaces), nil, c.enum, nil, nil)
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+
+			resp, body := doJSON(t, "POST", srv.URL+"/api/mcps/"+c.mcpID+"/enumerate", json.RawMessage(c.body))
+			if resp.StatusCode != c.wantCode {
+				t.Errorf("HTTP %d, want %d: %s", resp.StatusCode, c.wantCode, body)
+			}
+			if !strings.Contains(string(body), `"status":"`+c.wantStatus+`"`) {
+				t.Errorf("body does not carry status %q: %s", c.wantStatus, body)
+			}
+			if !strings.Contains(string(body), c.wantValues) {
+				t.Errorf("body does not carry %s: %s", c.wantValues, body)
+			}
+		})
+	}
+}
+
+// The dependency values an operator has already chosen reach the MCP through
+// the HTTP surface too — a picker in eve fills in dependency order or it fills
+// in the wrong order.
+func TestEnumerateRoute_HTTPCarriesTheChosenDependencies(t *testing.T) {
+	store := NewSettingsStoreAt(mkEmptySandboxRelayHome(t))
+	if err := store.EnsureInitialized(); err != nil {
+		t.Fatalf("EnsureInitialized: %v", err)
+	}
+	enum := okEnum("INBOX")
+	mux := http.NewServeMux()
+	RegisterProjectRoutes(mux, store, schemaProviderFunc(enumSurfaces), nil, enum, nil, nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, body := doJSON(t, "POST", srv.URL+"/api/mcps/macmcp/enumerate",
+		json.RawMessage(`{"field":"mail_mailboxes","values":{"mail_accounts":["Bob"]}}`))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("HTTP %d: %s", resp.StatusCode, body)
+	}
+	if len(enum.calls) != 1 || string(enum.calls[0].values["mail_accounts"]) != `["Bob"]` {
+		t.Fatalf("the chosen dependency did not reach the MCP: %+v", enum.calls)
+	}
+}
+
+// Enumeration is disclosure — every mail account on this machine — so it sits
+// behind the same bearer token as every other project route, on the same 0600
+// socket. Unauthenticated is 401 before the handler runs.
+func TestEnumerateRoute_RequiresTheFrontendToken(t *testing.T) {
+	_, sock := newTestFrontendServer(t, "the-token")
+	client := dialFrontendHTTP(sock)
+
+	req, _ := http.NewRequest("POST", "http://unix/api/mcps/macmcp/enumerate",
+		strings.NewReader(`{"field":"mail_accounts"}`))
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated enumerate = %d, want 401", resp.StatusCode)
+	}
+}
+
+// And it is not reachable from the remote listener at all. That dispatch table
+// is ListTools and CallTool; this adds a method to the FRONTEND surface and to
+// the tray's IPC channel, neither of which a remote client can address.
+func TestEnumerate_IsNotAnythingARemoteClientCanCall(t *testing.T) {
+	for _, name := range []string{mcp.MethodContextEnumerate, MsgEnumerateScopeField, "enumerate"} {
+		if _, ok := remoteHandlers[name]; ok {
+			t.Fatalf("%q reached the remote dispatch table", name)
+		}
+	}
+	if len(remoteHandlers) != 2 {
+		t.Fatalf("the remote dispatch table grew to %d entries; enumeration must not be one of them", len(remoteHandlers))
+	}
+}
+
+// The IPC half. Same function underneath, same result shape, emitted verbatim
+// so the tray picker can tell an empty answer from a failed one exactly as eve
+// can (ADR-004: the two editors are co-equal).
+func TestEnumerate_IPC(t *testing.T) {
+	ipc, _, ui, _ := newProjectsIPC(t)
+	ipc.Tools = &fakeTools{surfaces: enumSurfaces()}
+	enum := okEnum("Alice", "Bob")
+	ipc.Enumerate = enum
+
+	ipcEnumerateScopeField(ipc, json.RawMessage(`{"type":"enumerate_scope_field","mcp_id":"macmcp","field":"mail_mailboxes","values":{"mail_accounts":["Bob"]}}`))
+
+	args, ok := findEvent(ui, "onScopeFieldEnumerated")
+	if !ok {
+		t.Fatal("no onScopeFieldEnumerated event")
+	}
+	var res ContextEnumResult
+	if err := json.Unmarshal(args[0].(json.RawMessage), &res); err != nil {
+		t.Fatalf("event payload: %v", err)
+	}
+	if !res.OK() || res.Field != "mail_mailboxes" || len(res.Values) != 2 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if len(enum.calls) != 1 || string(enum.calls[0].values["mail_accounts"]) != `["Bob"]` {
+		t.Fatalf("the chosen dependency did not reach the MCP: %+v", enum.calls)
+	}
+
+	// A failure reaches the UI as a failure, with no value list to mistake for
+	// an empty one.
+	ipc.Enumerate = &fakeEnumerator{result: ContextEnumResult{Status: EnumStatusUnavailable, Error: "Mail timed out"}}
+	ipcEnumerateScopeField(ipc, json.RawMessage(`{"type":"enumerate_scope_field","mcp_id":"macmcp","field":"mail_accounts"}`))
+	args, _ = findEvent(ui, "onScopeFieldEnumerated")
+	res = ContextEnumResult{}
+	if err := json.Unmarshal(args[0].(json.RawMessage), &res); err != nil {
+		t.Fatalf("event payload: %v", err)
+	}
+	if res.Status != EnumStatusUnavailable || res.Values != nil {
+		t.Fatalf("a failure reached the UI as %+v", res)
+	}
+}
+
+// No enumerator wired at all (the IPC context a narrow test builds, or a mode
+// where the manager is absent) must not panic and must not claim emptiness.
+func TestEnumerate_IPCWithNoProvider(t *testing.T) {
+	ipc, _, ui, _ := newProjectsIPC(t)
+	ipc.Tools = &fakeTools{surfaces: enumSurfaces()}
+	ipc.Enumerate = nil
+
+	ipcEnumerateScopeField(ipc, json.RawMessage(`{"type":"enumerate_scope_field","mcp_id":"macmcp","field":"mail_accounts"}`))
+	args, ok := findEvent(ui, "onScopeFieldEnumerated")
+	if !ok {
+		t.Fatal("no event emitted")
+	}
+	var res ContextEnumResult
+	_ = json.Unmarshal(args[0].(json.RawMessage), &res)
+	if res.Status != EnumStatusUnavailable || res.Values != nil {
+		t.Fatalf("got %+v", res)
+	}
+}

--- a/context_schema.go
+++ b/context_schema.go
@@ -1,0 +1,557 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// The context-schema vocabulary (ADR-011 decision 3)
+// ---------------------------------------------------------------------------
+//
+// Relay must store, inject, render and refuse a scoping value without knowing
+// what it scopes. That is possible only because a v2 contextSchema describes
+// each field's ROLE IN THE PERMISSION MODEL rather than its meaning:
+//
+//	scope       "restrict"                      this field narrows access
+//	source      "operator" | "project_path"     who supplies the value
+//	applies_to  []string of tool-name globs     which tools it governs
+//	enumerable  bool                            the MCP can list valid values
+//	depends_on  []string of field names         enumeration ordering
+//
+// Relay learns "this field restricts access, an operator sets it, and it
+// governs mail_*". It never learns what a mailbox is. Every field name is an
+// opaque map key from relay's side, start to finish. The rejected alternative
+// is a registry inside relay mapping known field names to known handling —
+// which is what schemaHasField(…, "allowed_dirs") is today in miniature, and
+// it does not survive a second MCP.
+
+// contextSchemaV2 is the first contextSchemaVersion that carries those
+// keywords. An absent or lower version means v1 and is handled exactly as it
+// was before ADR-011 — the literal allowed_dirs branch, for one release.
+const contextSchemaV2 = 2
+
+// Keyword values. Each is a small closed set; anything else is ignored rather
+// than guessed at, because a keyword relay does not understand must not be
+// able to widen anything.
+const (
+	// ContextScopeRestrict marks a field that narrows access. Its absence
+	// means an ordinary context value relay injects and otherwise ignores.
+	//
+	// There is deliberately no "absent" keyword letting an MCP say a missing
+	// value means unrestricted: a field that says it restricts and then
+	// defaults open is not a restriction, and relay could never verify the
+	// claim either way. scope: "restrict" MEANS fail closed.
+	ContextScopeRestrict = "restrict"
+
+	// ContextSourceOperator — an operator sets the value explicitly. Local
+	// and remote alike; nothing about a mail account depends on the caller
+	// having a filesystem.
+	ContextSourceOperator = "operator"
+
+	// ContextSourceProjectPath — relay derives the value from Project.Path.
+	// An access profile (a remote-kind record) has no path, so such a field
+	// is ABSENT for one, and by decision 4 the tools it governs refuse.
+	ContextSourceProjectPath = "project_path"
+)
+
+// v1AllowedDirsField is the ONE domain-specific field name left anywhere in
+// relay, and it is here so that fact is checkable: TestNoDomainSpecificFieldNames
+// asserts the literal appears in exactly one non-test Go source. It exists only
+// for the v1 compatibility branch — an MCP that declares no contextSchemaVersion,
+// which is fsMCP as shipped today — and is scheduled for removal one release
+// after every MCP relay serves declares v2.
+//
+// Under v2 the same MCP declares the same field with source: "project_path",
+// and relay derives it because the SCHEMA asked for it, not because relay
+// recognised the name.
+const v1AllowedDirsField = "allowed_dirs"
+
+// v1FsBashTool is the second domain-specific string, and it is DEFERRED
+// rather than fixed: ADR-011 names moving this into the schema (as a
+// default_disabled_tools declaration) as out of scope, because it is the same
+// ADR-006 violation but it is not resource scoping. Until then relay keeps
+// auto-disabling this one tool for filesystem-scoped MCPs, exactly as before.
+const v1FsBashTool = "fs_bash"
+
+// ContextField is one declared field of a v2 contextSchema: the ordinary
+// JSON-Schema-ish fragment relay needs to validate a value, plus the ADR-011
+// keywords that tell relay what the field is FOR.
+type ContextField struct {
+	// Name is the map key the field was declared under. It is opaque to
+	// relay and is what gets written into _meta.
+	Name string `json:"-"`
+
+	// The value-shape fragment. A deliberate JSON-Schema SUBSET: array-of-string
+	// and string are what the model needs, and a full implementation would be a
+	// second validator to keep correct for no gain (see ValidateValue).
+	Type        string          `json:"type,omitempty"`
+	Items       json.RawMessage `json:"items,omitempty"`
+	Description string          `json:"description,omitempty"`
+
+	// The permission-model keywords.
+	Scope      string   `json:"scope,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	AppliesTo  []string `json:"applies_to,omitempty"`
+	Enumerable bool     `json:"enumerable,omitempty"`
+	DependsOn  []string `json:"depends_on,omitempty"`
+}
+
+// Restricts reports whether this field narrows access.
+func (f ContextField) Restricts() bool { return f.Scope == ContextScopeRestrict }
+
+// FromProjectPath reports whether relay derives this field's value from the
+// project's path.
+func (f ContextField) FromProjectPath() bool { return f.Source == ContextSourceProjectPath }
+
+// FromOperator reports whether an operator supplies this field's value.
+// A restrict-field with no declared source is treated as operator-supplied:
+// that is the reading that leaves the value un-derivable by relay, which is
+// the safe one — relay inventing a value for a field it does not understand
+// is the failure this whole mechanism exists to prevent.
+func (f ContextField) FromOperator() bool {
+	return f.Source == ContextSourceOperator || (f.Source == "" && f.Restricts())
+}
+
+// Governs reports whether this field's applies_to selects the named tool.
+//
+// An ABSENT or empty applies_to governs every tool the MCP exposes. That is
+// the domain-blind default: an MCP that offers no precision gets the widest
+// reading, and one that offers precision gets exactly what it declared.
+//
+// A malformed glob governs everything too. path.Match rejects e.g. an
+// unterminated character class, and the two readings of that are "governs
+// nothing" and "governs everything" — the second is the fail-closed one
+// (more tools require a value, and a grant whose MCP publishes a broken
+// pattern is refused rather than silently unscoped), so it is the one taken.
+func (f ContextField) Governs(toolName string) bool {
+	if len(f.AppliesTo) == 0 {
+		return true
+	}
+	for _, pattern := range f.AppliesTo {
+		if pattern == "" {
+			continue
+		}
+		ok, err := matchToolPattern(pattern, toolName)
+		if err != nil {
+			return true
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// matchToolPattern is THE tool-name matcher. Both places that select tools by
+// pattern go through it — a context field's applies_to (which tools a scope
+// governs) and an access profile's allowed_tools (which tools it may call) —
+// because two matchers with slightly different anchoring is how "mail_* does
+// not admit xmail_send" ends up true in one place and false in the other.
+//
+// It is path.Match, which is ANCHORED: the pattern must match the whole name.
+// So "mail_*" matches "mail_send" and not "xmail_send", and a pattern with no
+// metacharacter is an exact match. Tool names contain no "/", so path.Match's
+// one separator rule never comes into play.
+//
+// The error is returned rather than swallowed because the two callers must
+// fail closed in OPPOSITE directions, and only they know which way that is: an
+// unparseable applies_to governs everything (more tools need a value), an
+// unparseable allowed_tools entry admits nothing.
+func matchToolPattern(pattern, toolName string) (bool, error) {
+	return path.Match(pattern, toolName)
+}
+
+// toolAllowedByPatterns reports whether any pattern in the list selects the
+// tool. An unparseable pattern selects nothing — the fail-closed direction for
+// an allowlist, and the opposite of ContextField.Governs, which is the
+// fail-closed direction for a restriction.
+func toolAllowedByPatterns(patterns []string, toolName string) bool {
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		if ok, err := matchToolPattern(pattern, toolName); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// GovernsAll reports whether this field governs every tool in the given list.
+// This is the question ADR-011 decision 5 turns grant validation into: a field
+// whose value cannot be supplied makes every tool it governs refuse, so a
+// field that governs all of them leaves the MCP with nothing usable.
+//
+// An empty tool list answers false, not true. "This MCP exposes no tools" is
+// what an MCP relay has never connected to looks like, and vacuous truth there
+// would refuse a grant on the strength of missing information.
+func (f ContextField) GovernsAll(toolNames []string) bool {
+	if len(toolNames) == 0 {
+		return false
+	}
+	for _, name := range toolNames {
+		if !f.Governs(name) {
+			return false
+		}
+	}
+	return true
+}
+
+// itemType returns the declared type of an array's elements, or "".
+func (f ContextField) itemType() string {
+	if len(f.Items) == 0 {
+		return ""
+	}
+	var items struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(f.Items, &items); err != nil {
+		return ""
+	}
+	return items.Type
+}
+
+// ValidateValue checks a candidate value against the declared fragment.
+//
+// This is a JSON-Schema SUBSET on purpose — array-of-string and string are the
+// shapes the model needs, and everything else is accepted as long as it is
+// present and non-empty. What it will never do is accept an EMPTY value for a
+// restrict-field: ADR-011 decision 4 makes absent and empty both refusals on
+// all three sides, so "no restriction" is not expressible as emptiness and a
+// stored [] would be a grant that reads as confined and is not.
+func (f ContextField) ValidateValue(raw json.RawMessage) error {
+	trimmed := strings.TrimSpace(string(raw))
+	if len(trimmed) == 0 || trimmed == "null" {
+		return fmt.Errorf("%s: a value is required (an absent value means every call it governs is refused)", f.Name)
+	}
+
+	switch f.Type {
+	case "array":
+		var arr []json.RawMessage
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return fmt.Errorf("%s: expected an array of values", f.Name)
+		}
+		if len(arr) == 0 {
+			return fmt.Errorf("%s: expected at least one value (an empty list means every call it governs is refused, which is not how to say \"no restriction\")", f.Name)
+		}
+		if f.itemType() != "string" {
+			return nil
+		}
+		for i, el := range arr {
+			var s string
+			if err := json.Unmarshal(el, &s); err != nil {
+				return fmt.Errorf("%s[%d]: expected a string", f.Name, i)
+			}
+			if strings.TrimSpace(s) == "" {
+				return fmt.Errorf("%s[%d]: expected a non-empty string", f.Name, i)
+			}
+		}
+		return nil
+
+	case "string":
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return fmt.Errorf("%s: expected a string", f.Name)
+		}
+		if strings.TrimSpace(s) == "" {
+			return fmt.Errorf("%s: expected a non-empty string", f.Name)
+		}
+		return nil
+	}
+
+	// No declared type, or one outside the subset. Presence is still required;
+	// an empty container still is not presence.
+	if trimmed == "[]" || trimmed == "{}" || trimmed == `""` {
+		return fmt.Errorf("%s: a non-empty value is required", f.Name)
+	}
+	return nil
+}
+
+// ContextSchema is a parsed contextSchema declaration.
+//
+// Fields is populated only for v2. A v1 schema keeps its Raw form and is read
+// through schemaHasField, which is what "handled exactly as today" means: no
+// v2 rule can fire on a declaration that never opted into the vocabulary, even
+// if it happens to carry a key spelled like one of the keywords.
+type ContextSchema struct {
+	Version int
+	Raw     json.RawMessage
+
+	Fields []ContextField
+	byName map[string]ContextField
+}
+
+// V2 reports whether this schema declared the ADR-011 vocabulary.
+func (cs ContextSchema) V2() bool { return cs.Version >= contextSchemaV2 }
+
+// Field returns the named field.
+func (cs ContextSchema) Field(name string) (ContextField, bool) {
+	f, ok := cs.byName[name]
+	return f, ok
+}
+
+// RestrictFields returns every field declaring scope: "restrict", in name
+// order. Name order rather than declaration order because a JSON object has no
+// declaration order to preserve, and a stable one is what keeps a scope note
+// and an audit line from reshuffling between two identical calls.
+func (cs ContextSchema) RestrictFields() []ContextField {
+	out := make([]ContextField, 0, len(cs.Fields))
+	for _, f := range cs.Fields {
+		if f.Restricts() {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// GoverningFields returns every restrict-field that governs the named tool.
+func (cs ContextSchema) GoverningFields(toolName string) []ContextField {
+	out := make([]ContextField, 0, len(cs.Fields))
+	for _, f := range cs.RestrictFields() {
+		if f.Governs(toolName) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ProjectPathFields returns every restrict-field relay derives from the
+// project's path.
+func (cs ContextSchema) ProjectPathFields() []ContextField {
+	out := make([]ContextField, 0, len(cs.Fields))
+	for _, f := range cs.RestrictFields() {
+		if f.FromProjectPath() {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// OperatorFields returns every restrict-field an operator must supply. Phase-2
+// operator surfaces (the editor, the enumeration picker) work from this list.
+func (cs ContextSchema) OperatorFields() []ContextField {
+	out := make([]ContextField, 0, len(cs.Fields))
+	for _, f := range cs.RestrictFields() {
+		if f.FromOperator() {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ParseContextSchema turns a raw contextSchema plus its declared version into
+// the parsed form.
+//
+// The shape is fixed as the FLAT form — {fieldName: {fragment}} — and
+// documented (docs/context-schema.md), because issue #17 showed the ambiguity
+// between that and the nested JSON-Schema form is live and its failure
+// direction is fail-open. The nested form is still tolerated here, but only as
+// a rescue: it is consulted when the flat reading found no restrict-field at
+// all, and only adopted when the nested one does. Missing a restrict-field is
+// the failure that matters — the grant is then permitted and nothing is
+// enforced — so the tolerance runs in the fail-closed direction only.
+func ParseContextSchema(raw json.RawMessage, version int) ContextSchema {
+	cs := ContextSchema{Version: version, Raw: raw}
+	if len(raw) == 0 || !cs.V2() {
+		return cs
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return cs
+	}
+
+	fields := parseContextFields(top)
+	if !anyRestricts(fields) {
+		if nested, ok := top["properties"]; ok {
+			var props map[string]json.RawMessage
+			if err := json.Unmarshal(nested, &props); err == nil {
+				if alt := parseContextFields(props); anyRestricts(alt) {
+					fields = alt
+				}
+			}
+		}
+	}
+
+	cs.Fields = fields
+	cs.byName = make(map[string]ContextField, len(fields))
+	for _, f := range fields {
+		cs.byName[f.Name] = f
+	}
+	return cs
+}
+
+func parseContextFields(obj map[string]json.RawMessage) []ContextField {
+	names := make([]string, 0, len(obj))
+	for name := range obj {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := make([]ContextField, 0, len(names))
+	for _, name := range names {
+		var f ContextField
+		// A fragment that is not an object declares nothing relay can act on
+		// (a bare "type": "object" sibling key, say). Skipped rather than
+		// carried as an empty field.
+		if err := json.Unmarshal(obj[name], &f); err != nil {
+			continue
+		}
+		f.Name = name
+		out = append(out, f)
+	}
+	return out
+}
+
+func anyRestricts(fields []ContextField) bool {
+	for _, f := range fields {
+		if f.Restricts() {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Context values
+// ---------------------------------------------------------------------------
+
+// contextValues decodes a project's per-MCP context blob into its fields.
+// A blob that is absent, null, or not an object yields an empty map rather
+// than an error: every caller's next question is "is there a value for field
+// X", and the answer for all three is no.
+func contextValues(raw json.RawMessage) map[string]json.RawMessage {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+// hasScopeValue reports whether the context blob carries a usable value for
+// the field — present, non-null, and non-empty, which is the whole of what
+// decision 4 requires relay to check at call time. It deliberately does NOT
+// re-run ValidateValue: a type mismatch is the operator surface's problem to
+// refuse on save, whereas emptiness is the one that has to be caught here
+// because a schema can grow a field after a grant was already written.
+func hasScopeValue(values map[string]json.RawMessage, name string) bool {
+	raw, ok := values[name]
+	if !ok {
+		return false
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	switch trimmed {
+	case "", "null", "[]", "{}", `""`:
+		return false
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// What relay knows about a live MCP
+// ---------------------------------------------------------------------------
+
+// McpSurface is everything relay knows at runtime about one MCP that bears on
+// permission derivation: the contextSchema it declared at handshake, that
+// schema's version, and the tools it currently exposes.
+//
+// The three travel together because every question ADR-011 asks needs at
+// least two of them. "Would this grant leave the MCP with no usable tools"
+// (decision 5) needs the schema AND the tool list; "is this a v1 schema"
+// needs the schema AND the version. Passing them as three parallel maps is
+// how the versions and the tool list would end up plumbed to some call sites
+// and not others.
+type McpSurface struct {
+	Schema        json.RawMessage
+	SchemaVersion int
+	Tools         []string
+}
+
+// McpSurfaces maps MCP id to its surface. A nil map, or a missing entry,
+// means relay has not connected to that MCP and knows nothing about it —
+// which every consumer here treats as "no schema", matching the pre-ADR-011
+// contract that a nil schemas map skips derivation rather than failing closed.
+type McpSurfaces map[string]McpSurface
+
+// Schema returns the parsed context schema for an MCP.
+func (m McpSurfaces) Schema(mcpID string) ContextSchema {
+	s := m[mcpID]
+	return ParseContextSchema(s.Schema, s.SchemaVersion)
+}
+
+// ToolNames returns the tool names an MCP currently exposes.
+func (m McpSurfaces) ToolNames(mcpID string) []string { return m[mcpID].Tools }
+
+// ---------------------------------------------------------------------------
+// The scope note (ADR-011 decision 8)
+// ---------------------------------------------------------------------------
+
+// scopeNotePrefix marks a note relay appended, so appending is idempotent.
+// ListTools and ListSkillBuckets each build their own copy of a tool from the
+// same live list, and the skill renderer reads the second — the two must not
+// double-append, and the cheapest way to guarantee that is to make the second
+// append a no-op rather than to reason about who calls whom.
+const scopeNotePrefix = "Scope: "
+
+// scopeNoteFor builds the one-sentence note describing how a tool is confined,
+// from the schema field's OWN description and the operator's value. Returns ""
+// when the tool is governed by nothing, or when nothing has a value.
+//
+// A client is told its own limits through ListTools because renderBucketSkillMd
+// — the obvious place — is the wrong ONLY place: access profiles have no
+// skills (validateProjectShape refuses GenerateSkill), so the agent this
+// feature exists for would never see it.
+func scopeNoteFor(cs ContextSchema, values map[string]json.RawMessage, toolName string) string {
+	if !cs.V2() {
+		return ""
+	}
+	var parts []string
+	for _, f := range cs.GoverningFields(toolName) {
+		raw, ok := values[f.Name]
+		if !ok || !hasScopeValue(values, f.Name) {
+			continue
+		}
+		label := f.Description
+		if label == "" {
+			label = f.Name
+		}
+		parts = append(parts, fmt.Sprintf("%s — %s", label, renderScopeValue(raw)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return scopeNotePrefix + strings.Join(parts, "; ") + "."
+}
+
+// renderScopeValue prints a scope value for a human reading a tool
+// description. Arrays of strings become "a, b"; anything else is its compact
+// JSON, which is honest about a shape relay does not model.
+func renderScopeValue(raw json.RawMessage) string {
+	var list []string
+	if err := json.Unmarshal(raw, &list); err == nil && len(list) > 0 {
+		return strings.Join(list, ", ")
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// appendScopeNote adds the note to a description if it is not already there.
+func appendScopeNote(desc, note string) string {
+	if note == "" || strings.Contains(desc, note) {
+		return desc
+	}
+	if desc == "" {
+		return note
+	}
+	return desc + " " + note
+}

--- a/context_schema.go
+++ b/context_schema.go
@@ -555,3 +555,72 @@ func appendScopeNote(desc, note string) string {
 	}
 	return desc + " " + note
 }
+
+// ---------------------------------------------------------------------------
+// The operator's view of a schema (ADR-011 decision 6)
+// ---------------------------------------------------------------------------
+
+// ScopeFieldView is one declared scope: "restrict" field, projected for an
+// operator surface: the Settings UI's per-MCP permission panel, and the same
+// panel eve renders over the HTTP routes.
+//
+// It carries ONLY restrict fields. The panel is a permission editor, and an
+// ordinary context value (a field with no `scope`) is something relay injects
+// and otherwise ignores — showing it beside the values that decide what a
+// client may reach would put two different things under one heading.
+//
+// Source is NORMALISED here rather than passed through: ContextField.FromOperator
+// reads an absent source as operator-supplied, and that rule must be applied in
+// exactly one place. A surface that re-derived it from a raw "" would be a
+// second copy of the rule, free to disagree the day it changes.
+type ScopeFieldView struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type,omitempty"`
+	ItemType    string   `json:"item_type,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Source      string   `json:"source"`
+	AppliesTo   []string `json:"applies_to,omitempty"`
+	Enumerable  bool     `json:"enumerable,omitempty"`
+	DependsOn   []string `json:"depends_on,omitempty"`
+}
+
+// ScopeFieldViews projects a schema's restrict fields for an operator surface,
+// in the same name order RestrictFields uses.
+func (cs ContextSchema) ScopeFieldViews() []ScopeFieldView {
+	fields := cs.RestrictFields()
+	out := make([]ScopeFieldView, 0, len(fields))
+	for _, f := range fields {
+		source := ContextSourceOperator
+		if f.FromProjectPath() {
+			source = ContextSourceProjectPath
+		}
+		out = append(out, ScopeFieldView{
+			Name:        f.Name,
+			Type:        f.Type,
+			ItemType:    f.itemType(),
+			Description: f.Description,
+			Source:      source,
+			AppliesTo:   f.AppliesTo,
+			Enumerable:  f.Enumerable,
+			DependsOn:   f.DependsOn,
+		})
+	}
+	return out
+}
+
+// ScopeFields returns the operator-facing scope fields for every MCP relay
+// knows about, keyed by MCP id. An MCP that declares none gets an empty slice
+// rather than a missing key, so a UI can tell "this MCP scopes nothing" from
+// "relay has never heard of this MCP" — the second is the case where a panel
+// must say it cannot show the fields rather than that there are none.
+func (m McpSurfaces) ScopeFields() map[string][]ScopeFieldView {
+	out := make(map[string][]ScopeFieldView, len(m))
+	for id := range m {
+		views := m.Schema(id).ScopeFieldViews()
+		if views == nil {
+			views = []ScopeFieldView{}
+		}
+		out[id] = views
+	}
+	return out
+}

--- a/context_schema.go
+++ b/context_schema.go
@@ -566,6 +566,43 @@ func contextValues(raw json.RawMessage) map[string]json.RawMessage {
 	return m
 }
 
+// filterKnownContextFields drops any key from a stored context blob that cs
+// — the MCP's LIVE schema — does not currently declare, so a value stored
+// under a field name an MCP has since renamed or dropped is never injected
+// into _meta under that stale name. This is the call-time half of the stale-
+// key problem SyncProjectToken's doc comment describes: relay does not
+// rewrite settings.json when a schema changes underneath a stored grant
+// (doing that from a possibly-empty live schema would be indistinguishable
+// from an MCP that is merely down declaring nothing, and would delete an
+// operator's values on the strength of that), so the safe place to enforce
+// "no unknown key reaches the wire" is here, against the schema of an MCP
+// CallTool has already confirmed is live.
+//
+// Restricted to v2: a v1 schema's context blob is always exactly
+// {v1AllowedDirsField: [...]}, fully replaced by SyncProjectToken on every
+// resync, so there is no drift to filter and nothing else can be stored there
+// (validateProjectContextForMcp refuses it).
+func filterKnownContextFields(base json.RawMessage, cs ContextSchema) json.RawMessage {
+	if !cs.V2() {
+		return base
+	}
+	values := contextValues(base)
+	if values == nil {
+		return base
+	}
+	kept := make(map[string]json.RawMessage, len(values))
+	for name, v := range values {
+		if _, ok := cs.Field(name); ok {
+			kept[name] = v
+		}
+	}
+	out, err := json.Marshal(kept)
+	if err != nil {
+		return base
+	}
+	return out
+}
+
 // hasScopeValue reports whether the context blob carries a usable value for
 // the field — present, non-null, and non-empty, which is the whole of what
 // decision 4 requires relay to check at call time. It deliberately does NOT

--- a/context_schema.go
+++ b/context_schema.go
@@ -169,9 +169,24 @@ func matchToolPattern(pattern, toolName string) (bool, error) {
 // tool. An unparseable pattern selects nothing — the fail-closed direction for
 // an allowlist, and the opposite of ContextField.Governs, which is the
 // fail-closed direction for a restriction.
+//
+// An OVER-BROAD pattern selects nothing either, and that is enforcement
+// agreeing with validation rather than trusting it. validateToolPattern
+// refuses one on save, but a record that acquired one by a route validation
+// did not cover — a hand-edited settings.json, a restored backup, a migration
+// that predates the rule — must not thereby hold every tool its MCPs expose.
+// A grant is only as good as the weakest way into the file that holds it.
+//
+// Note the deliberate asymmetry with the denylist in checkToolAccess, which is
+// honoured wherever it came from: ignoring a denylist is the direction that
+// widens, and ignoring an over-broad allowlist entry is the direction that
+// narrows. Both rules are "prefer the smaller grant"; they only look opposite.
 func toolAllowedByPatterns(patterns []string, toolName string) bool {
 	for _, pattern := range patterns {
 		if pattern == "" {
+			continue
+		}
+		if _, over := overBroadToolPattern(pattern); over {
 			continue
 		}
 		if ok, err := matchToolPattern(pattern, toolName); err == nil && ok {
@@ -179,6 +194,122 @@ func toolAllowedByPatterns(patterns []string, toolName string) bool {
 		}
 	}
 	return false
+}
+
+// ---------------------------------------------------------------------------
+// What makes a tool pattern too broad to be an allowlist entry
+// ---------------------------------------------------------------------------
+//
+// ADR-011 decision 2b refuses a bare "*" in allowed_tools, because registering
+// a tool tomorrow would silently widen a grant made today. That refusal used
+// to be a literal string compare against "*" while the matcher underneath was
+// path.Match — and a tool name contains no "/", so "**", "?*", "*_*", "[a-z]*"
+// and "*e*" all match EVERY tool of an MCP and none of them is the string "*".
+// Measured: a read-only "mail" profile written with allowed_tools ["**"] held
+// 26 tools across 11 of macMCP's domains, web_fetch among them, which restores
+// the whole outbound channel decision 2b exists to remove.
+//
+// So the refusal cannot be a list of spellings — the next spelling slips
+// through the same way. It has to be a property of the MATCHER, asked as: does
+// this pattern select tools by NAME, or by SHAPE? Two questions answer that,
+// and a pattern is refused if either does:
+//
+//  1. Does it require any literal character at all? A pattern built only from
+//     "*", "?" and character classes constrains nothing about a name — it is a
+//     statement about length and alphabet, and every tool name satisfies it.
+//     "*", "**", "?*" and "[a-z]*" all fail here.
+//
+//  2. Does it match a name that is not a tool? A pattern whose literal content
+//     is one or two ordinary characters ("*_*", "*e*") is naming a substring
+//     every plausible identifier carries, which is selection by shape wearing
+//     a letter as a disguise. Probing it against names no MCP exposes is what
+//     tells the two apart, and it needs no knowledge of the MCP's tool list —
+//     which relay does not have at validation time and must not depend on
+//     anyway, since the whole point is the tool that does not exist yet.
+//
+// What survives is what an operator actually means: "mail_*", "mail_search",
+// "capture_screen*". What does not is anything that would still match after
+// the MCP grows a domain.
+
+// toolPatternProbes are names no MCP exposes. They are deliberately not
+// plausible tool names and deliberately wide — every letter of both cases,
+// every digit, and the separators identifiers use — so that a pattern whose
+// only literal content is an ordinary character or two matches one of them.
+//
+// The alphabet runs in order on purpose: no real tool-name fragment ("mail",
+// "list", "get", "send") appears as a substring of it, so a pattern naming a
+// real fragment is not caught by accident. They contain no "/" because a tool
+// name contains none and path.Match's separator rule must stay out of this.
+var toolPatternProbes = []string{
+	"zqx_abcdefghijklmnopqrstuvwxyz_0123456789",
+	"ZQX-ABCDEFGHIJKLMNOPQRSTUVWXYZ.0123456789",
+	// One character, so "?" and "?*" are answered too.
+	"z",
+}
+
+// overBroadToolPattern reports whether a pattern selects tools by shape rather
+// than by name, and returns the reason in the voice a refusal can use.
+//
+// It is only ever asked about an ALLOWLIST entry. A context field's applies_to
+// runs through the same matcher and is deliberately NOT filtered by this: a
+// field that governs everything is a restriction that applies to everything,
+// which is the fail-closed reading there (see ContextField.Governs). The same
+// pattern is over-broad in one list and exactly right in the other.
+func overBroadToolPattern(pattern string) (string, bool) {
+	if toolPatternLiteral(pattern) == "" {
+		return "it requires no literal character at all, so it selects every tool the MCP has by shape rather than naming any", true
+	}
+	for _, probe := range toolPatternProbes {
+		if ok, err := matchToolPattern(pattern, probe); err == nil && ok {
+			return fmt.Sprintf("it matches %q, which is no tool of any MCP — a pattern that matches a name like that is matching by structure, so it would take in whatever an MCP is given tomorrow", probe), true
+		}
+	}
+	return "", false
+}
+
+// toolPatternLiteral returns the characters a pattern requires literally, with
+// the wildcards, the character classes and path.Match's backslash escapes
+// removed. A character class contributes nothing: it constrains which
+// characters may appear at a position, never that any particular one does.
+//
+// The class scanner mirrors path.Match's own — "^" negates, and a "]" in the
+// first position is a member rather than the terminator — so that what this
+// reads as a class is what the matcher reads as a class. An unterminated class
+// runs to the end of the pattern here; such a pattern does not compile and is
+// refused before this answer is used for anything.
+func toolPatternLiteral(pattern string) string {
+	var lit strings.Builder
+	for i := 0; i < len(pattern); {
+		switch c := pattern[i]; c {
+		case '*', '?':
+			i++
+		case '\\':
+			i++
+			if i < len(pattern) {
+				lit.WriteByte(pattern[i])
+				i++
+			}
+		case '[':
+			i++
+			if i < len(pattern) && pattern[i] == '^' {
+				i++
+			}
+			for first := true; i < len(pattern); first = false {
+				if pattern[i] == ']' && !first {
+					i++
+					break
+				}
+				if pattern[i] == '\\' {
+					i++
+				}
+				i++
+			}
+		default:
+			lit.WriteByte(c)
+			i++
+		}
+	}
+	return lit.String()
 }
 
 // GovernsAll reports whether this field governs every tool in the given list.

--- a/context_schema_test.go
+++ b/context_schema_test.go
@@ -35,7 +35,7 @@ const macmcpSchema = `{
     "applies_to": ["mail_*"], "enumerable": true,
     "depends_on": ["mail_accounts"]
   },
-  "write_dirs": {
+  "file_dirs": {
     "type": "array", "items": {"type": "string"},
     "description": "Directories this client may write files into",
     "scope": "restrict", "source": "project_path",
@@ -84,7 +84,7 @@ func TestParseContextSchema_V2FlatFormIsTheContract(t *testing.T) {
 	for _, f := range cs.RestrictFields() {
 		names = append(names, f.Name)
 	}
-	if strings.Join(names, ",") != "mail_accounts,mail_mailboxes,write_dirs" {
+	if strings.Join(names, ",") != "file_dirs,mail_accounts,mail_mailboxes" {
 		t.Fatalf("restrict fields out of name order: %v", names)
 	}
 
@@ -98,7 +98,7 @@ func TestParseContextSchema_V2FlatFormIsTheContract(t *testing.T) {
 	if !f.Enumerable || len(f.DependsOn) != 1 || f.DependsOn[0] != "mail_accounts" {
 		t.Fatalf("enumerable/depends_on misread: %+v", f)
 	}
-	if len(cs.ProjectPathFields()) != 1 || cs.ProjectPathFields()[0].Name != "write_dirs" {
+	if len(cs.ProjectPathFields()) != 1 || cs.ProjectPathFields()[0].Name != "file_dirs" {
 		t.Fatalf("project_path fields = %v", cs.ProjectPathFields())
 	}
 	if len(cs.OperatorFields()) != 2 {
@@ -138,7 +138,7 @@ func TestParseContextSchema_SurvivesRubbish(t *testing.T) {
 func TestContextField_GovernsReadsAppliesTo(t *testing.T) {
 	cs := ParseContextSchema(json.RawMessage(macmcpSchema), 2)
 	mail, _ := cs.Field("mail_accounts")
-	dirs, _ := cs.Field("write_dirs")
+	dirs, _ := cs.Field("file_dirs")
 
 	if !mail.Governs("mail_search") || !mail.Governs("mail_send") {
 		t.Fatal("mail_* did not match a mail tool")
@@ -305,7 +305,7 @@ func TestScopeNoteFor_UsesTheSchemasOwnDescription(t *testing.T) {
 			t.Errorf("note %q missing %q", note, want)
 		}
 	}
-	// write_dirs governs neither of those tools and has no value here, so it
+	// file_dirs governs neither of those tools and has no value here, so it
 	// must not appear.
 	if strings.Contains(note, "Directories") {
 		t.Errorf("note mentioned an ungoverned field: %q", note)
@@ -318,6 +318,36 @@ func TestScopeNoteFor_UsesTheSchemasOwnDescription(t *testing.T) {
 	}
 	if n := scopeNoteFor(ParseContextSchema(json.RawMessage(macmcpSchema), 0), values, "mail_search"); n != "" {
 		t.Errorf("a v1 schema got a note: %q", n)
+	}
+}
+
+func TestFilterKnownContextFields_DropsWhatTheLiveSchemaNoLongerDeclares(t *testing.T) {
+	cs := ParseContextSchema(json.RawMessage(macmcpSchema), 2)
+	base := json.RawMessage(`{"mail_accounts":["Bob"],"write_dirs":["/etc"]}`)
+
+	out := filterKnownContextFields(base, cs)
+	values := contextValues(out)
+	if _, present := values["write_dirs"]; present {
+		t.Errorf("a field the live schema no longer declares survived filtering: %s", out)
+	}
+	if string(values["mail_accounts"]) != `["Bob"]` {
+		t.Errorf("a field the live schema DOES declare was dropped: %s", out)
+	}
+
+	// A v1 schema is passed through untouched: it has no Fields to check
+	// against, and its context blob is always fully replaced by
+	// SyncProjectToken, so there is nothing to filter.
+	v1 := ParseContextSchema(json.RawMessage(macmcpSchema), 0)
+	if got := filterKnownContextFields(base, v1); string(got) != string(base) {
+		t.Errorf("a v1 schema was filtered: got %s, want unchanged %s", got, base)
+	}
+
+	// Absent/empty/malformed input all pass through as-is rather than
+	// manufacturing an error on a path CallTool cannot recover from.
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(``), json.RawMessage(`null`)} {
+		if got := filterKnownContextFields(raw, cs); string(got) != string(raw) {
+			t.Errorf("filterKnownContextFields(%q) = %q, want unchanged", raw, got)
+		}
 	}
 }
 

--- a/context_schema_test.go
+++ b/context_schema_test.go
@@ -1,0 +1,411 @@
+package main
+
+// Unit coverage for the v2 context-schema vocabulary (ADR-011 decision 3).
+// Every question relay asks of a schema is answered here without a live MCP:
+// the parse, the applies_to glob, the value validator, and the scope note.
+// The enforcement that consumes them is covered in router_access_test.go and
+// router_scope_test.go.
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// macmcpSchema is ADR-011's worked example, verbatim: two operator-supplied
+// restrict fields governing mail_*, and one project_path field governing
+// exactly two tools.
+const macmcpSchema = `{
+  "mail_accounts": {
+    "type": "array", "items": {"type": "string"},
+    "description": "Mail accounts this client may read from or send as",
+    "scope": "restrict", "source": "operator",
+    "applies_to": ["mail_*"], "enumerable": true
+  },
+  "mail_mailboxes": {
+    "type": "array", "items": {"type": "string"},
+    "description": "Mailbox paths within those accounts this client may reach",
+    "scope": "restrict", "source": "operator",
+    "applies_to": ["mail_*"], "enumerable": true,
+    "depends_on": ["mail_accounts"]
+  },
+  "write_dirs": {
+    "type": "array", "items": {"type": "string"},
+    "description": "Directories this client may write files into",
+    "scope": "restrict", "source": "project_path",
+    "applies_to": ["mail_save_attachment", "mail_get_source"]
+  }
+}`
+
+// fsmcpV2Schema is what fsMCP looks like once it declares v2: one
+// project_path field with no applies_to at all, which governs everything.
+const fsmcpV2Schema = `{
+  "allowed_dirs": {
+    "type": "array", "items": {"type": "string"},
+    "description": "Directories this client may reach",
+    "scope": "restrict", "source": "project_path"
+  }
+}`
+
+func TestParseContextSchema_V1DeclaresNoFieldsWhateverItSays(t *testing.T) {
+	// A schema that never opted into the vocabulary must be handled exactly as
+	// it was before ADR-011 — including one that carries a key spelled like a
+	// keyword. Reading v2 semantics off an un-versioned declaration would let
+	// an MCP change how relay enforces without saying so.
+	cs := ParseContextSchema(json.RawMessage(macmcpSchema), 0)
+	if cs.V2() {
+		t.Fatal("version 0 parsed as v2")
+	}
+	if len(cs.Fields) != 0 {
+		t.Fatalf("v1 schema exposed %d fields; v1 is read through schemaHasField only", len(cs.Fields))
+	}
+	if len(cs.RestrictFields()) != 0 {
+		t.Fatal("v1 schema produced restrict fields")
+	}
+}
+
+func TestParseContextSchema_V2FlatFormIsTheContract(t *testing.T) {
+	cs := ParseContextSchema(json.RawMessage(macmcpSchema), 2)
+	if !cs.V2() {
+		t.Fatal("version 2 did not parse as v2")
+	}
+	if got := len(cs.RestrictFields()); got != 3 {
+		t.Fatalf("restrict fields = %d, want 3", got)
+	}
+	// Name order, so a scope note and an audit line do not reshuffle between
+	// two identical calls.
+	var names []string
+	for _, f := range cs.RestrictFields() {
+		names = append(names, f.Name)
+	}
+	if strings.Join(names, ",") != "mail_accounts,mail_mailboxes,write_dirs" {
+		t.Fatalf("restrict fields out of name order: %v", names)
+	}
+
+	f, ok := cs.Field("mail_mailboxes")
+	if !ok {
+		t.Fatal("mail_mailboxes missing")
+	}
+	if !f.Restricts() || !f.FromOperator() || f.FromProjectPath() {
+		t.Fatalf("mail_mailboxes keywords misread: %+v", f)
+	}
+	if !f.Enumerable || len(f.DependsOn) != 1 || f.DependsOn[0] != "mail_accounts" {
+		t.Fatalf("enumerable/depends_on misread: %+v", f)
+	}
+	if len(cs.ProjectPathFields()) != 1 || cs.ProjectPathFields()[0].Name != "write_dirs" {
+		t.Fatalf("project_path fields = %v", cs.ProjectPathFields())
+	}
+	if len(cs.OperatorFields()) != 2 {
+		t.Fatalf("operator fields = %v", cs.OperatorFields())
+	}
+}
+
+func TestParseContextSchema_NestedFormIsRescuedOnlyTowardsFailClosed(t *testing.T) {
+	// Issue #17 showed the flat/nested ambiguity is live and that its failure
+	// direction is fail-open: a restrict field relay does not see is a grant
+	// permitted and nothing enforced. The nested shape is therefore consulted,
+	// but only when the flat reading found no restriction at all.
+	nested := `{"type":"object","properties":` + macmcpSchema + `}`
+	cs := ParseContextSchema(json.RawMessage(nested), 2)
+	if len(cs.RestrictFields()) != 3 {
+		t.Fatalf("nested v2 schema yielded %d restrict fields, want 3", len(cs.RestrictFields()))
+	}
+	// And a flat schema that already declares a restriction is NOT re-read
+	// under a "properties" key it happens to also carry.
+	both := `{"mail_accounts":{"type":"array","scope":"restrict","source":"operator"},` +
+		`"properties":{"decoy":{"type":"array","scope":"restrict","source":"project_path"}}}`
+	cs = ParseContextSchema(json.RawMessage(both), 2)
+	if _, ok := cs.Field("decoy"); ok {
+		t.Fatal("nested rescue overrode a flat reading that already found a restriction")
+	}
+}
+
+func TestParseContextSchema_SurvivesRubbish(t *testing.T) {
+	for _, raw := range []string{``, `null`, `[]`, `{not json`, `{"a":3}`, `"a string"`} {
+		cs := ParseContextSchema(json.RawMessage(raw), 2)
+		if len(cs.RestrictFields()) != 0 {
+			t.Fatalf("%q produced restrict fields", raw)
+		}
+	}
+}
+
+func TestContextField_GovernsReadsAppliesTo(t *testing.T) {
+	cs := ParseContextSchema(json.RawMessage(macmcpSchema), 2)
+	mail, _ := cs.Field("mail_accounts")
+	dirs, _ := cs.Field("write_dirs")
+
+	if !mail.Governs("mail_search") || !mail.Governs("mail_send") {
+		t.Fatal("mail_* did not match a mail tool")
+	}
+	if mail.Governs("messages_send") {
+		t.Fatal("mail_* matched a non-mail tool")
+	}
+	if !dirs.Governs("mail_get_source") || dirs.Governs("mail_search") {
+		t.Fatal("an explicit applies_to list did not select exactly its two tools")
+	}
+}
+
+func TestContextField_AbsentAppliesToGovernsEverything(t *testing.T) {
+	// The domain-blind default: an MCP that offers no precision gets the
+	// widest reading.
+	cs := ParseContextSchema(json.RawMessage(fsmcpV2Schema), 2)
+	f, _ := cs.Field(v1AllowedDirsField)
+	for _, name := range []string{"fs_read", "fs_bash", "anything_at_all"} {
+		if !f.Governs(name) {
+			t.Fatalf("absent applies_to did not govern %q", name)
+		}
+	}
+	if !f.GovernsAll([]string{"fs_read", "fs_write"}) {
+		t.Fatal("absent applies_to did not govern all")
+	}
+}
+
+func TestMatchToolPattern_IsAnchoredAndShared(t *testing.T) {
+	// One matcher serves both applies_to and allowed_tools, so the anchoring
+	// is asserted once, here, on the matcher itself.
+	cases := []struct {
+		pattern, tool string
+		want          bool
+	}{
+		{"mail_*", "mail_send", true},
+		{"mail_*", "mail_", true},
+		{"mail_*", "xmail_send", false},    // not a substring match
+		{"mail_*", "send_mail_now", false}, // nor a suffix one
+		{"mail_send", "mail_send", true},   // no metacharacter: exact
+		{"mail_send", "mail_sender", false},
+		{"mail_send", "mail_", false},
+		{"*", "anything", true},
+	}
+	for _, tc := range cases {
+		got, err := matchToolPattern(tc.pattern, tc.tool)
+		if err != nil {
+			t.Fatalf("matchToolPattern(%q,%q): %v", tc.pattern, tc.tool, err)
+		}
+		if got != tc.want {
+			t.Errorf("matchToolPattern(%q,%q) = %v, want %v", tc.pattern, tc.tool, got, tc.want)
+		}
+	}
+}
+
+func TestToolAllowedByPatterns_MalformedPatternAdmitsNothing(t *testing.T) {
+	// The opposite fail-closed direction to ContextField.Governs, and the
+	// reason matchToolPattern returns the error instead of deciding.
+	if toolAllowedByPatterns([]string{"mail_[unterminated"}, "mail_send") {
+		t.Fatal("a malformed allowlist pattern admitted a tool")
+	}
+	if toolAllowedByPatterns(nil, "mail_send") {
+		t.Fatal("an empty allowlist admitted a tool")
+	}
+	if !toolAllowedByPatterns([]string{"nope_*", "mail_*"}, "mail_send") {
+		t.Fatal("a later matching pattern was not reached")
+	}
+}
+
+func TestContextField_MalformedGlobGovernsEverything(t *testing.T) {
+	// The two readings of an uncompilable pattern are "governs nothing" and
+	// "governs everything". The second is fail-closed — more tools require a
+	// value, and a grant whose MCP publishes a broken pattern is refused
+	// rather than silently unscoped — so it is the one taken.
+	f := ContextField{Name: "x", Scope: ContextScopeRestrict, AppliesTo: []string{"mail_[unterminated"}}
+	if !f.Governs("nothing_like_it") {
+		t.Fatal("a malformed glob failed open")
+	}
+}
+
+func TestContextField_GovernsAllIsFalseForAnUnknownToolSurface(t *testing.T) {
+	// "This MCP exposes no tools" is what an MCP relay has never connected to
+	// looks like. Vacuous truth there would refuse a grant on the strength of
+	// missing information.
+	f := ContextField{Name: "x", Scope: ContextScopeRestrict}
+	if f.GovernsAll(nil) {
+		t.Fatal("an empty tool list answered GovernsAll true")
+	}
+}
+
+func TestContextField_ValidateValueRefusesEmptyInEveryShape(t *testing.T) {
+	arr := ContextField{Name: "mail_accounts", Type: "array", Items: json.RawMessage(`{"type":"string"}`)}
+	str := ContextField{Name: "root", Type: "string"}
+	free := ContextField{Name: "anything"}
+
+	refuse := []struct {
+		f   ContextField
+		val string
+	}{
+		{arr, ``},
+		{arr, `null`},
+		{arr, `[]`},
+		{arr, `["ok",""]`},
+		{arr, `["ok","  "]`},
+		{arr, `[3]`},
+		{arr, `"not an array"`},
+		{str, `""`},
+		{str, `null`},
+		{str, `["a"]`},
+		{free, `[]`},
+		{free, `{}`},
+		{free, `""`},
+		{free, `null`},
+	}
+	for _, tc := range refuse {
+		if err := tc.f.ValidateValue(json.RawMessage(tc.val)); err == nil {
+			t.Errorf("%s accepted %q", tc.f.Name, tc.val)
+		}
+	}
+
+	accept := []struct {
+		f   ContextField
+		val string
+	}{
+		{arr, `["Bob"]`},
+		{arr, `["Alice","Bob"]`},
+		{str, `"/tmp/project"`},
+		{free, `{"a":1}`},
+		{free, `3`},
+	}
+	for _, tc := range accept {
+		if err := tc.f.ValidateValue(json.RawMessage(tc.val)); err != nil {
+			t.Errorf("%s refused %q: %v", tc.f.Name, tc.val, err)
+		}
+	}
+}
+
+func TestHasScopeValue_EmptyIsAbsent(t *testing.T) {
+	values := map[string]json.RawMessage{
+		"present": json.RawMessage(`["Bob"]`),
+		"empty":   json.RawMessage(`[]`),
+		"null":    json.RawMessage(`null`),
+		"blank":   json.RawMessage(`""`),
+		"object":  json.RawMessage(`{}`),
+	}
+	if !hasScopeValue(values, "present") {
+		t.Error("a real value read as absent")
+	}
+	for _, name := range []string{"empty", "null", "blank", "object", "missing"} {
+		if hasScopeValue(values, name) {
+			t.Errorf("%q read as a usable scope value", name)
+		}
+	}
+}
+
+func TestScopeNoteFor_UsesTheSchemasOwnDescription(t *testing.T) {
+	cs := ParseContextSchema(json.RawMessage(macmcpSchema), 2)
+	values := map[string]json.RawMessage{
+		"mail_accounts":  json.RawMessage(`["Bob"]`),
+		"mail_mailboxes": json.RawMessage(`["INBOX","Projects/Archive"]`),
+	}
+	note := scopeNoteFor(cs, values, "mail_search")
+	for _, want := range []string{"Mail accounts this client may read from or send as", "Bob", "INBOX, Projects/Archive"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("note %q missing %q", note, want)
+		}
+	}
+	// write_dirs governs neither of those tools and has no value here, so it
+	// must not appear.
+	if strings.Contains(note, "Directories") {
+		t.Errorf("note mentioned an ungoverned field: %q", note)
+	}
+	if n := scopeNoteFor(cs, values, "messages_send"); n != "" {
+		t.Errorf("an ungoverned tool got a note: %q", n)
+	}
+	if n := scopeNoteFor(cs, nil, "mail_search"); n != "" {
+		t.Errorf("a grant with no values got a note: %q", n)
+	}
+	if n := scopeNoteFor(ParseContextSchema(json.RawMessage(macmcpSchema), 0), values, "mail_search"); n != "" {
+		t.Errorf("a v1 schema got a note: %q", n)
+	}
+}
+
+func TestAppendScopeNote_IsIdempotent(t *testing.T) {
+	// ListTools and ListSkillBuckets each annotate their own copy of the same
+	// live tool; the two must not double-append.
+	note := "Scope: accounts — Bob."
+	once := appendScopeNote("Search mail.", note)
+	twice := appendScopeNote(once, note)
+	if once != twice {
+		t.Fatalf("double-appended: %q then %q", once, twice)
+	}
+	if appendScopeNote("desc", "") != "desc" {
+		t.Fatal("an empty note changed the description")
+	}
+	if appendScopeNote("", note) != note {
+		t.Fatal("an empty description did not become the note")
+	}
+}
+
+// TestNoDomainSpecificFieldNamesRemainInRelay is ADR-011's closing consequence
+// made checkable: "the only domain-specific string left in relay is the v1
+// allowed_dirs compatibility branch, kept for one release with a deprecation
+// line and a test asserting it is the last one."
+//
+// It reads STRING LITERALS out of the AST rather than grepping, so the many
+// comments explaining the history do not count and cannot be gamed by
+// rewording. fs_bash is the one other survivor and is deliberately named here
+// too, with its deferral, so that adding a third needs a deliberate edit to
+// this list.
+func TestNoDomainSpecificFieldNamesRemainInRelay(t *testing.T) {
+	allowed := map[string]struct {
+		file string
+		why  string
+	}{
+		v1AllowedDirsField: {"context_schema.go", "the v1 compatibility branch (ADR-011 decision 3), scheduled for removal"},
+		v1FsBashTool:       {"context_schema.go", "the fs_bash auto-disable, DEFERRED by ADR-011 as not resource scoping"},
+	}
+
+	counts := map[string]int{}
+	fset := token.NewFileSet()
+	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if name := info.Name(); name != "." && (strings.HasPrefix(name, ".") || name == "test" || name == "web" || name == "node_modules") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", path, perr)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			val, uerr := strconv.Unquote(lit.Value)
+			if uerr != nil {
+				return true
+			}
+			spec, watched := allowed[val]
+			if !watched {
+				return true
+			}
+			counts[val]++
+			if filepath.Base(path) != spec.file {
+				t.Errorf("domain-specific literal %q appears in %s; it belongs only in %s (%s)",
+					val, path, spec.file, spec.why)
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for name, spec := range allowed {
+		if counts[name] != 1 {
+			t.Errorf("literal %q appears %d times in non-test sources, want exactly 1 (%s in %s)",
+				name, counts[name], spec.why, spec.file)
+		}
+	}
+}

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -122,6 +122,13 @@ and re-reading `settings.json` at query time answers a different question. So a
   map, because `_meta` is a general channel and a future MCP may pass an API
   key through it. Filtering to declared restrict-fields is both safer and
   domain-blind.
+- Both fields are on a **refusal** as well as a completion. A `denied` or
+  `throttled` record carries the mode that was in force and the scope the grant
+  carried, because "which layer refused this, and under what mode?" is the
+  question those records exist to answer. Nothing went on the wire for a
+  refused call, so what `scope` shows there is the authority the call was
+  judged against; an empty `scope` on a `denied` record is itself the finding —
+  a grant with no value for a field its MCP declares.
 - For a **remote** call both fields are on the **intent** record as well as the
   completion — the intent is the one written before the MCP runs, and an
   authority recorded only on the completion would be missing from exactly the

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -92,6 +92,60 @@ The pid is for attribution only. It is never consulted for an authorization
 decision: pids are reusable and racy, which is fine for "who called this" and
 not fine for "may they call it".
 
+### The authority a call ran with
+
+A record that carries the tool and the arguments but not the authority cannot
+answer *was this call confined?* once an operator has since edited the grant,
+and re-reading `settings.json` at query time answers a different question. So a
+`call_tool` record carries what was actually in force (ADR-011 decision 7):
+
+```json
+{
+  "mcp_id": "macmcp",
+  "tool": "mail_search",
+  "access": "read",
+  "scope": { "mail_accounts": ["Bob"], "mail_mailboxes": ["INBOX"] },
+  "outcome": "tool_error",
+  "scope_violation": true
+}
+```
+
+- **`access`** is the operation mode the call ran under — `read` or `write`.
+  Relay applies this rule itself and this field is the record of what it
+  decided; the *input* (whether a tool is read-only) is the MCP's own
+  `annotations.readOnlyHint`. Absent for a service token, which is not scoped
+  by it.
+- **`scope`** is the resource scope relay injected, taken from the `_meta` it
+  assembled rather than from the project, so what is recorded is what went on
+  the wire. It carries **only** the fields the MCP declared as
+  `scope: "restrict"` in its `contextSchema` — never the whole per-MCP context
+  map, because `_meta` is a general channel and a future MCP may pass an API
+  key through it. Filtering to declared restrict-fields is both safer and
+  domain-blind.
+- For a **remote** call both fields are on the **intent** record as well as the
+  completion — the intent is the one written before the MCP runs, and an
+  authority recorded only on the completion would be missing from exactly the
+  record that survives a crash mid-call.
+
+**`scope_violation`** is a field and not an outcome. `tool_error` already means
+"the call completed and the MCP answered no", which is what a scope refusal is;
+promoting it would inflate a small enum that `--outcome`, the CLI table and the
+UI pill all key on. It is set when an MCP marks its own error result:
+
+```json
+{"content": [...], "isError": true, "_meta": {"scope_violation": true}}
+```
+
+The key `relay/scope_violation` is accepted as an equivalent spelling. The
+marker is honoured only when `isError` is true and the value is boolean `true`;
+anything else leaves the flag off and the record is an ordinary `tool_error`.
+Relay trusts the marker rather than parsing the error text — reading the text
+would put domain knowledge inside relay — so the flag says what the MCP said
+about itself. It changes no outcome and gates no decision; it exists so
+alerting has something to select on. A refusal relay made itself (a tool
+outside `allowed_tools`, a read-only grant meeting a mutating tool, a missing
+scope value) is `denied`, not this.
+
 ### Arguments and results
 
 **Arguments** are recorded with values under credential-like keys replaced by

--- a/docs/context-schema.md
+++ b/docs/context-schema.md
@@ -220,7 +220,15 @@ refusals, each naming the problem:
   reason: the v1 branch replaces the whole blob;
 - an `access` that is not `read` or `write`;
 - an `allowed_tools` pattern that will not compile, which would match no tool
-  at all.
+  at all in *that* list (the same pattern in a field's `applies_to` governs
+  every tool — the two callers of the shared matcher fail closed in opposite
+  directions);
+- an `allowed_tools` pattern that is **over-broad**: one requiring no literal
+  character (`*`, `**`, `?*`, `[a-z]*`) or matching a probe name no MCP exposes
+  (`*_*`, `*e*`). Such a pattern selects by shape rather than by name, so a
+  tool registered tomorrow would join the grant unreviewed. The matcher refuses
+  one at call time as well, so a record that reached `settings.json` by another
+  route cannot widen a grant either.
 
 An MCP relay has never connected to is **permitted** with nothing but an
 emptiness check, exactly as `ValidateProjectGrants` permits a grant it cannot

--- a/docs/context-schema.md
+++ b/docs/context-schema.md
@@ -120,6 +120,62 @@ names fields whose already-chosen values must be sent as parameters, so the UI
 fills in dependency order (mailboxes cannot be listed without an account).
 Neither affects enforcement.
 
+## `context/enumerate`
+
+An MCP declaring `enumerable: true` on a field must answer this JSON-RPC
+method. Relay sends it for those fields and no others.
+
+```json
+{"jsonrpc":"2.0","id":7,"method":"context/enumerate",
+ "params":{"field":"mail_mailboxes","values":{"mail_accounts":["Bob"]}}}
+```
+
+```json
+{"jsonrpc":"2.0","id":7,"result":{"field":"mail_mailboxes",
+ "values":[{"value":"INBOX","label":"INBOX"},
+           {"value":"Projects/Archive","label":"Projects/Archive (Bob)"}]}}
+```
+
+`value` is what goes into `_meta` verbatim; `label` is display only. An empty
+`values` list is a valid answer and means there are none.
+
+**`values` carries only the fields this one declares in `depends_on`**, and only
+those the operator has already chosen. An absent key — and an empty one, which
+relay never sends — means **across everything**, never "match nothing". A server
+that reads an empty filter as matching nothing returns an empty list in exactly
+the state a picker opens in, which is indistinguishable from a host that holds
+nothing.
+
+It is **not a tool call**. It carries no `_meta`, spends no ADR-010 budget, and
+never reaches the audited tool chokepoint — routing an operator-UI read through
+`CallTool` would put a call nobody made in the audit log and run it with relay's
+own unscoped authority (ADR-011 decision 6).
+
+### Failing it
+
+Relay recognises exactly two error codes and treats every other outcome the
+same way. The three cases are kept apart because an operator's next action
+differs in each.
+
+| the server answers | relay | the editor |
+|---|---|---|
+| `-32601` method not found | records it for the life of the connection and stops asking | falls back to text entry, silently and permanently for that MCP |
+| `-32602` invalid params | surfaces it | says relay asked for a field it should not have — a relay bug — and offers text entry |
+| anything else, or no answer at all | surfaces it as retryable | says the values could not be listed *right now*, offers a retry, and keeps text entry |
+
+"Anything else" includes JSON-RPC's implementation-defined server-error range
+(`-32000` to `-32099`), which is what macMCP answers when Mail itself will not
+answer, along with a transport failure, a timeout, and a malformed result. None
+of them is ever rendered as an empty list: **a failure and "there are none" must
+not look the same**, or a profile gets saved against a host the operator was
+shown nothing about. Relay enforces that on the wire — `"values": []` is an
+answer, `"values": null` is a failure.
+
+Enumeration is **disclosure**: the list of every mail account on the host. It is
+served only on relay's admin-authenticated surfaces (the frontend socket and the
+tray's IPC channel) and is unreachable from the remote listener, whose dispatch
+table holds `ListTools` and `CallTool` and nothing else.
+
 ## Who fills a value in, and where
 
 An `operator` field is set in the Settings UI's per-MCP permission panel
@@ -127,8 +183,20 @@ An `operator` field is set in the Settings UI's per-MCP permission panel
 uses:
 
     GET  /api/mcps/{id}/scope_fields   -> the restrict fields this MCP declares
+    POST /api/mcps/{id}/enumerate      -> { "field": …, "values": {…} } (see below)
     POST /api/projects                 -> { "context": { "<mcp>": { "<field>": … } } }
     PUT  /api/projects/{id}            -> the same, as a patch
+
+`enumerate` is a POST for a read because `values` is a map from field name to
+that field's value, whose shape is whatever the MCP declared — there is no
+query-string encoding of that which does not quietly assume array-of-string.
+It answers with `{mcp_id, field, status, values, error}`: `200` for a real
+answer and for an MCP that does not implement enumeration (a true, final answer
+about that MCP), `404` for an MCP relay has never connected to, `400` for a
+field it never declared enumerable, `502` when the MCP refused the request relay
+built, and `503` when it could not answer. The `status` field is the precise
+answer; the code is there so a client reading only codes cannot mistake a
+failure for an empty list.
 
 `scope_fields` is the projection an editor renders from: name, `type`,
 `item_type`, `description`, `source`, `applies_to`, `enumerable`, `depends_on`.

--- a/docs/context-schema.md
+++ b/docs/context-schema.md
@@ -22,7 +22,7 @@ in its `initialize` response, beside its name and version:
       "applies_to": ["mail_*"], "enumerable": true,
       "depends_on": ["mail_accounts"]
     },
-    "write_dirs": {
+    "file_dirs": {
       "type": "array", "items": {"type": "string"},
       "description": "Directories this client may write files into",
       "scope": "restrict", "source": "project_path",
@@ -98,7 +98,7 @@ account added later does not silently join the grant.
 A grant is refused at edit time if a `project_path` field's `applies_to` covers
 **every** tool the MCP exposes and the record has no path — the grant would buy
 nothing. fsMCP is refused to a profile for that reason; macMCP is not, and
-loses exactly the two tools its `write_dirs` governs.
+loses exactly the two tools its `file_dirs` governs.
 
 ### `applies_to` selects tools, anchored
 

--- a/docs/context-schema.md
+++ b/docs/context-schema.md
@@ -1,0 +1,173 @@
+# The MCP context schema
+
+An MCP tells relay what may be narrowed about it by returning a `contextSchema`
+in its `initialize` response, beside its name and version:
+
+```json
+"serverInfo": {
+  "name": "macmcp",
+  "version": "1.1.0",
+  "contextSchemaVersion": 2,
+  "contextSchema": {
+    "mail_accounts": {
+      "type": "array", "items": {"type": "string"},
+      "description": "Mail accounts this client may read from or send as",
+      "scope": "restrict", "source": "operator",
+      "applies_to": ["mail_*"], "enumerable": true
+    },
+    "mail_mailboxes": {
+      "type": "array", "items": {"type": "string"},
+      "description": "Mailbox paths within those accounts this client may reach",
+      "scope": "restrict", "source": "operator",
+      "applies_to": ["mail_*"], "enumerable": true,
+      "depends_on": ["mail_accounts"]
+    },
+    "write_dirs": {
+      "type": "array", "items": {"type": "string"},
+      "description": "Directories this client may write files into",
+      "scope": "restrict", "source": "project_path",
+      "applies_to": ["mail_save_attachment", "mail_get_source"]
+    }
+  }
+}
+```
+
+Relay stores the values an operator (or the derivation below) supplies, injects
+them into `_meta` on every `tools/call`, renders them, and refuses a call whose
+required value is missing. It does all of that **without knowing what any field
+means**. Every field name is an opaque map key from relay's side, start to
+finish. See [ADR-011](decisions/011-resource-scope.md) for why.
+
+## The shape is flat
+
+`contextSchema` is `{fieldName: {fragment}}` — a map from field name to its
+declaration. It is **not** a JSON Schema, so there is no `"type": "object"` and
+no `"properties"` wrapper.
+
+This is stated because the ambiguity is live: relay's own fixtures once used
+the nested form and `schemaHasField` had to learn both shapes (issue #17), and
+the failure direction of getting it wrong is fail-open — a restrict field relay
+does not see is a grant permitted and nothing enforced. Relay still consults a
+`"properties"` object as a rescue, but only when the flat reading found no
+`scope: "restrict"` field at all. Do not rely on it.
+
+## The keywords
+
+| keyword | values | what relay does with it |
+|---|---|---|
+| `scope` | `"restrict"` | this field narrows access; the rules below apply. Absent means an ordinary context value relay injects and otherwise ignores. |
+| `source` | `"operator"` \| `"project_path"` | who supplies the value |
+| `applies_to` | tool-name patterns | which of this MCP's tools the field governs |
+| `enumerable` | bool | the MCP can list this field's valid values |
+| `depends_on` | field names | enumeration ordering |
+
+Plus the ordinary fragment relay uses to validate a value: `type`, `items`,
+`description`. This is a deliberate JSON-Schema **subset** — array-of-string
+and string are what is validated, and anything else is accepted as long as it
+is present and non-empty.
+
+### `scope: "restrict"` means fail closed
+
+A restrict field that is missing from `_meta`, or present and empty, means the
+server **refuses every call it governs**. Not "falls back to a default", not
+"no restriction". `[]`, `null`, `""` and `{}` are all absent.
+
+There is deliberately no keyword letting an MCP declare otherwise. A field that
+says it restricts and then defaults open is not a restriction, and relay could
+never verify the claim either way.
+
+There is also no wildcard. "No restriction" is not expressible as emptiness and
+is not expressible at all — it is spelled by enumerating, or by not granting
+the MCP. An operator who wants every account lists every account, and an
+account added later does not silently join the grant.
+
+### `source` decides who fills it in
+
+- **`project_path`** — relay derives the value from the project's `path`,
+  because the schema asked it to. An array-typed field gets `[path]`; a
+  string-typed one gets the bare path. A **remote-kind record (an access
+  profile) has no path**, so such a field is absent for one and every tool it
+  governs refuses. Relay never derives one for a profile, unconditionally,
+  whatever validation decided earlier.
+- **`operator`** — an operator sets it explicitly, local and remote alike. A
+  restrict field with no declared `source` is treated as operator-supplied,
+  because that is the reading that leaves the value un-derivable: relay
+  inventing a value for a field it does not understand is the failure this
+  mechanism exists to prevent.
+
+A grant is refused at edit time if a `project_path` field's `applies_to` covers
+**every** tool the MCP exposes and the record has no path — the grant would buy
+nothing. fsMCP is refused to a profile for that reason; macMCP is not, and
+loses exactly the two tools its `write_dirs` governs.
+
+### `applies_to` selects tools, anchored
+
+Patterns are matched with Go's `path.Match`, **anchored**: the pattern must
+match the whole tool name. `mail_*` matches `mail_send` and not `xmail_send`,
+and a pattern with no metacharacter is an exact match. The same matcher decides
+`allowed_tools` on a project, so the two can never disagree about anchoring.
+
+An **absent or empty** `applies_to` governs every tool the MCP exposes — the
+domain-blind default. A pattern relay cannot compile governs everything too,
+which is the fail-closed reading for a restriction.
+
+### `enumerable` and `depends_on`
+
+`enumerable: true` says the MCP can list this field's valid values, so the
+operator UI can offer a picker over real values rather than a free-text box
+where the easiest failure is a confinement that does not confine. `depends_on`
+names fields whose already-chosen values must be sent as parameters, so the UI
+fills in dependency order (mailboxes cannot be listed without an account).
+Neither affects enforcement.
+
+## Versioning
+
+`contextSchemaVersion: 2` marks a schema using these keywords.
+
+**Absent or lower means v1** and is handled exactly as it was before ADR-011:
+relay looks for a field literally named `allowed_dirs`, in either the flat or
+the nested shape, and derives the project path into it. That is the last
+domain-specific field name anywhere in relay; a test asserts it is the last one,
+and it is scheduled for removal one release after every MCP relay serves
+declares v2. Connecting an MCP that declares v1 logs a deprecation line.
+
+No v2 rule fires on a v1 declaration, even one that happens to carry a key
+spelled like a keyword — reading v2 semantics off an un-versioned declaration
+would let an MCP change how relay enforces without saying so.
+
+## What the MCP must do
+
+Declaring a field is an assertion that the server enforces it. Relay injecting a
+scope an MCP ignores is **worse than no scope at all**, because the UI then
+asserts a confinement that does not exist. Relay cannot verify enforcement and
+does not pretend to.
+
+The reconciliation rule, so every scoping MCP implements it identically:
+
+- An **absent or default-valued** scope-relevant argument resolves **to the
+  scope**, not to everything.
+- A **tool-level wildcard** argument (`mailbox: "all"`) means "everything I am
+  allowed to see" and resolves to the scope. It does not error.
+- An **explicit** argument outside the scope is an **error**, not a silent
+  narrowing. Silent narrowing lets an agent build a false model of what it can
+  reach.
+- **Enumerators are scoped too.** A tool that lists accounts or mailboxes
+  reports only what is in scope — otherwise it is both a disclosure and a map
+  of what to try next.
+
+`_meta` being present at all is a reliable signal that a chokepoint mediated the
+call: relay injects `_meta.project_id` on every mediated call and has since
+ADR-007. An MCP can therefore require its own declared restrict fields whenever
+`_meta` is present, needing nothing from relay beyond the fact of mediation. An
+absent `_meta` means nobody mediated — an operator running the MCP over stdio by
+hand, which is same-user local access.
+
+A server that refuses a call for scope reasons may say so on the error result:
+
+```json
+{"content": [...], "isError": true, "_meta": {"scope_violation": true}}
+```
+
+Relay records that as `scope_violation: true` in the audit log with `outcome`
+staying `tool_error`. It changes no outcome and gates no decision; it exists so
+alerting has something to select on.

--- a/docs/context-schema.md
+++ b/docs/context-schema.md
@@ -120,6 +120,51 @@ names fields whose already-chosen values must be sent as parameters, so the UI
 fills in dependency order (mailboxes cannot be listed without an account).
 Neither affects enforcement.
 
+## Who fills a value in, and where
+
+An `operator` field is set in the Settings UI's per-MCP permission panel
+(Projects tab → edit a record → the MCP's panel), or over the HTTP routes eve
+uses:
+
+    GET  /api/mcps/{id}/scope_fields   -> the restrict fields this MCP declares
+    POST /api/projects                 -> { "context": { "<mcp>": { "<field>": … } } }
+    PUT  /api/projects/{id}            -> the same, as a patch
+
+`scope_fields` is the projection an editor renders from: name, `type`,
+`item_type`, `description`, `source`, `applies_to`, `enumerable`, `depends_on`.
+`source` is **normalised** there — a field that declared none comes back as
+`operator`, so no consumer re-derives that rule. An MCP relay has never
+connected to is a **404**, not an empty list: "scopes nothing" and "cannot say"
+are different answers and only the first lets an editor safely offer no fields.
+
+**Every value is validated on save, whichever surface produced it**, and an
+invalid one is refused rather than stored (`validateProjectPermissions`). The
+refusals, each naming the problem:
+
+- a value for a field the MCP does not declare — the refusal lists the ones it
+  does, because a refusal that says a name is wrong without saying which are
+  right is one an operator answers by guessing;
+- a value of the wrong type for the declared fragment;
+- an empty value for a `scope: "restrict"` field;
+- an operator-supplied value for a `source: "project_path"` field — relay
+  derives those, and one written by hand would be replaced at the next resync;
+- a context value for an MCP that declares a **v1** schema, for the same
+  reason: the v1 branch replaces the whole blob;
+- an `access` that is not `read` or `write`;
+- an `allowed_tools` pattern that will not compile, which would match no tool
+  at all.
+
+An MCP relay has never connected to is **permitted** with nothing but an
+emptiness check, exactly as `ValidateProjectGrants` permits a grant it cannot
+qualify: this is a coherence check an operator sees at edit time, not the
+boundary, and refusing on missing information would make an MCP that is merely
+not running unconfigurable. The call-time presence re-check still denies.
+
+A grant that is missing a value is named in the UI — on the record's row, in
+the editor, and in a banner over the list — because the other half of
+loud-and-closed is a `denied` at call time, which is silent from the operator's
+side.
+
 ## Versioning
 
 `contextSchemaVersion: 2` marks a schema using these keywords.

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -595,6 +595,20 @@ incomplete, and never let a save silently delete something.**
   that can hold no session, and ADR-009 decision 2's argument — refusing at the
   door is more honest than a control that quietly no-ops — does not stop at the
   fields that ADR happened to list.
+
+  Two details make that a door rather than a wall. An **empty** policy is not a
+  policy: the update path already reads one as "clear it", so a refusal using a
+  different reading of empty would refuse the very request that clears one —
+  which is why one definition (`permissionPolicyIsEmpty`) serves the refusal,
+  the candidate that is validated and the mutation that stores it, so the shape
+  validated is the shape stored. And an existing local project carrying either
+  can still be **converted**, by clearing them in the same request, which is the
+  escape hatch `disabled_tools` already has
+  (`TestProjectConvertLocalToRemote_CannotInheritFilesystemScope`). Without it
+  an operator who had ever set a policy could never turn that project into a
+  profile. Both are checked on the create candidate too: each is applied by a
+  sub-mutation *after* the record exists, so otherwise a profile could be
+  created carrying one and never rechecked.
 - **Editing one thing must not delete another.** Writing an operator's scope
   re-runs the derivation so `source: "project_path"` fields are put back;
   without that, editing a local project's mail scope would silently drop its
@@ -662,28 +676,6 @@ the copy Mail autosaves behind its back, and does so regardless of
 carry this message's subject, so it can surface nothing but the client's own
 message. Scoping it would break the sweep and protect nothing. The account it
 runs in is already scope-checked by the sender guard.
-
-### 12. Two controls a profile can hold and cannot use are refused
-
-`permission_policy` and `chat_templates` were the last two fields a remote-kind
-record could carry that do nothing on one. A permission policy is a set of
-Claude CLI gates on a session; a chat template is a preset for starting one. An
-access profile launches no session — it has no path to launch in, and
-`resolvePtyEnv` and `resolveProjectTemplate` both refuse a remote record
-outright — so both are inert, and ADR-009 decision 2's rule applies: refusing an
-inert control at the door is more honest than shipping one that quietly no-ops.
-It is the same argument that already removes the path, the skill toggle, the
-shell templates, the model allowlist and directory auth. A `default_mode` of
-`bypassPermissions` sitting on a profile is the worst of it: it reads as a
-widening that never happens and cannot be reasoned about from the record alone.
-
-Two details make the refusal usable rather than a wall. An **empty** policy is
-not a policy — the update path already reads one as "clear it", so refusing on
-it would refuse the very request that clears one. And an existing local project
-carrying either can still be **converted**, by clearing them in the same
-request, exactly as `disabled_tools` is handled
-(`TestProjectConvertLocalToRemote_CannotInheritFilesystemScope`). The editor
-stops calling them "inert" and says what saving will do instead.
 
 ## The reconciliation rule the MCP implements
 

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -232,7 +232,28 @@ scope confines mail *within* the mail tools, and the mode filters mutation
 across all of them, but neither keeps a mail client out of the address book.
 
 **An access profile carries `allowed_tools` per MCP: an explicit enumeration,
-patterns permitted (`mail_*`), the bare `*` refused, absent meaning none.**
+patterns permitted (`mail_*`), an over-broad pattern refused, absent meaning
+none.**
+
+*Over-broad* is a property of the matcher, not a list of spellings. The first
+implementation refused the literal string `"*"` while matching with
+`path.Match`, and a tool name contains no `/` — so `**`, `?*`, `*_*`, `[a-z]*`
+and `*e*` each match **every** tool of an MCP and not one of them is the string
+`"*"`. A pre-merge review built a read-only "mail" profile with
+`allowed_tools: {"macmcp": ["**"]}`, was served 26 tools across 11 of macMCP's
+domains, and exfiltrated through `web_fetch` — restoring the outbound channel
+this decision claims to remove. Blacklisting `**` would have been answered by
+the next spelling. The rule asked instead is *does this pattern select tools by
+name, or by shape?*, and a pattern is refused if it requires no literal
+character at all (`*`, `**`, `?*`, `[a-z]*`) or if it matches a probe name no
+MCP exposes (`*_*`, `*e*` — an underscore or a letter is in every identifier).
+It is enforced in `validateToolPattern` **and** in `toolAllowedByPatterns`, so
+a record that reached `settings.json` by a route validation did not cover
+cannot widen a grant either; the matcher ignoring such an entry is the same
+direction the editor refuses it in. A context field's `applies_to` runs through
+the same matcher and is deliberately **not** subject to this: a field that
+governs everything is a restriction that applies to everything, which is the
+fail-closed reading there.
 
 This is ADR-009 decision 4's reasoning applied one level down. It refused
 `allowed_mcp_ids: ["*"]` on a remote grant because "registering a new MCP on

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -537,6 +537,17 @@ values recorded are the ones actually injected, taken from `meta` where
 `CallTool` assembles it, on the single record for a local call and on the
 **intent** record for a remote one.
 
+**On a refusal too, and that is where it matters most.** The authority was
+first recorded where the call is handed to the MCP, which is *after* the tool
+check, the scope-presence check and the budget — so `denied` and `throttled`
+records, the two a security review reads first, carried no `access` and no
+`scope` at all. "Which layer refused this, and under what mode?" was
+unanswerable from exactly the records `relay audit --outcome denied` returns.
+It is recorded immediately after the MCP's live surface is read, before the
+first thing that can refuse. On a refusal nothing goes on the wire, so what is
+recorded is the authority the call was judged against — the same set of values,
+and the question the record is being asked.
+
 **Only declared `scope: "restrict"` fields, never the whole context map.**
 `_meta` is a general channel and a future MCP may pass an API key through it.
 Logging `Context[extID]` wholesale would make the audit file the place

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -447,6 +447,39 @@ every mail account on the machine becomes readable by anything that can open
 the Settings UI or reach the project routes. That is host-local admin surface
 today, so it is acceptable — but it is a new read path.
 
+**The wire shape**, pinned so both halves interoperate:
+
+    -> {"method":"context/enumerate",
+        "params":{"field":"mail_mailboxes","values":{"mail_accounts":["Bob"]}}}
+    <- {"result":{"field":"mail_mailboxes",
+        "values":[{"value":"INBOX","label":"INBOX"},
+                  {"value":"Projects/Archive","label":"Projects/Archive (Bob)"}]}}
+
+`value` is what goes into `_meta` verbatim — for a mailbox, the full path,
+never a leaf name. `label` is display only. `values` on the request carries
+already-chosen values for `depends_on` fields.
+
+Four outcomes that must stay distinct, because collapsing any two of them
+produces a form that lies: `-32601` means the MCP does not enumerate and the
+field degrades to text entry; `-32602` means relay asked for a field the MCP
+will not enumerate, which is a relay bug and is surfaced; any other error or a
+transport failure means the MCP could not answer *right now*, which keeps text
+entry available so an operator is never blocked; and an empty list is a valid
+answer meaning there are none. **An empty list must never be rendered for a
+call that failed.**
+
+**A stored value that is no longer offered stays visible and selected**, marked
+unrecognised. An account renamed on the host must not quietly widen or narrow a
+profile by vanishing from a form — a permission that changes because a list
+refreshed is the failure this whole picker exists to prevent.
+
+**Enumeration is not scoped and is not a tool.** It runs for the operator
+configuring a profile, not for any client, so it lists the whole host; and it
+stays off `tools/list` so it can never become agent-callable or appear in a
+generated `SKILL.md`. It is unreachable from a remote client by construction —
+that dispatch table is `ListTools` and `CallTool` and nothing else — and it
+sits behind the same admin authentication as the other project routes.
+
 **A raw JSON editor is the fallback, not the plan.** The owner offered one as a
 first draft. It is retained for MCPs that do not implement `context/enumerate`,
 and for those it is the honest surface. Where the MCP *can* enumerate, a
@@ -532,6 +565,30 @@ on disk — never a client's own report of success. That standard is inherited:
 ADR-010's client passed 95 tests and an adversarial review while its primary
 interface was broken, because nobody had executed the string the generator
 printed.
+
+### 9b. What an editor may save, and what it must refuse
+
+Building the editor forced four questions the ADR had not answered. The rule
+that settles them: **refuse what cannot be made true, permit what is merely
+incomplete, and never let a save silently delete something.**
+
+- **An incomplete profile may be saved.** Refusing would make it impossible to
+  grant an MCP before typing a scope. A missing value is a warning in the
+  editor, a warning in the list, and a `denied` at call time — loud in three
+  places without making the editor unusable.
+- **A value for a v1-schema MCP is refused.** The v1 branch of
+  `SyncProjectToken` replaces the whole context blob, so a stored value would
+  vanish at the next path or grant edit. A silent disappearance is worse than a
+  refusal.
+- **`permission_policy` and `chat_templates` are refused on a profile**, joining
+  path, cwd-auth, skills, shell templates and models. Both are inert on a record
+  that can hold no session, and ADR-009 decision 2's argument — refusing at the
+  door is more honest than a control that quietly no-ops — does not stop at the
+  fields that ADR happened to list.
+- **Editing one thing must not delete another.** Writing an operator's scope
+  re-runs the derivation so `source: "project_path"` fields are put back;
+  without that, editing a local project's mail scope would silently drop its
+  `write_dirs` and disable the two tools that field governs.
 
 ### 10. Two seams that are not in the list, and one reference implementation that was wrong
 

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -461,12 +461,22 @@ already-chosen values for `depends_on` fields.
 
 Four outcomes that must stay distinct, because collapsing any two of them
 produces a form that lies: `-32601` means the MCP does not enumerate and the
-field degrades to text entry; `-32602` means relay asked for a field the MCP
-will not enumerate, which is a relay bug and is surfaced; any other error or a
-transport failure means the MCP could not answer *right now*, which keeps text
-entry available so an operator is never blocked; and an empty list is a valid
-answer meaning there are none. **An empty list must never be rendered for a
-call that failed.**
+field degrades to text entry, permanently; `-32602` means relay asked for a
+field the MCP will not enumerate, which is a relay bug and is surfaced;
+`-32000..-32099` (JSON-RPC's implementation-defined server range), any
+unrecognised code, or a transport failure all mean the MCP could not answer
+*right now*, which is retryable and keeps text entry available so an operator is
+never blocked; and an empty list is a valid answer meaning there are none.
+**An empty list must never be rendered for a call that failed.**
+
+**An empty `values` entry means "all", never "none".** The dependent field's
+picker is opened before its dependency has been chosen — that is its normal
+initial state — so reading an empty-but-present filter as "match nothing" shows
+an operator zero mailboxes everywhere at exactly the moment they are trying to
+choose one. Absent and empty are the same request here. Note this is the
+opposite of decision 4's rule for a *scope value*, where empty is a refusal, and
+the two are not in tension: a scope value is an authorisation and must fail
+closed, while a picker filter is a query and must fail informative.
 
 **A stored value that is no longer offered stays visible and selected**, marked
 unrecognised. An account renamed on the host must not quietly widen or narrow a

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -490,6 +490,32 @@ generated `SKILL.md`. It is unreachable from a remote client by construction —
 that dispatch table is `ListTools` and `CallTool` and nothing else — and it
 sits behind the same admin authentication as the other project routes.
 
+**Three failures, not one.** An MCP can fail to enumerate in ways whose right
+answers differ, and collapsing them produces a UI that lies. `-32601` means the
+server does not implement the method: degrade to text entry, silently and
+permanently for that MCP, because a retry button in front of a method that does
+not exist is noise. `-32602` means relay asked for a field the MCP will not
+enumerate — relay is meant to ask only for fields declaring `enumerable: true`,
+so that is a **relay** bug and is surfaced rather than degraded away. Everything
+else — another code (macMCP answers in the `-32000..-32099` implementation-defined
+range when Mail will not answer), a transport failure, a timeout, a malformed
+result — is "could not answer right now": retryable, with text entry still there
+so an operator is never blocked.
+
+**And an empty list is an answer.** `values: []` means there are none;
+`values: null` means nobody could look. Rendering the second as the first tells
+an operator there are no mailboxes on a machine full of them, and the profile
+they save on the strength of it confines nothing they intended. That is the
+single sharpest edge in this decision and both the wire format and the picker
+are shaped around it.
+
+**A value already stored that is no longer offered stays visible and stays
+selected**, flagged as unrecognised. An account renamed on the host must not
+quietly widen or narrow a profile by disappearing from a form — a value that
+vanishes from the editor is a value the next save deletes. This falls out of
+the picker being a control over the same stored value the text box edits,
+rather than a separate representation that has to be reconciled with it.
+
 **A raw JSON editor is the fallback, not the plan.** The owner offered one as a
 first draft. It is retained for MCPs that do not implement `context/enumerate`,
 and for those it is the honest surface. Where the MCP *can* enumerate, a

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -171,12 +171,25 @@ it changes naming and the UI, not the enforcement path.
 
 For each `(profile, MCP)` pair:
 
-| layer | field | who enforces | verifiable by relay |
+| layer | field | who decides | what relay can stand behind |
 |---|---|---|---|
-| which MCP | `allowed_mcp_ids` (exists) | relay | yes |
-| which tools | `allowed_tools` (**new**, decision 2b) | relay | yes |
-| which operations | `access: "read" \| "write"` (**new**) | relay | yes |
-| which resources | `context` → injected `_meta` (mechanism exists) | the MCP | **no** |
+| which MCP | `allowed_mcp_ids` (exists) | relay | the whole thing |
+| which tools | `allowed_tools` (**new**, decision 2b) | relay | the whole thing |
+| which operations | `access: "read" \| "write"` (**new**) | relay | the rule, not the input |
+| which resources | `context` → injected `_meta` (mechanism exists) | the MCP | nothing |
+
+The third row needs its qualifier stated rather than rounded up. Relay applies
+the mode itself, at its own chokepoint, and the decision is visible in the
+audit log and in what `ListTools` returns — so an operator can see it was
+made. But the *classification* of a tool as read-only comes from the MCP's own
+`readOnlyHint`. An MCP that mislabels a mutating tool defeats the mode.
+
+That is still meaningfully stronger than the resource layer, in two ways worth
+being precise about. Relay can tell you with certainty that it applied the rule
+and what it decided; for scope it cannot tell whether the MCP did anything at
+all. And a false `readOnlyHint` is a lie told in the MCP's *published tool
+list*, which an operator can read, `relay mcp list --schema` prints, and a
+reviewer can diff — whereas an ignored `_meta` leaves no trace anywhere.
 
 The third layer is the one issue #16 proposed and it is genuinely
 unverifiable — relay cannot check that a returned message came from INBOX
@@ -310,6 +323,35 @@ present and empty, means the server **refuses every call governed by it**
 must change (finding 8); macMCP is being written to this contract from the
 start.
 
+**`_meta` present is what makes a call governed, and this is the MCP's own
+test, not relay's.** The obvious reading — "a call is scoped if it carries one
+of my restrict fields" — has a hole in the fail-open direction: relay failing to
+inject a field for any reason produces a call that looks, to the MCP, exactly
+like an unscoped one. The MCP would then be relying entirely on relay's
+call-time presence check to have run, which is one check and not two.
+
+Relay injects `_meta.project_id` on **every** mediated call and has since
+ADR-007. So the presence of `_meta` at all is a reliable signal that a
+chokepoint mediated this call, and the MCP can require its own declared
+restrict fields on that basis — reading its own `applies_to`, needing nothing
+from relay beyond the fact of mediation. An absent `_meta` means nobody
+mediated: an operator running the MCP over stdio by hand, which is same-user
+local access equivalent to opening Mail.app, and behaves exactly as today.
+
+This is the belt-and-braces ADR-009 decision 3 called for, in the one place it
+was still missing, and it is genuinely independent: relay's check lives in
+`CallTool`, the MCP's lives in the MCP, and neither is derived from the other.
+
+**It applies to local projects too, and that is the deliberate part.** A local
+project granted an MCP that declares an operator-set restrict field must set a
+value or lose the tools that field governs. The asymmetry in decision 2 is not
+extended here, because the two cases are different in kind: a *mode* has a
+defensible default in each direction (`read` is safe, `write` is what a local
+project already had), whereas a *scope* has no default at all — there is no
+answer to "which mailbox" that relay could pick and be right about. So mode
+defaults asymmetrically and scope is always required, and the reason is that
+one of them has a safe wrong answer and the other does not.
+
 **Relay's contract.** Relay writes a non-empty, type-conformant value or it
 refuses the operation. Never a placeholder, never `[]`, never `null`, never the
 field omitted while the grant stands.
@@ -320,8 +362,8 @@ enumerating, or by not granting the MCP.
 
 **Presence is re-checked at call time**, in `CallTool`, against the MCP's
 *live* schema, and a missing value is `denied`. This is the third defence and
-the only one that catches an MCP which grows a scope field *after* a grant was
-validated — the runtime-discovery argument ADR-009 gave for defending
+the only one *in relay* that catches an MCP which grows a scope field *after* a
+grant was validated — the runtime-discovery argument ADR-009 gave for defending
 `allowed_dirs` twice, generalised. `denied` is the right outcome because relay
 made the decision.
 
@@ -633,6 +675,12 @@ mail or quietly returning nothing.
   domain-specific string left in relay is the v1 `allowed_dirs` compatibility
   branch, kept for one release with a deprecation line and a test asserting it
   is the last one.
+
+- **Local projects granted a scope-declaring MCP need a scope too.** The
+  presence requirement is not remote-only (decision 4), so the existing local
+  `Relay` project — which holds `allowed_mcp_ids: ["*"]` and therefore macMCP —
+  loses the mail tools until someone sets one. Loud and closed, and the UI
+  names it.
 
 - **Profiles can break after an MCP upgrade**, loudly and closed: an MCP that
   adds a restrict-field makes existing grants unsatisfiable, and

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -15,10 +15,14 @@ shows the gap exactly:
                                                           disabled_tools: (none)
 
 That grant reads **both** fixture accounts and **every** folder in each, sends
-mail as either identity, moves messages between mailboxes, and writes files to
-arbitrary absolute paths on the host. Relay's permission model stops at the
-tool: a project holds `mail_search` or it does not. There is no way to say
-*this client may read Bob's INBOX, and nothing else, and may not write.*
+mail as either identity, moves messages between mailboxes, writes files to
+arbitrary absolute paths on the host — and reaches all 47 of macMCP's tools,
+because the grant's unit is the MCP and macMCP is thirteen domains wide. It
+holds screen capture, microphone capture, arbitrary Shortcut execution, an
+outbound HTTP channel, the whole address book, the whole calendar, and
+`messages_send`. Relay's permission model stops at the MCP and, below that, at
+a per-tool *denylist*. There is no way to say *this client may read Bob's
+INBOX, and nothing else, and may not write.*
 
 The owner's target is several agents on one VM, each authenticating with its
 own identity and each confined differently: client A reaches these mailboxes
@@ -93,13 +97,30 @@ Findings 2–8 restate issue #16's, re-verified; findings 1 and 9 are new.
    (`fsmcp/src/security.ts:13`): `if (allowedDirs.length === 0) return null; //
    no restrictions`.
 
-9. **`disabled_tools` is a denylist, so it fails open on upgrade.** Granting
+9. **`disabled_tools` is a denylist, so it fails open twice over.** Granting
    `macmcp` grants all 47 tools minus whatever was enumerated *at grant time*.
    Add a tool to macMCP tomorrow and every existing remote grant silently gains
    it. This is the same fail-open shape ADR-009 decision 3 named for
-   `allowed_dirs`, one level up, and it is why the operation gate below is a
-   *mode* derived from the MCP's own declaration rather than a list an operator
-   maintains by hand.
+   `allowed_dirs`, one level up.
+
+   **It also fails open on the tools that already exist**, which is the more
+   urgent half and was measured rather than reasoned. Every one of the
+   following was called through the live `hermes-vm-2` enrolment — a grant
+   whose name is "Hermes Mail" — and **relay authorized every one**:
+   `capture_screenshot` (reached `/usr/sbin/screencapture` and failed only on a
+   missing Screen Recording TCC grant, not on any permission relay holds),
+   `capture_audio`, `shortcuts_run`, `web_fetch`, `contacts_list_groups`,
+   `shortcuts_list`. The ones that returned nothing returned nothing because
+   the host has no shortcuts and no contacts, not because anything refused
+   them.
+
+   So a profile created to read one mailbox holds screen capture, microphone
+   capture, arbitrary macOS automation, an outbound network channel, the
+   address book, the calendar, and the ability to send iMessage as the user.
+   The access mode in decision 2 does **not** close this: `contacts_*`,
+   `calendars_*`, `messages_get_chat` and `web_fetch` are all legitimately
+   read-only, so a `read` profile keeps every one of them. An allowlist is the
+   only thing that does (decision 2b).
 
    Relay already receives what it needs to fix this and throws it away:
    `mcp.Tool.Annotations` (`mcp/types.go:25`) is carried as `json.RawMessage`
@@ -153,6 +174,7 @@ For each `(profile, MCP)` pair:
 | layer | field | who enforces | verifiable by relay |
 |---|---|---|---|
 | which MCP | `allowed_mcp_ids` (exists) | relay | yes |
+| which tools | `allowed_tools` (**new**, decision 2b) | relay | yes |
 | which operations | `access: "read" \| "write"` (**new**) | relay | yes |
 | which resources | `context` → injected `_meta` (mechanism exists) | the MCP | **no** |
 
@@ -173,9 +195,6 @@ than silently granted.
 
 `write` implies `read`. There is deliberately no third mode: no one has named
 one, and an enum with a speculative member is a migration cost paid in advance.
-`disabled_tools` survives unchanged as the escape hatch for tools with no
-resource axis to scope on — keeping a mail profile out of `messages_*` is its
-job, and that is the honest boundary between the two mechanisms.
 
 **Defaults are asymmetric, deliberately.** An access profile with no `access`
 set for an MCP defaults to `read`; a local project defaults to `write`. The
@@ -183,6 +202,46 @@ asymmetry is the same one ADR-009 and ADR-010 apply everywhere else — the
 threat model differs — and it means this ADR landing turns the live `Hermes
 Mail` profile read-only until an operator says otherwise. That is the safe
 direction, it is loud in the UI, and it is the whole point.
+
+### 2b. An access profile names the tools it may call, and a denylist cannot do it
+
+The MCP is the wrong unit of grant. macMCP is one MCP and thirteen domains, and
+finding 9 measured what that costs: a profile called "Hermes Mail" holds screen
+capture and `messages_send`. Nothing in decisions 2, 3 or 5 addresses it —
+scope confines mail *within* the mail tools, and the mode filters mutation
+across all of them, but neither keeps a mail client out of the address book.
+
+**An access profile carries `allowed_tools` per MCP: an explicit enumeration,
+patterns permitted (`mail_*`), the bare `*` refused, absent meaning none.**
+
+This is ADR-009 decision 4's reasoning applied one level down. It refused
+`allowed_mcp_ids: ["*"]` on a remote grant because "registering a new MCP on
+the host silently widens what another machine can reach — with no action taken
+against the project itself and no diff to review." Registering a new *tool* is
+the same event at finer grain, and it happens far more often: `macmcp` grew
+from 46 tools to 47 during ADR-010's own testing.
+
+**Patterns are permitted, and that is not a hole**, because the layers compose.
+`mail_*` does admit a future `mail_delete_everything` — but that tool is still
+denied by `access: "read"` unless someone annotates it read-only, and still
+confined to the profile's mailboxes by `mail_accounts`, whose `applies_to` is
+the same `mail_*`. A pattern that widens the tool list cannot widen the
+resources or the operations. Without patterns an operator maintains eleven tool
+names by hand and the feature goes unused, which is constraint 2 defeating
+constraint 1 by a slower route.
+
+**`disabled_tools` stays for local projects and is not extended to profiles.**
+Subtracting from everything is coherent when the caller is same-user on the
+same machine and the denylist is a convenience; it is not coherent as the
+boundary against another machine. Two mechanisms for one concept is a cost, and
+it is paid deliberately rather than by migrating every existing local project's
+denylist into an allowlist it did not ask for. A profile that sets
+`disabled_tools` is refused at validation, naming `allowed_tools` — an inert
+control is the thing ADR-009 decision 2 refuses at the door.
+
+The four layers are then four allowlists, each failing closed, each answering a
+different question, and none able to widen another: **which MCP, which tools,
+which operations, which resources.**
 
 ### 3. The context schema carries five keywords and no field names relay knows
 
@@ -486,8 +545,8 @@ unambiguous enough to be a permission value at all.
   "name": "Hermes — Bob INBOX (read-only)",
   "kind": "remote",
   "allowed_mcp_ids": ["macmcp"],
+  "allowed_tools": { "macmcp": ["mail_*"] },
   "access": { "macmcp": "read" },
-  "disabled_tools": { "macmcp": ["messages_send", "messages_get_chat", "messages_list_chats"] },
   "context": {
     "macmcp": { "mail_accounts": ["Bob"], "mail_mailboxes": ["INBOX"] }
   }
@@ -551,10 +610,18 @@ mail or quietly returning nothing.
   correct outcome (finding 1) and it removes a capability that has been
   exercised, so it is a behaviour change and not only a hardening.
 
-- **A denylist stops being the mechanism that bounds a client.**
-  `disabled_tools` remains, but the thing that keeps a new mutating tool away
-  from a read-only client is the mode, and it works on tools that did not exist
-  when the profile was written.
+- **The live `Hermes Mail` profile loses 36 tools**, including screen capture,
+  microphone capture, `shortcuts_run`, `web_fetch`, contacts, calendars and
+  `messages_send` — everything outside `mail_*`. It never should have held
+  them, and it holds them today. This is the largest behaviour change here and
+  the one most likely to surprise: a client that quietly relied on any of those
+  breaks loudly at the next call.
+
+- **A denylist stops being the mechanism that bounds a remote client.**
+  `disabled_tools` remains for local projects only. What bounds a profile is
+  `allowed_tools`, and what keeps a *new mutating* tool away from a read-only
+  profile is the mode — which works on tools that did not exist when the
+  profile was written.
 
 - **Every tool relay serves needs a truthful `readOnlyHint`.** A missing one
   now costs the tool its availability to read-only profiles. That is the
@@ -584,8 +651,9 @@ mail or quietly returning nothing.
 ### Deferred, deliberately
 
 - **Calendars, contacts and iMessage.** Same mechanism, no new decisions.
-  `messages_*` has no resource axis short of per-chat and stays a
-  `disabled_tools` job.
+  `messages_*` has no resource axis short of per-chat, so a profile that needs
+  it grants `messages_*` in `allowed_tools` and is confined by the mode alone.
+  Until then decision 2b keeps it out, which is the change that matters.
 - **A per-account mailbox map**, replacing the cross-product.
 - **`fs_bash` auto-disable moving into the schema** (`default_disabled_tools`).
   The same ADR-006 violation as finding 7, but it is not resource scoping.

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -646,6 +646,21 @@ mail or quietly returning nothing.
   asymmetric default is what does the first half; the second half cannot be
   guessed and must be typed.
 
+- **A read-only profile loses `mail_get_source` entirely**, which is a real
+  capability loss and not the one the tool's name suggests. The tool can write
+  a file (`save_to`), so it is annotated `readOnlyHint: false`, so the mode
+  denies it before `write_dirs` is ever consulted — including for the inline
+  read that writes nothing. The layers deny in order and the outer one wins.
+
+  Keeping the annotation truthful is the right call anyway: the mode is relay's
+  own check and does not depend on macMCP's scope enforcement being correct,
+  which is exactly the independence decision 4 argued for. The clean fix is to
+  split the writing half into its own tool so the reading half can be annotated
+  honestly read-only; that is deferred rather than done here, because it is a
+  tool-surface change and this ADR is already large. A profile that genuinely
+  needs raw source today must be granted `write`, which also grants send — so
+  the workaround is bad enough to be worth the eventual split.
+
 - **Two macMCP tools lose their filesystem write for every access profile**, and
   gain a project-directory bound for every local project. `mail_save_attachment`
   is unusable remotely by construction — it requires `destination`. That is the
@@ -715,6 +730,11 @@ mail or quietly returning nothing.
   it grants `messages_*` in `allowed_tools` and is confined by the mode alone.
   Until then decision 2b keeps it out, which is the change that matters.
 - **A per-account mailbox map**, replacing the cross-product.
+- **Splitting `mail_get_source`'s `save_to` into its own tool**, so the reading
+  half can carry an honest `readOnlyHint: true` and stay available to
+  read-only profiles. See the consequence above.
+- **A recipient allowlist for `mail_send`**, on the same `applies_to`
+  machinery, closing the channel named in the consequences.
 - **`fs_bash` auto-disable moving into the schema** (`default_disabled_tools`).
   The same ADR-006 violation as finding 7, but it is not resource scoping.
 - **Per-tool tri-state permissions** (`allow`/`prompt`/`deny`), still where

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -62,6 +62,13 @@ Findings 2–8 restate issue #16's, re-verified; findings 1 and 9 are new.
    holds no filesystem grant), so these parameters have close to zero utility
    remotely and are pure liability.
 
+   **Reopened on the read side**, after this ADR's own review missed it —
+   see Consequences, "Finding 1 is reopened, on the read side."
+   `mail_send` and `mail_create_draft`'s `attachments` read a file from this
+   host to send it out, which this finding's write-only framing did not cover
+   and which is worse: an unscoped read wired to an outbound channel is
+   exfiltration, not the escalation this finding named.
+
 2. **macMCP declares no `contextSchema`.** `main.swift:60-71` returns
    `serverInfo` with `name` and `version` only. It cannot be narrowed and would
    ignore a narrowing if relay attempted one.
@@ -650,7 +657,8 @@ incomplete, and never let a save silently delete something.**
 - **Editing one thing must not delete another.** Writing an operator's scope
   re-runs the derivation so `source: "project_path"` fields are put back;
   without that, editing a local project's mail scope would silently drop its
-  `write_dirs` and disable the two tools that field governs.
+  `file_dirs` and disable `mail_save_attachment`, the one tool that field's
+  `applies_to` governs.
 
 ### 10. Two seams that are not in the list, and one reference implementation that was wrong
 
@@ -756,11 +764,11 @@ Stated once, here, so every scoping MCP implements it identically:
       "applies_to": ["mail_*"], "enumerable": true,
       "depends_on": ["mail_accounts"]
     },
-    "write_dirs": {
+    "file_dirs": {
       "type": "array", "items": {"type": "string"},
-      "description": "Directories this client may write files into",
+      "description": "Directories on this host this client may write files into and read attachments from",
       "scope": "restrict", "source": "project_path",
-      "applies_to": ["mail_save_attachment", "mail_get_source"]
+      "applies_to": ["mail_save_attachment"]
     }
   }
 }
@@ -775,6 +783,32 @@ line and the reconciliation rule would each have to learn. Mailbox values are
 the **full paths** `mail_list_mailboxes` already returns (`Projects/Archive`,
 not `Archive`) — the path work in macMCP is what makes a mailbox name
 unambiguous enough to be a permission value at all.
+
+`file_dirs` was named `write_dirs` until it was found to govern a read as well
+(Consequences, "finding 1 reopened on the read side"): `mail_save_attachment`'s
+`destination` and `mail_get_source`'s `save_to` write a file to this host,
+`mail_send`'s `attachments` and `mail_create_draft`'s `attachments` read one
+from it. One field, four parameters, two directions — the name and the
+description both had to stop implying "write" alone.
+
+Its `applies_to` names exactly **one** tool, not four, and not the two the
+field governed before this revision. `mail_save_attachment` cannot do anything
+without `destination` — there is no call that succeeds without a value, so
+relay's presence check (decision 4) is right to refuse the whole tool outright
+when `file_dirs` is absent. The other three each have a *purpose that does not
+touch the field*: `mail_get_source` without `save_to` is a plain read,
+`mail_send` and `mail_create_draft` without `attachments` are plain mail. Naming
+them in `applies_to` would make relay refuse a metadata-only `mail_get_source`
+or an attachment-free `mail_send` for want of a value neither call needed —
+gating the tool on a parameter it never used. So `applies_to` names only the
+tool that cannot function without the field; a tool with a mere *parameter*
+that needs it keeps working, and it is macMCP, not relay, that refuses the
+parameter. This is unaffected by the narrower `applies_to`: `_meta` injection
+is not gated by it (`filterKnownContextFields` keeps every field the live
+schema still declares, for every tool call, whatever that field's `applies_to`
+says), so `mail_get_source`, `mail_send` and `mail_create_draft` all receive
+`file_dirs` on every call and can check `save_to` / each attachment path
+against it — or refuse the specific argument, never the tool — themselves.
 
 ### The resulting access profile
 
@@ -793,8 +827,8 @@ unambiguous enough to be a permission value at all.
 ```
 
 `ValidateProjectGrants` permits it: macMCP retains usable tools without
-`write_dirs`. It still refuses fsMCP, whose every tool is governed by one.
-`SyncProjectToken` derives nothing — `write_dirs` is `project_path` and this
+`file_dirs`. It still refuses fsMCP, whose every tool is governed by one.
+`SyncProjectToken` derives nothing — `file_dirs` is `project_path` and this
 record has no path.
 
 ### What macMCP receives on `mail_search`
@@ -846,7 +880,7 @@ mail or quietly returning nothing.
 - **A read-only profile loses `mail_get_source` entirely**, which is a real
   capability loss and not the one the tool's name suggests. The tool can write
   a file (`save_to`), so it is annotated `readOnlyHint: false`, so the mode
-  denies it before `write_dirs` is ever consulted — including for the inline
+  denies it before `file_dirs` is ever consulted — including for the inline
   read that writes nothing. The layers deny in order and the outer one wins.
 
   Keeping the annotation truthful is the right call anyway: the mode is relay's
@@ -858,11 +892,48 @@ mail or quietly returning nothing.
   needs raw source today must be granted `write`, which also grants send — so
   the workaround is bad enough to be worth the eventual split.
 
-- **Two macMCP tools lose their filesystem write for every access profile**, and
-  gain a project-directory bound for every local project. `mail_save_attachment`
-  is unusable remotely by construction — it requires `destination`. That is the
-  correct outcome (finding 1) and it removes a capability that has been
-  exercised, so it is a behaviour change and not only a hardening.
+- **`mail_save_attachment` loses its filesystem write for every access
+  profile**, and gains a project-directory bound for every local project. It is
+  unusable remotely by construction — it requires `destination` and there is no
+  call that succeeds without one, so relay's presence check refuses the whole
+  tool when `file_dirs` is absent. That is the correct outcome (finding 1) and
+  it removes a capability that has been exercised, so it is a behaviour change
+  and not only a hardening. `mail_get_source`'s `save_to`, `mail_send`'s
+  `attachments` and `mail_create_draft`'s `attachments` are bounded
+  differently, and deliberately not by relay refusing the tool — see finding 1,
+  reopened, below.
+
+- **Finding 1 is reopened, on the read side, and this ADR is what missed it.**
+  Finding 1 named `mail_save_attachment`'s `destination` and
+  `mail_get_source`'s `save_to` — both writes — and scoped exactly those two
+  under `write_dirs`. `mail_send` and `mail_create_draft` both take an
+  `attachments` list naming a file **on this host** to read and encode into the
+  outgoing message, and that parameter was not scoped by anything: any client
+  holding either tool could name any path this process could read. The two
+  write parameters were scoped; the read parameter sitting right next to them,
+  on the same field's obvious remit, was missed — not a different risk found
+  later, an omission in this review.
+
+  It is worse than the hole finding 1 closed, not merely a repeat of it. The
+  write side was named **escalation, not exfiltration** (Context, above) — a
+  remote client with no filesystem grant of its own cannot read back a file it
+  wrote there, so the practical use of an arbitrary write with no arbitrary
+  read is limited to damage, not theft. `attachments` on `mail_send` is a read
+  wired directly to an outbound channel: whatever this process can read, a
+  `write`-mode mail profile can mail out, which is exactly the exfiltration
+  this ADR's threat model (Context) says is the thing being defended against —
+  not the one exception finding 1 carved out for escalation, but the main
+  case. Reproduced live, not theoretical: an adversarial validator read and
+  exfiltrated `/tmp/zsec-secret.txt` — a file with no relationship to any
+  mailbox — through `mail_send.attachments` via a real `write` access profile,
+  before this field existed.
+
+  This is why the field was renamed `write_dirs` -> `file_dirs` and its
+  description stopped saying only "write": the same directory bound now gates
+  both directions, on all four parameters, under the worked example above. The
+  fix is a scope value macMCP checks the attachment path against, exactly as
+  it already checks `save_to` — there is no new mechanism here, only a
+  parameter that should have been named in the first pass and was not.
 
 - **The live `Hermes Mail` profile loses 36 tools**, including screen capture,
   microphone capture, `shortcuts_run`, `web_fetch`, contacts, calendars and

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -642,6 +642,18 @@ mail or quietly returning nothing.
   thing this ADR exists to prevent. The UI surfaces it as "N profiles need a
   value for `macmcp`" rather than leaving it to be discovered from a `denied`.
 
+- **A `write` mail profile is an exfiltration channel and this ADR does not
+  close it.** `mail_accounts` scopes the identity a message is *sent as*; it
+  says nothing about who it is sent *to*. A profile holding `mail_send` can
+  mail anything it can read to any address. That is inherent in granting send
+  to a semi-trusted agent rather than a defect in the scope model, and it is
+  why `read` is the default (decision 2) and why the layers are worth having
+  separately: a read-only mail profile has no outbound channel at all, once
+  decision 2b has taken `web_fetch` away from it. A recipient allowlist is a
+  coherent later addition on the same `applies_to` machinery. The fixture hides
+  this — its SMTP server refuses non-fixture recipients with 550 — so it must
+  not be mistaken for a control that exists.
+
 - **Relay still cannot tell whether an MCP honoured `_meta`.** There is no
   structural answer and this ADR does not pretend one. The mitigations are
   containment, not verification: MCPs are host-side code the operator installed

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -1,0 +1,619 @@
+# ADR-011: A Client Is an Identity, an Access Profile, and a Resource Scope
+
+**Status:** Proposed
+**Date:** 2026-08-22
+
+## Context
+
+ADR-009 made the project model coherent for a client on another machine.
+ADR-010 made that client reachable and gave it an identity. Neither bounded
+*what it may reach once connected*, and the live configuration on this host
+shows the gap exactly:
+
+    enrolment hermes-vm-2  ->  project "Hermes Mail"  ->  allowed_mcp_ids: ["macmcp"]
+                                                          context: (none)
+                                                          disabled_tools: (none)
+
+That grant reads **both** fixture accounts and **every** folder in each, sends
+mail as either identity, moves messages between mailboxes, and writes files to
+arbitrary absolute paths on the host. Relay's permission model stops at the
+tool: a project holds `mail_search` or it does not. There is no way to say
+*this client may read Bob's INBOX, and nothing else, and may not write.*
+
+The owner's target is several agents on one VM, each authenticating with its
+own identity and each confined differently: client A reaches these mailboxes
+with these operations, client B reaches others, possibly read-only. The threat
+model is unchanged from ADR-009 — **exfiltration, not privilege escalation** —
+with one exception this ADR closes, where it is escalation (finding 1).
+
+Three constraints, stated in the owner's order of priority:
+
+1. **Security.** A client can only do what it is allowed to do.
+2. **Operability.** An operator must be able to express that without it being
+   easy to make a mistake. A configuration UI that is hard to get right
+   defeats constraint 1 rather than trading against it.
+3. **Simplicity.** Tight, not defensive sprawl. Every mechanism here has to
+   pay for itself.
+
+Scope of this ADR is **MCP tool access and mail resources**. Calendars,
+contacts and iMessage share the shape and are deliberately not built here.
+
+## What a review of the current tree found
+
+Verified against `relay` at `df8683a`, `macMCP` at `df8683a`, `fsmcp` at HEAD.
+Findings 2–8 restate issue #16's, re-verified; findings 1 and 9 are new.
+
+1. **macMCP hands a mail-only remote client an arbitrary filesystem write.**
+   `mail_save_attachment` takes `destination` — "Absolute POSIX path … (created
+   if missing)", **required** — and `mail_get_source` takes `save_to`, both
+   unscoped (`MailService.swift:5859`, `:5882`). ADR-009's premise is that "the
+   VM never touches the host filesystem, so whole tool classes (`fs_*`,
+   `bash*`) do not apply"; macMCP reopens that class from inside a mail grant.
+   A remote client can write `~/.zshrc` or `~/Library/LaunchAgents/*.plist`.
+   That is **escalation, not exfiltration**, and it is reachable in the live
+   configuration today — the audit log shows `mail_save_attachment` already
+   called through `hermes-vm-2`.
+
+   Note the corollary: a remote client cannot *read back* a file it wrote (it
+   holds no filesystem grant), so these parameters have close to zero utility
+   remotely and are pure liability.
+
+2. **macMCP declares no `contextSchema`.** `main.swift:60-71` returns
+   `serverInfo` with `name` and `version` only. It cannot be narrowed and would
+   ignore a narrowing if relay attempted one.
+
+3. **macMCP drops `_meta` on the floor.** `main.swift:95-101` reads
+   `params.name` and `params.arguments`; a grep for `_meta` across `Sources/`
+   returns nothing. `ToolHandler` is `(JSONObject?) -> MCPCallResult` — there is
+   no side channel to a handler at all. Relay has been injecting
+   `_meta.project_id` into every macMCP call since ADR-007 and macMCP has never
+   read it.
+
+4. **macMCP's mail tools default to everything.** `resolveTargets`
+   (`MailService.swift:1596`) expands an omitted `account` to every configured
+   account plus the local pass; `mail_search`'s `mailbox` defaults to `all`.
+
+5. **`account` and `mailbox` are already ordinary tool arguments** on all 11
+   mail tools. Scoping is therefore not "inject and done": the MCP must
+   reconcile a caller-supplied argument against a relay-supplied scope, and
+   that rule has to be stated once rather than invented per tool.
+
+6. **There is no operator path to `context` at all.** `projectCreateFields` and
+   `projectUpdateFields` (`project_apply.go:8-39`) carry no `context` field;
+   `web/src/app.js` never mentions it. `Project.Context` is only ever *derived*,
+   by the one hardcoded rule in `SyncProjectToken`.
+
+7. **`ValidateProjectGrants` matches a literal field name** —
+   `schemaHasField(schemas[mcpID], "allowed_dirs")` (`settings.go:493`, `:527`).
+   ADR-006's principle is that service-specific knowledge lives in services.
+   More importantly it is the *wrong rule*: it encodes "filesystem" where it
+   means "derived from the project's path".
+
+8. **The one enforcing MCP fails open on empty.** `validatePath`
+   (`fsmcp/src/security.ts:13`): `if (allowedDirs.length === 0) return null; //
+   no restrictions`.
+
+9. **`disabled_tools` is a denylist, so it fails open on upgrade.** Granting
+   `macmcp` grants all 47 tools minus whatever was enumerated *at grant time*.
+   Add a tool to macMCP tomorrow and every existing remote grant silently gains
+   it. This is the same fail-open shape ADR-009 decision 3 named for
+   `allowed_dirs`, one level up, and it is why the operation gate below is a
+   *mode* derived from the MCP's own declaration rather than a list an operator
+   maintains by hand.
+
+   Relay already receives what it needs to fix this and throws it away:
+   `mcp.Tool.Annotations` (`mcp/types.go:25`) is carried as `json.RawMessage`
+   and read by nothing. macMCP populates `annotations.readOnlyHint`
+   (`main.swift:85`) — but **not** on `mail_save_attachment`, `mail_move` or
+   `mail_mark_read`, two of which mutate, and it sets `readOnlyHint: true` on
+   `mail_get_source`, which writes a file when `save_to` is given.
+
+Issue #16's finding 6 (`schemaHasField` missing the nested schema shape) is
+already closed by issue #17, commit `934325b`, and is not restated.
+
+## Decision
+
+### 1. The unit of authority stays two records, and the remote one is renamed
+
+A client's authority is the pair `(enrolment, access profile)`: the enrolment
+is the certificate and the budget, the profile is what may be done. The obvious
+simplification is to collapse them — put the capabilities directly on the
+enrolment, so one client is one record.
+
+**Rejected, for one concrete reason: certificate rotation must not require
+re-authoring the permission set.** `hermes-vm-1` was revoked and `hermes-vm-2`
+created during ADR-010's own testing; that will happen again. Under a collapsed
+model every rotation retypes every mailbox name, which is a fresh opportunity
+to make constraint 1's mistake at exactly the moment nobody is reviewing
+carefully. Keeping the profile separate also lets several agents share one
+reviewed confinement, which is the `hermes-mail` / `hermes-cal` /
+`hermes-triage` shape ADR-010 already draws.
+
+**What is wrong is the word.** A remote project is not a project: it has no
+directory, no skills, no shell, no models, no session. Calling it one invites
+the reader to expect all of those, and it is the reason the model reads as a
+poor fit. Every operator-facing surface — Settings UI, `relay enrol`, the audit
+CLI, this ADR — calls a remote-kind record an **access profile**. `kind:
+"remote"` on disk is unchanged: renaming a storage key is migration risk for no
+security gain, and `IsRemote()` is already the only place the distinction is
+made.
+
+The enrolment listing gains the profile's *effective* authority inline — MCPs,
+mode, scope — so "what can this client do" is answered in one place without
+mentally joining two records. That is the real cost of two records and it is
+paid in the UI, not in the model.
+
+**This decision is the one most worth overruling**, and it is cheap to reverse:
+it changes naming and the UI, not the enforcement path.
+
+### 2. Authority has three layers, and relay enforces the two it can verify
+
+For each `(profile, MCP)` pair:
+
+| layer | field | who enforces | verifiable by relay |
+|---|---|---|---|
+| which MCP | `allowed_mcp_ids` (exists) | relay | yes |
+| which operations | `access: "read" \| "write"` (**new**) | relay | yes |
+| which resources | `context` → injected `_meta` (mechanism exists) | the MCP | **no** |
+
+The third layer is the one issue #16 proposed and it is genuinely
+unverifiable — relay cannot check that a returned message came from INBOX
+without parsing mail results, which is the ADR-006 line. The second layer is
+new here, and it is the one relay *can* decide by itself, at its own
+chokepoint, from a declaration the MCP already publishes. It is also the direct
+answer to "read-only or read-write", which is how an operator actually thinks
+about a client.
+
+**`access` is enforced in `checkToolAccess` and fails closed.** A tool is
+admitted to a `read` profile only if its `annotations.readOnlyHint` is
+explicitly `true`. Absent, malformed, or `false` all mean *mutating*. This is
+the rule that makes finding 9 safe: a tool added to an MCP after a grant was
+written is denied to every read-only profile until someone annotates it, rather
+than silently granted.
+
+`write` implies `read`. There is deliberately no third mode: no one has named
+one, and an enum with a speculative member is a migration cost paid in advance.
+`disabled_tools` survives unchanged as the escape hatch for tools with no
+resource axis to scope on — keeping a mail profile out of `messages_*` is its
+job, and that is the honest boundary between the two mechanisms.
+
+**Defaults are asymmetric, deliberately.** An access profile with no `access`
+set for an MCP defaults to `read`; a local project defaults to `write`. The
+asymmetry is the same one ADR-009 and ADR-010 apply everywhere else — the
+threat model differs — and it means this ADR landing turns the live `Hermes
+Mail` profile read-only until an operator says otherwise. That is the safe
+direction, it is loud in the UI, and it is the whole point.
+
+### 3. The context schema carries five keywords and no field names relay knows
+
+Relay must store, inject, render and refuse a scoping value without knowing
+what it scopes. It can, if the schema describes each field's **role in the
+permission model** rather than its meaning. A `contextSchema` field keeps its
+JSON-Schema-ish fragment (`type`, `items`, `description`) and gains:
+
+| keyword | values | what relay does with it |
+|---|---|---|
+| `scope` | `"restrict"` | this field narrows access; the rules below apply. Absent means an ordinary context value relay injects and otherwise ignores. |
+| `source` | `"operator"` \| `"project_path"` | who supplies the value (decision 5) |
+| `applies_to` | tool-name globs | which of this MCP's tools the field governs |
+| `enumerable` | bool | the MCP can list this field's valid values (decision 6) |
+| `depends_on` | field names | enumeration ordering |
+
+Relay learns "this field restricts access, an operator sets it, and it governs
+`mail_*`". It never learns what a mailbox is. The field name is an opaque map
+key from relay's side start to finish.
+
+The rejected alternative is a registry inside relay mapping known field names
+to known handling. That is what `schemaHasField(…, "allowed_dirs")` is today in
+miniature, and it does not survive a second MCP.
+
+**The shape is fixed as the flat form** — `{fieldName: {fragment}}` — and
+documented, because issue #17 showed the ambiguity is live and its failure
+direction is fail-open. `contextSchemaVersion: 2` in `serverInfo` marks a
+schema using these keywords. An absent version means v1 and is handled exactly
+as today, literal `allowed_dirs` branch included, for one release.
+
+**Five keywords, not eight.** The proposal in issue #16 also carried `absent`,
+`wildcard` and `ui`. Each is dropped with a reason:
+
+- **`absent`** declared whether a missing value means deny or unrestricted. A
+  field that says `scope: "restrict"` and then defaults open is not a
+  restriction, and relay could never verify the claim either way. So
+  `scope: "restrict"` *means* fail closed, and the keyword that let an MCP say
+  otherwise is a knob whose only setting is the wrong one.
+- **`wildcard`** let an operator type an explicit "all". Dropped entirely: on
+  an access profile the wildcard was already going to be refused (ADR-009
+  decision 4's reasoning — a grant must be an enumeration someone typed, not a
+  value that widens when the host's configuration changes), and on the
+  `project_path` side there is nothing for it to mean. An operator who wants
+  every account lists every account, and a new account added later does not
+  silently join the grant.
+- **`ui`** was a rendering hint. `type` plus `enumerable` already determines
+  the widget, and fsMCP's existing `ui: "directory-list"` has never had a
+  consumer.
+
+**An attestation echo is deliberately not part of this.** Issue #16 proposed
+that a compliant MCP echo the scope it applied so relay could warn when one
+never came back. It defends against an MCP that ignores `_meta` through
+negligence — but *declaring the field in `contextSchema` is already that
+assertion*, and an MCP that stopped enforcing while still declaring would
+happily still echo. The echo therefore adds no information relay does not
+already hold. What catches a regression is an end-to-end test that asserts the
+confinement, which decision 9 requires.
+
+### 4. Absent and empty are refusals, on all three sides
+
+Generalising ADR-009 decision 3 from one field to the mechanism:
+
+**The MCP's contract.** A `scope: "restrict"` field missing from `_meta`, or
+present and empty, means the server **refuses every call governed by it**
+(`applies_to`). Not "falls back to a CLI default", not "no restriction". fsMCP
+must change (finding 8); macMCP is being written to this contract from the
+start.
+
+**Relay's contract.** Relay writes a non-empty, type-conformant value or it
+refuses the operation. Never a placeholder, never `[]`, never `null`, never the
+field omitted while the grant stands.
+
+**The operator's contract.** "No restriction" is not expressible as emptiness,
+and with `wildcard` dropped it is not expressible at all — it is spelled by
+enumerating, or by not granting the MCP.
+
+**Presence is re-checked at call time**, in `CallTool`, against the MCP's
+*live* schema, and a missing value is `denied`. This is the third defence and
+the only one that catches an MCP which grows a scope field *after* a grant was
+validated — the runtime-discovery argument ADR-009 gave for defending
+`allowed_dirs` twice, generalised. `denied` is the right outcome because relay
+made the decision.
+
+### 5. `source` replaces the hardcoded name, and unifies local with remote
+
+This is the decision that marries the two models, and it is the reason the
+directory case and the mailbox case are one mechanism rather than two.
+
+- **`source: "project_path"`** — relay derives the value from `Project.Path`.
+  An access profile has no path, so such a field is **absent** for one, and by
+  decision 4 the tools it governs refuse.
+- **`source: "operator"`** — an operator sets it explicitly. Local and remote
+  alike. Nothing about a mail account depends on the caller having a
+  filesystem.
+
+`ValidateProjectGrants` stops asking "does this MCP declare `allowed_dirs`" and
+asks the general question: **would this grant leave the MCP with no usable
+tools?** For fsMCP that is yes — every tool is governed by a `project_path`
+field that a profile cannot supply — so the grant is refused exactly as today,
+by a derived rule instead of a hardcoded string. For macMCP it is no: only
+`mail_save_attachment` and `mail_get_source` are governed by its `project_path`
+field, so the MCP is grantable and precisely those two lose their filesystem
+write. **This is finding 1's fix**, and it arrives as a consequence of the
+model rather than as a special case.
+
+It also improves the *local* side, which today is unbounded: a local project
+granted macMCP can currently write an attachment anywhere on the host. Under
+`source: "project_path"` it writes inside its own project directory and nowhere
+else.
+
+`SyncProjectToken` keeps its independent second defence in generic form: never
+derive a `project_path` field for a remote-kind record, unconditionally, before
+the loop. Belt-and-braces for the reason ADR-009 gave — the failure mode is a
+silent widening, and schemas are discovered at runtime.
+
+**Rejected: a third source, `"enrolment"`.** Scope on the certificate rather
+than the profile. It is the same collapse decision 1 rejected, and it adds the
+confused-deputy shape ADR-007 spent a PR removing: the same profile would mean
+different things to different callers.
+
+### 6. Enumeration is a separate request, and the UI is a picker over real values
+
+Constraint 2. Typing `INBOX` by hand is the error-prone step, and under
+decision 4 a typo now fails *closed* — the agent silently gets nothing, which
+is safe and baffling. So the editor should not ask an operator to type a
+resource name at all.
+
+An MCP answering `context/enumerate` returns `{field: [{value, label}]}` for
+fields declaring `enumerable: true`; relay honours it for those fields only and
+sends already-chosen values back as parameters for fields declaring
+`depends_on`, so the UI fills in dependency order (mailboxes cannot be listed
+without an account). macMCP implements it by delegating to the code
+`mail_list_accounts` and `mail_list_mailboxes` already call.
+
+**Rejected: declaring an existing tool as the enumerator** (`"enumerate":
+{"tool": "mail_list_accounts", "path": "$.accounts[*]"}`). Cheaper to build and
+worse to live with: it routes an operator-UI read through `appRouter.CallTool`,
+so it lands in the audit log as a tool call nobody made, consumes ADR-010
+budget, and must run with relay's own unscoped authority through the chokepoint
+that exists to constrain agents. It also makes relay extract values from a
+free-form result, which is a path expression per MCP — domain knowledge by the
+back door.
+
+**Enumeration is itself disclosure** and should be named as one: the list of
+every mail account on the machine becomes readable by anything that can open
+the Settings UI or reach the project routes. That is host-local admin surface
+today, so it is acceptable — but it is a new read path.
+
+**A raw JSON editor is the fallback, not the plan.** The owner offered one as a
+first draft. It is retained for MCPs that do not implement `context/enumerate`,
+and for those it is the honest surface. Where the MCP *can* enumerate, a
+free-text box would be a UI whose easiest failure is a confinement that does
+not confine what the operator thought — constraint 2 defeating constraint 1
+rather than trading against it. **Every value is validated against the declared
+fragment on save, whichever surface produced it, and an invalid one is refused
+rather than stored.**
+
+### 7. The scope is audited, and a violation is a field rather than an outcome
+
+**Record it.** ADR-008's property is that the log answers what was attempted
+with what authority. The authority is the grant *plus* the mode *plus* the
+injected scope. A record carrying the tool and the args but not those cannot
+answer "was this call confined?" once an operator has since edited the profile,
+and re-reading `settings.json` at query time answers a different question. The
+values recorded are the ones actually injected, taken from `meta` where
+`CallTool` assembles it, on the single record for a local call and on the
+**intent** record for a remote one.
+
+**Only declared `scope: "restrict"` fields, never the whole context map.**
+`_meta` is a general channel and a future MCP may pass an API key through it.
+Logging `Context[extID]` wholesale would make the audit file the place
+credentials go to be archived. Filtering to declared restrict-fields is both
+safer and domain-blind.
+
+**No new outcome for a scope violation.** ADR-008 already places it:
+`tool_error` means the call completed and the MCP answered no — a boundary was
+probed and held. `throttled` earned its slot in ADR-010 because a budget
+refusal is a decision *relay* makes with relay's numbers; a scope violation is
+made inside the MCP and relay is relaying it. Promoting it would require relay
+to distinguish it from any other `isError` by parsing a message (the ADR-006
+line) or by trusting a marker (a relay decision wearing an outcome's clothes).
+An optional structured marker surfaces as the audit **field**
+`scope_violation: true` with `outcome` staying `tool_error`, which gives
+alerting its signal without inflating a small enum that `--outcome`, the CLI
+table and the UI pill all key on. A `denied` from the *mode* check is a
+different thing and is already correctly `denied`, because relay decided it.
+
+### 8. A client is told its own limits through `ListTools`
+
+`renderBucketSkillMd` is the obvious place to say "this profile is limited to
+Bob's INBOX, read-only" and it is the wrong *only* place: **access profiles
+have no skills**, because `validateProjectShape` refuses `GenerateSkill`. The
+agent this feature exists for is the one that would never see it.
+
+So relay appends a scope note to the `description` of each governed tool inside
+`ListTools`, built from the schema's own `description` and the operator's
+value, with `applies_to` selecting which tools are governed (all of the MCP's
+when absent — domain-blind by default, MCP-supplied precision when offered).
+One implementation reaches the remote listener's `ListTools`, `relay mcp call
+--list`, and `ListSkillBuckets`, which feeds the skill renderer; the two list
+paths must not double-append. `renderBucketSkillMd` gains a short **Scope**
+section from the same data.
+
+The mode needs no note: a `read` profile simply does not see mutating tools,
+because `checkToolAccess` already filters `ListTools`.
+
+**The frontmatter `description` does not change.** `synthesizeDescription` is a
+500-byte lazy-load *routing* signal. "Restricted to Bob's INBOX" does not help
+a request route and consumes the budget that makes routing work.
+
+### 9. Nothing ships until the confinement is demonstrated end to end
+
+Relay injecting a scope that macMCP does not enforce is **worse than no scope
+at all**, because the UI would then assert a confinement that does not exist.
+The sequencing that prevents it is structural rather than procedural: relay
+only offers scope for fields an MCP *declares*, and macMCP declares none until
+it enforces them. Neither half can lie about the other.
+
+The demonstration is not a unit test. Two access profiles, two enrolments, two
+real clients, against the `testMail` fixture's real accounts:
+
+- profile **A** — Bob only, `INBOX` only, `read`
+- profile **B** — Alice only, `INBOX` + `Archive`, `write`
+
+and the assertions that matter are the negative ones: A cannot read Alice at
+all, cannot read Bob's `Archive`, cannot send, cannot move, cannot mark read,
+cannot write a file; B cannot read Bob; neither can save an attachment to an
+arbitrary path; an explicit out-of-scope argument is an **error** rather than a
+silent narrowing. Ground truth is relay's audit log and the fixture's Maildir
+on disk — never a client's own report of success. That standard is inherited:
+ADR-010's client passed 95 tests and an adversarial review while its primary
+interface was broken, because nobody had executed the string the generator
+printed.
+
+## The reconciliation rule the MCP implements
+
+Stated once, here, so every scoping MCP implements it identically:
+
+- An **absent or default-valued** scope-relevant argument resolves **to the
+  scope**, not to everything. `mail_search` with no `account` scans the allowed
+  accounts.
+- A **tool-level wildcard** argument (`mailbox: "all"`) means "everything I am
+  allowed to see" and resolves to the scope. It does not error.
+- An **explicit** argument outside the scope is an **error**, not a silent
+  narrowing. Silent narrowing lets an agent build a false model of what it can
+  reach and burn calls discovering the truth; ADR-009's principle is to refuse
+  incoherent combinations rather than degrade.
+- **Enumerators are scoped too.** `mail_list_accounts` and
+  `mail_list_mailboxes` report only what is in scope. An enumerator that lists
+  the machine's real account names to a confined client is a disclosure, and it
+  is also how that client learns what to try next.
+
+## Worked example
+
+### What macMCP declares
+
+```json
+"serverInfo": {
+  "name": "macmcp",
+  "version": "1.1.0",
+  "contextSchemaVersion": 2,
+  "contextSchema": {
+    "mail_accounts": {
+      "type": "array", "items": {"type": "string"},
+      "description": "Mail accounts this client may read from or send as",
+      "scope": "restrict", "source": "operator",
+      "applies_to": ["mail_*"], "enumerable": true
+    },
+    "mail_mailboxes": {
+      "type": "array", "items": {"type": "string"},
+      "description": "Mailbox paths within those accounts this client may reach",
+      "scope": "restrict", "source": "operator",
+      "applies_to": ["mail_*"], "enumerable": true,
+      "depends_on": ["mail_accounts"]
+    },
+    "write_dirs": {
+      "type": "array", "items": {"type": "string"},
+      "description": "Directories this client may write files into",
+      "scope": "restrict", "source": "project_path",
+      "applies_to": ["mail_save_attachment", "mail_get_source"]
+    }
+  }
+}
+```
+
+`mail_accounts` and `mail_mailboxes` combine as a **cross-product**: accounts
+`[Alice, Bob]` with mailboxes `[INBOX]` means both INBOXes. "Alice's INBOX and
+Bob's Archive" is not expressible in one profile and is two profiles. This is a
+real limitation, accepted for now because the pair covers the stated case and a
+per-account mailbox map is a structure the picker, the validator, the audit
+line and the reconciliation rule would each have to learn. Mailbox values are
+the **full paths** `mail_list_mailboxes` already returns (`Projects/Archive`,
+not `Archive`) — the path work in macMCP is what makes a mailbox name
+unambiguous enough to be a permission value at all.
+
+### The resulting access profile
+
+```json
+{
+  "id": "prof_hermes_bob_inbox",
+  "name": "Hermes — Bob INBOX (read-only)",
+  "kind": "remote",
+  "allowed_mcp_ids": ["macmcp"],
+  "access": { "macmcp": "read" },
+  "disabled_tools": { "macmcp": ["messages_send", "messages_get_chat", "messages_list_chats"] },
+  "context": {
+    "macmcp": { "mail_accounts": ["Bob"], "mail_mailboxes": ["INBOX"] }
+  }
+}
+```
+
+`ValidateProjectGrants` permits it: macMCP retains usable tools without
+`write_dirs`. It still refuses fsMCP, whose every tool is governed by one.
+`SyncProjectToken` derives nothing — `write_dirs` is `project_path` and this
+record has no path.
+
+### What macMCP receives on `mail_search`
+
+```json
+{
+  "name": "mail_search",
+  "arguments": {"query": "invoice", "limit": 20},
+  "_meta": {
+    "project_id": "prof_hermes_bob_inbox",
+    "mail_accounts": ["Bob"],
+    "mail_mailboxes": ["INBOX"]
+  }
+}
+```
+
+`resolveTargets(account: nil)` yields `["Bob"]` rather than every account plus
+the local pass; the scan's `mailbox: "all"` resolves to `["INBOX"]`;
+`fmInScope` gains the scope as a second condition ANDed with the caller's own
+`account` argument; `senderJXA` refuses a `from` whose owning account is out of
+scope even though Mail owns the address; `mail_move` checks both the source it
+found and the destination it resolved. `mail_get_emails {"account": "Alice"}`
+returns `isError` with `scope_violation`, rather than quietly returning Bob's
+mail or quietly returning nothing.
+
+### The audit line
+
+```json
+{
+  "id": "01J…", "ts": "2026-08-22T09:14:02Z", "event": "call_tool",
+  "phase": "intent",
+  "actor": {"kind": "remote", "auth": "mtls", "client_id": "hermes-bob",
+            "project_id": "prof_hermes_bob_inbox", "fingerprint": "sha256:9f2a…"},
+  "mcp_id": "macmcp", "tool": "mail_search",
+  "args": {"query": "invoice", "limit": 20},
+  "access": "read",
+  "scope": {"mail_accounts": ["Bob"], "mail_mailboxes": ["INBOX"]},
+  "outcome": "pending"
+}
+```
+
+## Consequences
+
+- **The live `Hermes Mail` profile becomes read-only** when this lands, and
+  keeps reading both accounts until an operator narrows it. Decision 2's
+  asymmetric default is what does the first half; the second half cannot be
+  guessed and must be typed.
+
+- **Two macMCP tools lose their filesystem write for every access profile**, and
+  gain a project-directory bound for every local project. `mail_save_attachment`
+  is unusable remotely by construction — it requires `destination`. That is the
+  correct outcome (finding 1) and it removes a capability that has been
+  exercised, so it is a behaviour change and not only a hardening.
+
+- **A denylist stops being the mechanism that bounds a client.**
+  `disabled_tools` remains, but the thing that keeps a new mutating tool away
+  from a read-only client is the mode, and it works on tools that did not exist
+  when the profile was written.
+
+- **Every tool relay serves needs a truthful `readOnlyHint`.** A missing one
+  now costs the tool its availability to read-only profiles. That is the
+  fail-closed direction, and it makes the annotation load-bearing where it was
+  previously decorative — including the three mail tools that lack it today and
+  `mail_get_source`, whose `true` is wrong while `save_to` exists.
+
+- **Relay learns five keywords and no field names.** After this, the only
+  domain-specific string left in relay is the v1 `allowed_dirs` compatibility
+  branch, kept for one release with a deprecation line and a test asserting it
+  is the last one.
+
+- **Profiles can break after an MCP upgrade**, loudly and closed: an MCP that
+  adds a restrict-field makes existing grants unsatisfiable, and
+  `SyncProjectToken` will not run again until someone edits settings. The
+  call-time presence check (decision 4) is the catch. Accepted deliberately —
+  the alternative is a profile that keeps working with no scope, which is the
+  thing this ADR exists to prevent. The UI surfaces it as "N profiles need a
+  value for `macmcp`" rather than leaving it to be discovered from a `denied`.
+
+- **Relay still cannot tell whether an MCP honoured `_meta`.** There is no
+  structural answer and this ADR does not pretend one. The mitigations are
+  containment, not verification: MCPs are host-side code the operator installed
+  and can read, ADR-010's per-enrolment budget bounds the drain regardless, and
+  decision 9's end-to-end test is what catches a regression.
+
+### Deferred, deliberately
+
+- **Calendars, contacts and iMessage.** Same mechanism, no new decisions.
+  `messages_*` has no resource axis short of per-chat and stays a
+  `disabled_tools` job.
+- **A per-account mailbox map**, replacing the cross-product.
+- **`fs_bash` auto-disable moving into the schema** (`default_disabled_tools`).
+  The same ADR-006 violation as finding 7, but it is not resource scoping.
+- **Per-tool tri-state permissions** (`allow`/`prompt`/`deny`), still where
+  ADR-009 left them. Orthogonal: no mode or scope value expresses "prompt
+  before `mail_send`", and no tri-state value expresses "only INBOX". One
+  caution for that design — `prompt` must never become a way to approve a scope
+  violation interactively, which would move enforcement back inside relay.
+
+## See also
+
+- ADR-006 — "service-specific knowledge lives in services, not in relay", the
+  constraint decision 3 answers to and finding 7 shows relay bending.
+- ADR-007 — the permission model this extends; the confused-deputy shape
+  decision 5 declines to reintroduce.
+- ADR-008 — the audit chokepoint, and the outcome enum decision 7 declines to
+  extend.
+- ADR-009 — decision 3 is the `allowed_dirs` trap decision 4 generalises;
+  decision 4 is the wildcard reasoning decision 3 reuses to drop the keyword.
+- ADR-010 — decision 3 for the enrolment/grant split decision 1 relies on,
+  decision 7 for the `denied`/`tool_error`/`throttled` distinction.
+- `relay/settings.go` — `SyncProjectToken`, `ValidateProjectGrants`,
+  `schemaHasField`.
+- `relay/router.go` — `checkToolAccess`, `mergeProjectID`, `ListTools`.
+- `relay/mcp/types.go` — `Tool.Annotations`, carried and unread.
+- `relay/project_apply.go` — the DTOs that carry no `context` today.
+- `macMCP/Sources/macMCP/main.swift` — `initialize`, and the `tools/call`
+  dispatch that drops `_meta`.
+- `macMCP/Sources/macMCP/Services/MailService.swift` — `resolveTargets`,
+  `fmInScope`, `mailboxInAccountJXA`, `senderJXA`, `MailCall`.
+- `fsmcp/src/security.ts` — the fail-open empty case.

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -174,7 +174,7 @@ paid in the UI, not in the model.
 **This decision is the one most worth overruling**, and it is cheap to reverse:
 it changes naming and the UI, not the enforcement path.
 
-### 2. Authority has three layers, and relay enforces the two it can verify
+### 2. Authority has four layers, and relay decides three of them
 
 For each `(profile, MCP)` pair:
 

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -490,32 +490,6 @@ generated `SKILL.md`. It is unreachable from a remote client by construction —
 that dispatch table is `ListTools` and `CallTool` and nothing else — and it
 sits behind the same admin authentication as the other project routes.
 
-**Three failures, not one.** An MCP can fail to enumerate in ways whose right
-answers differ, and collapsing them produces a UI that lies. `-32601` means the
-server does not implement the method: degrade to text entry, silently and
-permanently for that MCP, because a retry button in front of a method that does
-not exist is noise. `-32602` means relay asked for a field the MCP will not
-enumerate — relay is meant to ask only for fields declaring `enumerable: true`,
-so that is a **relay** bug and is surfaced rather than degraded away. Everything
-else — another code (macMCP answers in the `-32000..-32099` implementation-defined
-range when Mail will not answer), a transport failure, a timeout, a malformed
-result — is "could not answer right now": retryable, with text entry still there
-so an operator is never blocked.
-
-**And an empty list is an answer.** `values: []` means there are none;
-`values: null` means nobody could look. Rendering the second as the first tells
-an operator there are no mailboxes on a machine full of them, and the profile
-they save on the strength of it confines nothing they intended. That is the
-single sharpest edge in this decision and both the wire format and the picker
-are shaped around it.
-
-**A value already stored that is no longer offered stays visible and stays
-selected**, flagged as unrecognised. An account renamed on the host must not
-quietly widen or narrow a profile by disappearing from a form — a value that
-vanishes from the editor is a value the next save deletes. This falls out of
-the picker being a control over the same stored value the text box edits,
-rather than a separate representation that has to be reconciled with it.
-
 **A raw JSON editor is the fallback, not the plan.** The owner offered one as a
 first draft. It is retained for MCPs that do not implement `context/enumerate`,
 and for those it is the honest surface. Where the MCP *can* enumerate, a

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -93,9 +93,16 @@ Findings 2–8 restate issue #16's, re-verified; findings 1 and 9 are new.
    More importantly it is the *wrong rule*: it encodes "filesystem" where it
    means "derived from the project's path".
 
-8. **The one enforcing MCP fails open on empty.** `validatePath`
-   (`fsmcp/src/security.ts:13`): `if (allowedDirs.length === 0) return null; //
-   no restrictions`.
+8. **The one enforcing MCP fails open on empty, and separately escapes its own
+   bound.** `validatePath` (`fsmcp/src/security.ts:13`): `if
+   (allowedDirs.length === 0) return null; // no restrictions`. And its
+   `realpath`-with-lexical-fallback resolution lets a symlink inside an allowed
+   directory escape it whenever the target does not exist yet — which for
+   `fs_write` creating a file is the normal case. Confirmed against the shipped
+   build: a write to `<allowed>/link/new.txt` reports success and lands outside.
+   Two further fail-open shapes were found alongside the first: `fs_glob` and
+   `fs_grep` fell back to `process.cwd()` when `path` was omitted, bypassing
+   `validatePath` altogether. See decision 10.
 
 9. **`disabled_tools` is a denylist, so it fails open twice over.** Granting
    `macmcp` grants all 47 tools minus whatever was enumerated *at grant time*.
@@ -360,6 +367,14 @@ field omitted while the grant stands.
 and with `wildcard` dropped it is not expressible at all — it is spelled by
 enumerating, or by not granting the MCP.
 
+**What the MCP cannot tell is *who* mediated.** `_meta` present means some
+client sent it, not that relay did. Any MCP client that sends `_meta` for its
+own reasons therefore loses every governed tool. That is the fail-closed
+direction and is accepted, but it is a compatibility surface rather than a
+relay-only rule, and it is the reason this test belongs to the MCP: an MCP that
+tried to identify relay specifically would be trusting a caller's assertion
+about its own identity, which is the thing neither side may do.
+
 **Presence is re-checked at call time**, in `CallTool`, against the MCP's
 *live* schema, and a missing value is `denied`. This is the third defence and
 the only one *in relay* that catches an MCP which grows a scope field *after* a
@@ -517,6 +532,69 @@ on disk — never a client's own report of success. That standard is inherited:
 ADR-010's client passed 95 tests and an adversarial review while its primary
 interface was broken, because nobody had executed the string the generator
 printed.
+
+### 10. Two seams that are not in the list, and one reference implementation that was wrong
+
+Both were found while building the enforcement, not while writing this ADR, and
+neither is a mail-specific accident — each is a shape any scoping MCP will have.
+
+**A cache is a seam.** macMCP holds a fetched message source for 60 seconds
+keyed on the message id and account. A cache hit returns bytes *without running
+the script*, and the script is where the scope is checked — so a second,
+differently-confined caller reaching the same process is served a message it
+may not read, with nothing having decided that. The confinement is therefore
+part of the cache key, with unscoped as its own bucket. Generally: **any
+memoisation of a scope-governed result must be keyed on the scope**, and the
+quietest bypass in this design is the one where no check runs at all.
+
+**A path that does not exist yet is the dangerous one.** The obvious
+implementation of a directory bound resolves symlinks with `realpath` and falls
+back to a lexical resolve when the path is absent — and for a tool whose job is
+*creating* a file, absent is the normal case. A symlink inside the allowed
+directory then escapes it, because the lexical resolve keeps the symlink in the
+string and the prefix check passes.
+
+This ADR named fsMCP's `validatePath` as the reference implementation for that
+comparison. **That was wrong and it is withdrawn.** fsMCP has exactly this bug,
+confirmed against the shipped build: `fs_write` to `<allowed>/link/new.txt`,
+where `link` points outside, reports success and writes outside. Resolution
+must be **component by component**, following symlinks in the existing prefix
+and carrying the not-yet-existing tail lexically. fsMCP is being fixed
+separately; the correct reference is macMCP's `resolvedForContainment`.
+
+A check-then-use of a path is still racy in principle. Whether that matters
+depends on who can create a symlink inside an allowed directory — if that is
+only the same user who already runs the MCP, it is not a new capability, and
+write-time enforcement (`O_NOFOLLOW`) is the answer if it ever becomes one.
+
+### 11. Three rulings on what a refusal says
+
+**A found-but-out-of-scope message is a refusal, not a "not found".** Because
+`byId` resolves globally, the id of a message in another account is a valid
+handle, so the MCP knows the difference and has to choose which to say. Saying
+"not found" is indistinguishable from a real miss and leaves an operator with
+nothing to debug; saying "out of scope" discloses that *some* message holds
+that id. The disclosure is real and is accepted: it is bounded by ADR-010's
+per-enrolment budget, which makes id-space enumeration impractical, and the
+refusal never names the account or mailbox the message is actually in. This is
+the same reasoning the reconciliation rule uses to refuse rather than silently
+narrow.
+
+**A scope naming a mailbox that does not exist is an error and NOT a
+violation.** The two are different events with different audiences: a violation
+is a client probing a boundary and belongs in alerting; a nonexistent mailbox is
+an operator typo and belongs in the editor. Conflating them would fill a
+security signal with configuration mistakes. Note this used to be silent —
+`total_messages: 0` with `scan_complete: true`, an affirmative claim of
+emptiness about a mailbox that was never there.
+
+**A tool's bookkeeping about the message it just wrote is not a read of the
+user's mail.** macMCP's compose path sweeps the sending account's Drafts for
+the copy Mail autosaves behind its back, and does so regardless of
+`mail_mailboxes`. It matches only ids absent before the compose began that
+carry this message's subject, so it can surface nothing but the client's own
+message. Scoping it would break the sweep and protect nothing. The account it
+runs in is already scope-checked by the sender guard.
 
 ## The reconciliation rule the MCP implements
 

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -689,6 +689,28 @@ carry this message's subject, so it can surface nothing but the client's own
 message. Scoping it would break the sweep and protect nothing. The account it
 runs in is already scope-checked by the sender guard.
 
+### 12. Two controls a profile can hold and cannot use are refused
+
+`permission_policy` and `chat_templates` were the last two fields a remote-kind
+record could carry that do nothing on one. A permission policy is a set of
+Claude CLI gates on a session; a chat template is a preset for starting one. An
+access profile launches no session — it has no path to launch in, and
+`resolvePtyEnv` and `resolveProjectTemplate` both refuse a remote record
+outright — so both are inert, and ADR-009 decision 2's rule applies: refusing an
+inert control at the door is more honest than shipping one that quietly no-ops.
+It is the same argument that already removes the path, the skill toggle, the
+shell templates, the model allowlist and directory auth. A `default_mode` of
+`bypassPermissions` sitting on a profile is the worst of it: it reads as a
+widening that never happens and cannot be reasoned about from the record alone.
+
+Two details make the refusal usable rather than a wall. An **empty** policy is
+not a policy — the update path already reads one as "clear it", so refusing on
+it would refuse the very request that clears one. And an existing local project
+carrying either can still be **converted**, by clearing them in the same
+request, exactly as `disabled_tools` is handled
+(`TestProjectConvertLocalToRemote_CannotInheritFilesystemScope`). The editor
+stops calling them "inert" and says what saving will do instead.
+
 ## The reconciliation rule the MCP implements
 
 Stated once, here, so every scoping MCP implements it identically:

--- a/docs/decisions/011-resource-scope.md
+++ b/docs/decisions/011-resource-scope.md
@@ -208,7 +208,13 @@ about a client.
 
 **`access` is enforced in `checkToolAccess` and fails closed.** A tool is
 admitted to a `read` profile only if its `annotations.readOnlyHint` is
-explicitly `true`. Absent, malformed, or `false` all mean *mutating*. This is
+explicitly `true`, **under that exact spelling**. Absent, malformed, `false`,
+or a case variant all mean *mutating* — the hint is read out of a map rather
+than decoded into a struct, because `encoding/json` matches struct fields
+case-insensitively and `{"ReadOnlyHint": true}` admitted a tool to a read
+profile under a key the MCP specification does not define. The whole claim of
+this decision is that the mode is decided from a declaration an operator can
+read and diff, which a near-miss key is not. This is
 the rule that makes finding 9 safe: a tool added to an MCP after a grant was
 written is denied to every read-only profile until someone annotates it, rather
 than silently granted.

--- a/enrol_cmd.go
+++ b/enrol_cmd.go
@@ -26,7 +26,11 @@ func enrolCreate(store SettingsStore, args []string) {
 	fs := flag.NewFlagSet("enrol create", flag.ExitOnError)
 	clientID := fs.String("client-id", "", "human-readable id for this enrolment (required, unique)")
 	var grants stringSlice
-	fs.Var(&grants, "grant", "project id this certificate may use (repeatable); every grant must name a remote-kind project")
+	// ADR-011 decision 1: a remote-kind record is an ACCESS PROFILE in every
+	// operator-facing surface. It has no directory, no skills, no shell and no
+	// models, so calling it a project invites the reader to expect all four.
+	// The stored kind, and every Go identifier, is unchanged.
+	fs.Var(&grants, "grant", "access profile id this certificate may use (repeatable); a grant must name an access profile (a remote-kind record), never a local project")
 	windowSeconds := fs.Int("window-seconds", defaultEnrolmentWindowSeconds, "budget window in seconds")
 	maxCalls := fs.Int("max-calls", defaultEnrolmentMaxCalls, "max tool calls per window")
 	maxResultBytes := fs.Int64("max-result-bytes", defaultEnrolmentMaxResultBytes, "max cumulative result bytes per window")
@@ -40,7 +44,7 @@ func enrolCreate(store SettingsStore, args []string) {
 	// takes on an empty allowed_mcp_ids. Say so rather than silently emitting
 	// a certificate that can reach nothing.
 	if len(grants) == 0 {
-		fmt.Println("note: no --grant given; this client is enrolled but can reach no project until one is added")
+		fmt.Println("note: no --grant given; this client is enrolled but can reach no access profile until one is added")
 	}
 
 	bundle, err := createEnrolment(store, enrolmentRequest{
@@ -59,7 +63,7 @@ func enrolCreate(store SettingsStore, args []string) {
 	e := bundle.Enrolment
 	fmt.Printf("enrolled %q\n", e.ClientID)
 	fmt.Printf("  fingerprint: %s\n", e.Fingerprint)
-	fmt.Printf("  grants:      %s\n", formatGrants(e.ProjectIDs))
+	fmt.Printf("  profiles:    %s\n", formatGrants(e.ProjectIDs))
 	fmt.Printf("  budget:      %d calls / %d bytes per %ds\n", e.Budget.MaxCalls, e.Budget.MaxResultBytes, e.Budget.WindowSeconds)
 	fmt.Printf("  bundle:      %s\n", bundle.Dir)
 	fmt.Println("    client.key  client private key (0600)")
@@ -81,7 +85,7 @@ func enrolList(store SettingsStore) {
 	}
 
 	w := newTabWriter()
-	fmt.Fprintln(w, "CLIENT ID\tGRANTS\tCALLS/WINDOW\tBYTES/WINDOW\tCREATED\tFINGERPRINT")
+	fmt.Fprintln(w, "CLIENT ID\tPROFILES\tCALLS/WINDOW\tBYTES/WINDOW\tCREATED\tFINGERPRINT")
 	for _, e := range s.Enrolments {
 		// The fingerprint prints in full. It is the last column precisely so
 		// that showing all 64 hex characters costs nothing in readability —
@@ -113,7 +117,7 @@ func enrolRevoke(store SettingsStore, args []string) {
 
 	fmt.Printf("revoked enrolment %q\n", removed.ClientID)
 	fmt.Printf("  fingerprint: %s\n", removed.Fingerprint)
-	fmt.Println("  the certificate itself is unchanged and no project was touched; the record is what granted it access")
+	fmt.Println("  the certificate itself is unchanged and no access profile was touched; the record is what granted it access")
 }
 
 // formatGrants renders a grant list for CLI output, distinguishing "enrolled

--- a/enrolment.go
+++ b/enrolment.go
@@ -194,10 +194,10 @@ func (s *Settings) ValidateEnrolmentGrants(e *Enrolment) error {
 	for _, id := range e.ProjectIDs {
 		proj, _ := s.findProjectByID(id)
 		if proj == nil {
-			return fmt.Errorf("enrolment %q cannot grant unknown project %q", e.ClientID, id)
+			return fmt.Errorf("enrolment %q cannot grant unknown access profile %q", e.ClientID, id)
 		}
 		if !proj.IsRemote() {
-			return fmt.Errorf("enrolment %q cannot grant project %q (%s): it is a local project, and a remote client granted one would inherit its host directory scope — only remote-kind projects may be enrolled", e.ClientID, id, proj.Name)
+			return fmt.Errorf("enrolment %q cannot grant %q (%s): it is a local project, not an access profile, and a remote client granted one would inherit its host directory scope — only access profiles may be enrolled", e.ClientID, id, proj.Name)
 		}
 	}
 	return nil
@@ -226,7 +226,7 @@ func (s *Settings) ValidateProjectEnrolments(proj *Project) error {
 	if len(holders) == 0 {
 		return nil
 	}
-	return fmt.Errorf("project %q cannot become a local project while enrolled clients grant it: %s — revoke those enrolments or drop the grant first", proj.ID, strings.Join(holders, ", "))
+	return fmt.Errorf("access profile %q cannot become a local project while enrolled clients grant it: %s — revoke those enrolments or drop the grant first", proj.ID, strings.Join(holders, ", "))
 }
 
 // ---------------------------------------------------------------------------

--- a/enrolment_test.go
+++ b/enrolment_test.go
@@ -255,7 +255,7 @@ func TestProjectConvertRemoteToLocal_RefusedWhileEnrolled(t *testing.T) {
 		Fingerprint: "sha256:" + strings.Repeat("a", 64),
 		ProjectIDs:  []string{mail.ID},
 	})
-	schemas := func() map[string]json.RawMessage { return nil }
+	schemas := func() McpSurfaces { return nil }
 
 	local := ProjectKindLocal
 	path := t.TempDir()

--- a/external_mcp.go
+++ b/external_mcp.go
@@ -64,7 +64,14 @@ type ExternalMcpManager struct {
 	conns          map[string]McpConnection
 	schemas        map[string]json.RawMessage // id → context schema (runtime-only)
 	schemaVersions map[string]int             // id → contextSchemaVersion (runtime-only)
-	onTokenRefresh OnTokenRefreshFunc
+	// enumUnsupported latches the MCPs that answered -32601 to
+	// context/enumerate, so the operator UI degrades to text entry once
+	// rather than re-asking on every panel open (context_enumerate.go).
+	// Scoped to the CONNECTION, not to the settings entry: it is cleared on
+	// Stop and on a fresh handshake, because a reconnect can be a new build
+	// that now implements the method.
+	enumUnsupported map[string]bool
+	onTokenRefresh  OnTokenRefreshFunc
 }
 
 // pendingResponse holds a channel for delivering a JSON-RPC response to a waiting caller.
@@ -288,10 +295,11 @@ func extractContextSchema(initResp json.RawMessage) (json.RawMessage, int) {
 // token refresh persistence. This keeps the manager decoupled from Settings.
 func NewExternalMcpManager(onTokenRefresh OnTokenRefreshFunc) *ExternalMcpManager {
 	return &ExternalMcpManager{
-		conns:          make(map[string]McpConnection),
-		schemas:        make(map[string]json.RawMessage),
-		schemaVersions: make(map[string]int),
-		onTokenRefresh: onTokenRefresh,
+		conns:           make(map[string]McpConnection),
+		schemas:         make(map[string]json.RawMessage),
+		schemaVersions:  make(map[string]int),
+		enumUnsupported: make(map[string]bool),
+		onTokenRefresh:  onTokenRefresh,
 	}
 }
 
@@ -316,6 +324,11 @@ func (m *ExternalMcpManager) setConnection(id string, conn McpConnection) {
 func (m *ExternalMcpManager) finalizeConnection(id string, conn McpConnection, result *handshakeResult) {
 	m.setConnection(id, conn)
 	conn.SetTools(result.Tools)
+	// A new process gets asked about context/enumerate again: the previous
+	// one's -32601 was a fact about a build, not about the MCP's id.
+	m.mu.Lock()
+	delete(m.enumUnsupported, id)
+	m.mu.Unlock()
 	if len(result.ContextSchema) > 0 {
 		m.mu.Lock()
 		m.schemas[id] = result.ContextSchema
@@ -692,6 +705,7 @@ func (m *ExternalMcpManager) Stop(id string) {
 		delete(m.conns, id)
 	}
 	delete(m.schemas, id)
+	delete(m.enumUnsupported, id)
 	m.mu.Unlock()
 
 	if ok {
@@ -707,6 +721,7 @@ func (m *ExternalMcpManager) StopAll() {
 	m.conns = make(map[string]McpConnection)
 	m.schemas = make(map[string]json.RawMessage)
 	m.schemaVersions = make(map[string]int)
+	m.enumUnsupported = make(map[string]bool)
 	m.mu.Unlock()
 
 	var wg sync.WaitGroup

--- a/external_mcp.go
+++ b/external_mcp.go
@@ -63,6 +63,7 @@ type ExternalMcpManager struct {
 	mu             sync.RWMutex
 	conns          map[string]McpConnection
 	schemas        map[string]json.RawMessage // id → context schema (runtime-only)
+	schemaVersions map[string]int             // id → contextSchemaVersion (runtime-only)
 	onTokenRefresh OnTokenRefreshFunc
 }
 
@@ -200,9 +201,16 @@ func (c *externalMcpConn) routeNotification(line []byte) {
 
 // handshakeResult holds the results of an MCP initialize + tools/list sequence.
 type handshakeResult struct {
-	Tools         []mcp.Tool
-	ToolInfos     []ToolInfo
-	ContextSchema json.RawMessage
+	Tools     []mcp.Tool
+	ToolInfos []ToolInfo
+	// ContextSchema and ContextSchemaVersion are read from the SAME serverInfo
+	// object and are stored together everywhere after this, because the
+	// version is what decides how the schema is read at all: absent or < 2 is
+	// v1, handled exactly as it was before ADR-011. A schema that arrived
+	// without its version would silently be read as v1 and every scope
+	// keyword in it ignored — fail-open, which is why they never travel apart.
+	ContextSchema        json.RawMessage
+	ContextSchemaVersion int
 }
 
 // mcpHandshake performs the MCP initialize -> notifications/initialized -> tools/list
@@ -221,7 +229,7 @@ func mcpHandshake(ctx context.Context, conn McpConnection) (*handshakeResult, er
 		return nil, fmt.Errorf("MCP handshake failed: %w", err)
 	}
 
-	contextSchema := extractContextSchema(initResp)
+	contextSchema, contextSchemaVersion := extractContextSchema(initResp)
 	conn.SendNotification(mcp.MethodInitialized)
 
 	resp, err := conn.SendRequest(ctx, mcp.MethodToolsList, nil)
@@ -246,26 +254,34 @@ func mcpHandshake(ctx context.Context, conn McpConnection) (*handshakeResult, er
 	}
 
 	return &handshakeResult{
-		Tools:         toolsResult.Tools,
-		ToolInfos:     toolInfos,
-		ContextSchema: contextSchema,
+		Tools:                toolsResult.Tools,
+		ToolInfos:            toolInfos,
+		ContextSchema:        contextSchema,
+		ContextSchemaVersion: contextSchemaVersion,
 	}, nil
 }
 
-// extractContextSchema pulls the contextSchema from an initialize response.
-func extractContextSchema(initResp json.RawMessage) json.RawMessage {
+// extractContextSchema pulls the contextSchema and its declared version from
+// an initialize response. Both live in serverInfo, beside name and version.
+//
+// A version of 0 (absent, or not a number) means v1 — the schema is read the
+// way it always was, allowed_dirs branch included, for one release. It is
+// returned even when the schema itself is absent so a caller can tell an MCP
+// that declared nothing from one that declared a v2 vocabulary and no fields.
+func extractContextSchema(initResp json.RawMessage) (json.RawMessage, int) {
 	if initResp == nil {
-		return nil
+		return nil, 0
 	}
 	var result struct {
 		ServerInfo struct {
-			ContextSchema json.RawMessage `json:"contextSchema,omitempty"`
+			ContextSchema        json.RawMessage `json:"contextSchema,omitempty"`
+			ContextSchemaVersion int             `json:"contextSchemaVersion,omitempty"`
 		} `json:"serverInfo"`
 	}
 	if err := json.Unmarshal(initResp, &result); err == nil && len(result.ServerInfo.ContextSchema) > 0 {
-		return result.ServerInfo.ContextSchema
+		return result.ServerInfo.ContextSchema, result.ServerInfo.ContextSchemaVersion
 	}
-	return nil
+	return nil, 0
 }
 
 // NewExternalMcpManager creates a manager with an injected callback for OAuth
@@ -274,6 +290,7 @@ func NewExternalMcpManager(onTokenRefresh OnTokenRefreshFunc) *ExternalMcpManage
 	return &ExternalMcpManager{
 		conns:          make(map[string]McpConnection),
 		schemas:        make(map[string]json.RawMessage),
+		schemaVersions: make(map[string]int),
 		onTokenRefresh: onTokenRefresh,
 	}
 }
@@ -302,7 +319,17 @@ func (m *ExternalMcpManager) finalizeConnection(id string, conn McpConnection, r
 	if len(result.ContextSchema) > 0 {
 		m.mu.Lock()
 		m.schemas[id] = result.ContextSchema
+		m.schemaVersions[id] = result.ContextSchemaVersion
 		m.mu.Unlock()
+		if result.ContextSchemaVersion < contextSchemaV2 {
+			// One line per connection, not per derivation: the v1 branch is
+			// scheduled for removal one release after every MCP relay serves
+			// declares v2, and this is what makes the remaining ones visible.
+			slog.Warn("MCP declares a v1 context schema (deprecated)",
+				"id", id,
+				"want_version", contextSchemaV2,
+				"detail", "relay falls back to the literal allowed_dirs rule; declare contextSchemaVersion 2 with scope/source/applies_to keywords (docs/context-schema.md)")
+		}
 	}
 	slog.Info("MCP connected", "id", id, "tools", len(result.Tools))
 }
@@ -480,15 +507,72 @@ func (m *ExternalMcpManager) GetContextSchema(id string) json.RawMessage {
 	return m.schemas[id]
 }
 
-// AllContextSchemas returns a snapshot copy of all known MCP context schemas,
-// keyed by MCP ID. Used by the project routes when (re)scoping a project's
-// token across every allowed MCP.
-func (m *ExternalMcpManager) AllContextSchemas() map[string]json.RawMessage {
+// AllMcpSurfaces returns a snapshot of everything relay knows at runtime about
+// each connected MCP: its context schema, that schema's version, and the tools
+// it currently exposes. Used by the project routes when (re)scoping a
+// project's token and when validating its grants across every allowed MCP.
+//
+// The tool list is part of the snapshot because ADR-011 decision 5's question
+// — would this grant leave the MCP with no usable tools — cannot be answered
+// from a schema alone: a field's applies_to has to be measured against the
+// tools that exist.
+func (m *ExternalMcpManager) AllMcpSurfaces() McpSurfaces {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-	out := make(map[string]json.RawMessage, len(m.schemas))
-	for id, schema := range m.schemas {
-		out[id] = schema
+	ids := make([]string, 0, len(m.conns)+len(m.schemas))
+	seen := make(map[string]bool, len(m.conns)+len(m.schemas))
+	for id := range m.schemas {
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	for id := range m.conns {
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	out := make(McpSurfaces, len(ids))
+	for _, id := range ids {
+		out[id] = McpSurface{Schema: m.schemas[id], SchemaVersion: m.schemaVersions[id]}
+	}
+	conns := make(map[string]McpConnection, len(m.conns))
+	for id, c := range m.conns {
+		conns[id] = c
+	}
+	m.mu.RUnlock()
+
+	// GetTools takes the connection's own lock, so it is called outside m.mu
+	// to keep the lock order (m.mu -> toolsMu) the one FindToolOwner and Tools
+	// already establish.
+	for id, c := range conns {
+		s := out[id]
+		s.Tools = toolNames(c.GetTools())
+		out[id] = s
+	}
+	return out
+}
+
+// McpSurfaceFor returns the runtime surface for one MCP.
+func (m *ExternalMcpManager) McpSurfaceFor(id string) McpSurface {
+	m.mu.RLock()
+	surface := McpSurface{Schema: m.schemas[id], SchemaVersion: m.schemaVersions[id]}
+	conn := m.conns[id]
+	m.mu.RUnlock()
+	if conn != nil {
+		surface.Tools = toolNames(conn.GetTools())
+	}
+	return surface
+}
+
+// toolNames projects a tool list down to its names.
+func toolNames(tools []mcp.Tool) []string {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, t.Name)
 	}
 	return out
 }
@@ -622,6 +706,7 @@ func (m *ExternalMcpManager) StopAll() {
 	conns := m.conns
 	m.conns = make(map[string]McpConnection)
 	m.schemas = make(map[string]json.RawMessage)
+	m.schemaVersions = make(map[string]int)
 	m.mu.Unlock()
 
 	var wg sync.WaitGroup
@@ -645,6 +730,7 @@ func discoverMcp(ctx context.Context, conn McpConnection, base ExternalMcp) (*Ex
 	}
 	base.DiscoveredTools = result.ToolInfos
 	base.ContextSchema = result.ContextSchema
+	base.ContextSchemaVersion = result.ContextSchemaVersion
 	return &base, nil
 }
 

--- a/external_mcp_test.go
+++ b/external_mcp_test.go
@@ -195,22 +195,28 @@ func TestMcpHandshake_ContextSchemaExtracted(t *testing.T) {
 
 func TestExtractContextSchema(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    json.RawMessage
-		wantNil  bool
-		wantType string // expected "type" field if non-nil
+		name        string
+		input       json.RawMessage
+		wantNil     bool
+		wantType    string // expected "type" field if non-nil
+		wantVersion int
 	}{
-		{"nil input", nil, true, ""},
-		{"valid with schema", json.RawMessage(`{"serverInfo":{"name":"test","contextSchema":{"type":"object","properties":{"dirs":{"type":"array"}}}}}`), false, "object"},
-		{"no contextSchema", json.RawMessage(`{"serverInfo":{"name":"test","version":"1.0"}}`), true, ""},
-		{"malformed JSON", json.RawMessage(`{not valid json`), true, ""},
-		{"empty serverInfo", json.RawMessage(`{"serverInfo":{}}`), true, ""},
-		{"no serverInfo", json.RawMessage(`{"protocolVersion":"2024-11-05"}`), true, ""},
+		{"nil input", nil, true, "", 0},
+		{"valid with schema", json.RawMessage(`{"serverInfo":{"name":"test","contextSchema":{"type":"object","properties":{"dirs":{"type":"array"}}}}}`), false, "object", 0},
+		{"v2 version carried", json.RawMessage(`{"serverInfo":{"name":"test","contextSchemaVersion":2,"contextSchema":{"type":"object"}}}`), false, "object", 2},
+		{"no contextSchema", json.RawMessage(`{"serverInfo":{"name":"test","version":"1.0"}}`), true, "", 0},
+		{"version without schema is still v1-shaped nothing", json.RawMessage(`{"serverInfo":{"name":"test","contextSchemaVersion":2}}`), true, "", 0},
+		{"malformed JSON", json.RawMessage(`{not valid json`), true, "", 0},
+		{"empty serverInfo", json.RawMessage(`{"serverInfo":{}}`), true, "", 0},
+		{"no serverInfo", json.RawMessage(`{"protocolVersion":"2024-11-05"}`), true, "", 0},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := extractContextSchema(tc.input)
+			result, version := extractContextSchema(tc.input)
+			if version != tc.wantVersion {
+				t.Errorf("expected version %d, got %d", tc.wantVersion, version)
+			}
 			if tc.wantNil {
 				if result != nil {
 					t.Errorf("expected nil, got %s", string(result))

--- a/frontend_server.go
+++ b/frontend_server.go
@@ -42,7 +42,7 @@ type FrontendServer struct {
 // relay-internal endpoints (project routes). It reads from the enhanced-
 // services registry to pick a target service per request — no hardcoded
 // per-service handlers live here.
-func NewFrontendServer(store SettingsStore, mcps ContextSchemasProvider, tools MCPToolsProvider, frontend Endpoint, enhanced *EnhancedServiceRegistry, skillLister SkillLister, onProjectsChanged ProjectsChangedFn) (*FrontendServer, error) {
+func NewFrontendServer(store SettingsStore, mcps McpSurfaceProvider, tools MCPToolsProvider, frontend Endpoint, enhanced *EnhancedServiceRegistry, skillLister SkillLister, onProjectsChanged ProjectsChangedFn) (*FrontendServer, error) {
 	if frontend.Socket == "" {
 		return nil, errors.New("frontend socket path is empty")
 	}

--- a/frontend_server.go
+++ b/frontend_server.go
@@ -35,6 +35,11 @@ type FrontendServer struct {
 // tools enumerates the live MCP tool list for the project-picker UI; nil
 // makes the GET /api/mcps/{id}/tools endpoint return 503.
 //
+// enum asks a connected MCP for a scope field's real values (ADR-011
+// decision 6). It rides on this server rather than on any other because the
+// answer is disclosure — every mail account on the host — and this is the
+// admin-authenticated surface.
+//
 // onProjectsChanged fires after every successful project mutation so the
 // tray Settings webview can rebuild its state; nil suppresses fan-out.
 //
@@ -42,7 +47,7 @@ type FrontendServer struct {
 // relay-internal endpoints (project routes). It reads from the enhanced-
 // services registry to pick a target service per request — no hardcoded
 // per-service handlers live here.
-func NewFrontendServer(store SettingsStore, mcps McpSurfaceProvider, tools MCPToolsProvider, frontend Endpoint, enhanced *EnhancedServiceRegistry, skillLister SkillLister, onProjectsChanged ProjectsChangedFn) (*FrontendServer, error) {
+func NewFrontendServer(store SettingsStore, mcps McpSurfaceProvider, tools MCPToolsProvider, enum ContextEnumerator, frontend Endpoint, enhanced *EnhancedServiceRegistry, skillLister SkillLister, onProjectsChanged ProjectsChangedFn) (*FrontendServer, error) {
 	if frontend.Socket == "" {
 		return nil, errors.New("frontend socket path is empty")
 	}
@@ -51,7 +56,7 @@ func NewFrontendServer(store SettingsStore, mcps McpSurfaceProvider, tools MCPTo
 	}
 
 	mux := http.NewServeMux()
-	RegisterProjectRoutes(mux, store, mcps, tools, skillLister, onProjectsChanged)
+	RegisterProjectRoutes(mux, store, mcps, tools, enum, skillLister, onProjectsChanged)
 
 	// Catch-all dispatcher: any path not matched by a more specific handler
 	// (project routes above) is resolved against the manifest registry and

--- a/frontend_server_test.go
+++ b/frontend_server_test.go
@@ -33,6 +33,7 @@ func newTestFrontendServer(t *testing.T, token string) (*FrontendServer, string)
 		store,
 		extMgr,
 		extMgr,
+		extMgr,
 		Endpoint{Socket: sock, Token: token},
 		enhanced,
 		nil,

--- a/frontend_server_ws_test.go
+++ b/frontend_server_ws_test.go
@@ -31,7 +31,7 @@ func startFrontendServerWith(t *testing.T, token string, enhanced *EnhancedServi
 		t.Fatalf("EnsureInitialized: %v", err)
 	}
 	extMgr := NewExternalMcpManager(nil)
-	srv, err := NewFrontendServer(store, extMgr, extMgr, Endpoint{Socket: sock, Token: token}, enhanced, nil, nil)
+	srv, err := NewFrontendServer(store, extMgr, extMgr, extMgr, Endpoint{Socket: sock, Token: token}, enhanced, nil, nil)
 	if err != nil {
 		t.Fatalf("NewFrontendServer: %v", err)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -66,14 +66,42 @@ func marshalForUI(v interface{}) json.RawMessage {
 	return json.RawMessage(data)
 }
 
+// mcpRPCError is the error every transport returns when an external MCP
+// answers with a JSON-RPC error object, carrying the CODE alongside the
+// rendered text.
+//
+// The code has to survive the trip because a caller can be required to act
+// differently on different ones: context/enumerate must tell -32601 ("this MCP
+// does not implement enumeration" — degrade permanently) from -32602 ("relay
+// asked for a field it should not have" — a relay bug, surface it) from
+// everything else ("could not answer right now" — offer a retry), and doing
+// that by matching on the message text is how the three quietly become one.
+//
+// It is deliberately NOT jsonrpc.CodedError. That type means "this is the code
+// relay's own listener should answer its caller with" (bridge/frameconn.go
+// reads it that way), and an external MCP's -32001 is not relay's -32001 —
+// promoting one to the other would let an MCP dictate how relay's own access
+// denials read.
+type mcpRPCError struct {
+	Code    int
+	Message string
+	Data    interface{}
+}
+
+func (e *mcpRPCError) Error() string {
+	if e.Data != nil {
+		return fmt.Sprintf("JSON-RPC error %d: %s (data: %v)", e.Code, e.Message, e.Data)
+	}
+	return fmt.Sprintf("JSON-RPC error %d: %s", e.Code, e.Message)
+}
+
 // formatJSONRPCError formats a JSON-RPC error response into a Go error.
 // Includes the Data field when present so diagnostic details from external
-// MCPs are not silently discarded.
+// MCPs are not silently discarded. The text is unchanged from when this
+// returned a bare fmt.Errorf; what is new is that the code is recoverable with
+// errors.As (see mcpRPCError).
 func formatJSONRPCError(e *jsonrpc.Error) error {
-	if e.Data != nil {
-		return fmt.Errorf("JSON-RPC error %d: %s (data: %v)", e.Code, e.Message, e.Data)
-	}
-	return fmt.Errorf("JSON-RPC error %d: %s", e.Code, e.Message)
+	return &mcpRPCError{Code: e.Code, Message: e.Message, Data: e.Data}
 }
 
 // formatBytes renders a byte count for display in the tray menu's aux column.

--- a/ipc_enrolments_test.go
+++ b/ipc_enrolments_test.go
@@ -463,7 +463,7 @@ func TestRenderSettingsHTML_SeedsEnrolmentsAndRemoteBlock(t *testing.T) {
 	})
 
 	s := store.Get()
-	html := renderSettingsHTML(s, nil, nil)
+	html := renderSettingsHTML(s, nil, nil, nil)
 	fingerprint := s.Enrolments[0].Fingerprint
 
 	for _, want := range []string{"hermes-mail", fingerprint, `"configured":true`, `"listen":"127.0.0.1:9910"`} {
@@ -488,7 +488,7 @@ func TestRenderSettingsHTML_SeedsEnrolmentsAndRemoteBlock(t *testing.T) {
 // the same reason.)
 func TestRenderSettingsHTML_LeavesNoUnsubstitutedPlaceholder(t *testing.T) {
 	_, store := newEnrolmentSandbox(t)
-	html := renderSettingsHTML(store.Get(), nil, nil)
+	html := renderSettingsHTML(store.Get(), nil, nil, nil)
 	if left := regexp.MustCompile(`__[A-Z0-9_]+_JSON__`).FindAllString(html, -1); len(left) > 0 {
 		t.Fatalf("renderSettingsHTML left placeholders unsubstituted: %v", left)
 	}

--- a/ipc_handlers.go
+++ b/ipc_handlers.go
@@ -14,7 +14,7 @@ import (
 
 func (a *App) openSettingsWindow() {
 	s := a.store.Get()
-	html := renderSettingsHTML(s, a.registry.RunningIDs(), a.buildToolCache(s))
+	html := renderSettingsHTML(s, a.registry.RunningIDs(), a.buildToolCache(s), a.buildScopeFields())
 	a.platform.OpenSettings(html)
 	a.settingsOpen.Store(true)
 	// First paint shouldn't wait the full 2s poll interval. pushServiceStatusBatch
@@ -74,11 +74,12 @@ func (a *App) pushServiceStatus() {
 func (a *App) pushFullSettings() {
 	s := a.store.Get()
 	a.emitSettingsEvent("onSettingsReloaded", map[string]interface{}{
-		"external_mcps":  s.ExternalMcps,
-		"services":       s.Services,
-		"running_ids":    a.registry.RunningIDs(),
-		"projects":       s.Projects,
-		"mcp_tool_cache": a.buildToolCache(s),
+		"external_mcps":    s.ExternalMcps,
+		"services":         s.Services,
+		"running_ids":      a.registry.RunningIDs(),
+		"projects":         s.Projects,
+		"mcp_tool_cache":   a.buildToolCache(s),
+		"mcp_scope_fields": a.buildScopeFields(),
 		// Enrolments and the remote block ride along so the Remote Clients tab
 		// reflects an enrolment created or revoked by `relay enrol` while the
 		// window is open. The audit state comes from the live recorder rather
@@ -103,6 +104,15 @@ func (a *App) buildToolCache(s *Settings) map[string][]ToolInfo {
 		out[m.ID] = infos
 	}
 	return out
+}
+
+// buildScopeFields snapshots what each connected MCP declares as narrowable
+// (ADR-011 decision 6). Keyed by MCP id; an MCP that declares no restrict
+// fields gets an empty slice, and one relay has never connected to gets no key
+// at all — which is what lets the editor say "relay cannot see what this MCP
+// scopes" instead of "this MCP scopes nothing".
+func (a *App) buildScopeFields() map[string][]ScopeFieldView {
+	return a.extMgr.AllMcpSurfaces().ScopeFields()
 }
 
 // pushFullProjects sends only the projects slice. Used as the

--- a/ipc_handlers.go
+++ b/ipc_handlers.go
@@ -154,6 +154,12 @@ type IPCContext struct {
 	// picker. nil means "no tool data available" — handlers degrade by
 	// emitting empty lists rather than panicking.
 	Tools MCPToolsProvider
+	// Enumerate asks a connected MCP for a scope field's real values
+	// (ADR-011 decision 6), so the Projects tab can offer a picker instead of
+	// a box. nil means every enumeration answers "unavailable", which is the
+	// state the editor already has to render correctly — the text box is the
+	// fallback, so a missing provider costs nothing but the picker.
+	Enumerate ContextEnumerator
 	// SkillLister is the same interface skills.go uses; threaded here so the
 	// Regen Now button can run without re-importing *appRouter.
 	SkillLister SkillLister
@@ -269,6 +275,7 @@ const (
 	MsgRegenProjectSkill          = "regen_project_skill"
 	MsgUpdateProjectDisabledTools = "update_project_disabled_tools"
 	MsgListMcpTools               = "list_mcp_tools"
+	MsgEnumerateScopeField        = "enumerate_scope_field"
 
 	// Tool Calls / audit log (ipc_audit.go)
 	MsgQueryAudit     = "query_audit"
@@ -308,6 +315,7 @@ var ipcHandlers = map[string]func(*IPCContext, json.RawMessage){
 	MsgRegenProjectSkill:          ipcRegenProjectSkill,
 	MsgUpdateProjectDisabledTools: ipcUpdateProjectDisabledTools,
 	MsgListMcpTools:               ipcListMcpTools,
+	MsgEnumerateScopeField:        ipcEnumerateScopeField,
 
 	// Tool Calls (ipc_audit.go)
 	MsgQueryAudit:     ipcQueryAudit,

--- a/ipc_projects.go
+++ b/ipc_projects.go
@@ -52,7 +52,7 @@ func ipcCreateProject(ctx *IPCContext, raw json.RawMessage) {
 	var created Project
 	var createErr error
 	okSettings := ctx.withSettings(func(s *Settings) {
-		created, createErr = applyProjectCreate(s, *msg, mcpContextSchemasFrom(ctx))
+		created, createErr = applyProjectCreate(s, *msg, mcpSurfacesFrom(ctx))
 	})
 	if !okSettings {
 		return
@@ -93,8 +93,8 @@ func ipcUpdateProject(ctx *IPCContext, raw json.RawMessage) {
 	var found bool
 	var updateErr error
 	okSettings := ctx.withSettings(func(s *Settings) {
-		updated, found, updateErr = applyProjectUpdate(s, msg.ID, msg.projectUpdateFields, func() map[string]json.RawMessage {
-			return mcpContextSchemasFrom(ctx)
+		updated, found, updateErr = applyProjectUpdate(s, msg.ID, msg.projectUpdateFields, func() McpSurfaces {
+			return mcpSurfacesFrom(ctx)
 		})
 	})
 	if !okSettings {
@@ -270,14 +270,14 @@ func ipcListMcpTools(ctx *IPCContext, raw json.RawMessage) {
 	ctx.UI.EmitEvent("onMcpToolsListed", msg.McpID, marshalForUI(infos))
 }
 
-// mcpContextSchemasFrom returns the MCP context-schema map from the IPC
-// context's tool provider when it also implements ContextSchemasProvider
-// (the production *ExternalMcpManager satisfies both). In tests where Tools
-// is a narrow stub, returns nil and SyncProjectToken falls back to its
-// "no filesystem auto-detect" path.
-func mcpContextSchemasFrom(ctx *IPCContext) map[string]json.RawMessage {
-	if p, ok := ctx.Tools.(ContextSchemasProvider); ok {
-		return p.AllContextSchemas()
+// mcpSurfacesFrom returns the runtime MCP surfaces from the IPC context's
+// tool provider when it also implements McpSurfaceProvider (the production
+// *ExternalMcpManager satisfies both). In tests where Tools is a narrow stub,
+// returns nil and SyncProjectToken falls back to its "no scope derivation"
+// path.
+func mcpSurfacesFrom(ctx *IPCContext) McpSurfaces {
+	if p, ok := ctx.Tools.(McpSurfaceProvider); ok {
+		return p.AllMcpSurfaces()
 	}
 	return nil
 }

--- a/ipc_projects.go
+++ b/ipc_projects.go
@@ -32,6 +32,14 @@ type ipcListMcpToolsMsg struct {
 	McpID string `json:"mcp_id"`
 }
 
+// ipcEnumerateScopeFieldMsg mirrors the POST /api/mcps/{id}/enumerate body,
+// with the MCP id inline as every IPC message carries it.
+type ipcEnumerateScopeFieldMsg struct {
+	McpID  string                     `json:"mcp_id"`
+	Field  string                     `json:"field"`
+	Values map[string]json.RawMessage `json:"values,omitempty"`
+}
+
 // ipcCreateProject creates a new project, applies optional skill/policy, and
 // emits onProjectAdded with the full row (including the freshly-generated
 // plaintext token — the user copies it from the form's Token field).
@@ -268,6 +276,33 @@ func ipcListMcpTools(ctx *IPCContext, raw json.RawMessage) {
 		infos = []ToolInfo{}
 	}
 	ctx.UI.EmitEvent("onMcpToolsListed", msg.McpID, marshalForUI(infos))
+}
+
+// ipcEnumerateScopeField is the tray's half of ADR-011 decision 6, and the
+// exact counterpart of POST /api/mcps/{id}/enumerate: ADR-004 keeps the two
+// editors co-equal, and an editor that can only offer a picker over HTTP is
+// not co-equal with one that cannot.
+//
+// Both surfaces call enumerateScopeField, so every check relay makes on its
+// own — is this a field the MCP declared, did it declare it enumerable, which
+// dependency values may be sent — is made once and identically. The result is
+// emitted VERBATIM, including its status, because the whole point is that the
+// picker must render "no values" and "could not ask" differently.
+//
+// It runs off the UI thread: a context/enumerate is a live round trip to
+// another process, and blocking the main thread on one would freeze the whole
+// settings window for as long as the MCP takes.
+func ipcEnumerateScopeField(ctx *IPCContext, raw json.RawMessage) {
+	msg, ok := unmarshalIPC[ipcEnumerateScopeFieldMsg](raw, "enumerate_scope_field")
+	if !ok {
+		return
+	}
+	surfaces := mcpSurfacesFrom(ctx)
+	enum := ctx.Enumerate
+	ctx.GoFunc(func() {
+		res := enumerateScopeField(ctx.Ctx, surfaces, enum, msg.McpID, msg.Field, msg.Values)
+		dispatchEmit(ctx, "onScopeFieldEnumerated", marshalForUI(res))
+	})
 }
 
 // mcpSurfacesFrom returns the runtime MCP surfaces from the IPC context's

--- a/ipc_projects_test.go
+++ b/ipc_projects_test.go
@@ -23,6 +23,11 @@ import (
 // so a map-backed stub is plenty.
 type fakeTools struct {
 	infos map[string][]ToolInfo
+	// surfaces is what mcpSurfacesFrom hands to the apply layer. Nil (the
+	// default) means SyncProjectToken skips scope derivation, which is what
+	// every test predating ADR-011's operator path wants; a test that
+	// exercises a v2 contextSchema sets it.
+	surfaces McpSurfaces
 }
 
 func (f *fakeTools) ToolInfos(id string) []ToolInfo {
@@ -35,7 +40,12 @@ func (f *fakeTools) ToolInfos(id string) []ToolInfo {
 // AllMcpSurfaces lets fakeTools also stand in as the McpSurfaceProvider that
 // mcpSurfacesFrom looks for. Returning nil causes SyncProjectToken to skip
 // scope derivation — fine for unit tests that don't exercise it.
-func (f *fakeTools) AllMcpSurfaces() McpSurfaces { return nil }
+func (f *fakeTools) AllMcpSurfaces() McpSurfaces {
+	if f == nil {
+		return nil
+	}
+	return f.surfaces
+}
 
 // fakeSkillLister returns a fixed minimal tool list so EmitSkill can produce
 // a stable SKILL.md without spinning up a real router.

--- a/ipc_projects_test.go
+++ b/ipc_projects_test.go
@@ -32,11 +32,10 @@ func (f *fakeTools) ToolInfos(id string) []ToolInfo {
 	return f.infos[id]
 }
 
-// AllContextSchemas lets fakeTools also stand in as the
-// ContextSchemasProvider that mcpContextSchemasFrom looks for. Returning nil
-// causes SyncProjectToken to skip filesystem auto-detection — fine for unit
-// tests that don't exercise allowed_dirs.
-func (f *fakeTools) AllContextSchemas() map[string]json.RawMessage { return nil }
+// AllMcpSurfaces lets fakeTools also stand in as the McpSurfaceProvider that
+// mcpSurfacesFrom looks for. Returning nil causes SyncProjectToken to skip
+// scope derivation — fine for unit tests that don't exercise it.
+func (f *fakeTools) AllMcpSurfaces() McpSurfaces { return nil }
 
 // fakeSkillLister returns a fixed minimal tool list so EmitSkill can produce
 // a stable SKILL.md without spinning up a real router.

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -15,6 +15,19 @@ const (
 	// A client opts in by including _meta.progressToken on a request; the
 	// server then emits these referencing that token.
 	MethodProgress = "notifications/progress"
+
+	// MethodContextEnumerate asks a server to list the valid values of one
+	// contextSchema field it declared `enumerable: true` (ADR-011 decision 6),
+	// so an operator picks a resource rather than typing its name.
+	//
+	// Params: {"field": "<name>", "values": {"<dependency>": <chosen>}}
+	// Result: {"field": "<name>", "values": [{"value": …, "label": "…"}]}
+	//
+	// A server that does not implement it answers -32601, which relay reads as
+	// "free-text entry for this MCP" and stops asking. It is NOT a tool call:
+	// it carries no _meta, spends no budget, and never reaches the audited
+	// tool chokepoint.
+	MethodContextEnumerate = "context/enumerate"
 )
 
 // Tool represents an MCP tool definition.

--- a/mock_mcp_test.go
+++ b/mock_mcp_test.go
@@ -40,9 +40,9 @@ func (m *mockMcpConn) Close() {
 	}
 }
 
-func (m *mockMcpConn) GetTools() []mcp.Tool       { return m.tools }
-func (m *mockMcpConn) SetTools(tools []mcp.Tool)  { m.tools = tools }
-func (m *mockMcpConn) GetConfig() ExternalMcp      { return m.config }
+func (m *mockMcpConn) GetTools() []mcp.Tool      { return m.tools }
+func (m *mockMcpConn) SetTools(tools []mcp.Tool) { m.tools = tools }
+func (m *mockMcpConn) GetConfig() ExternalMcp    { return m.config }
 
 // ---------------------------------------------------------------------------
 // Test helpers — reduce lock/unlock boilerplate in router and manager tests
@@ -56,6 +56,15 @@ func addMockConn(mgr *ExternalMcpManager, id string, mock *mockMcpConn) {
 	mgr.mu.Unlock()
 }
 
+// addMockSchema registers a context schema and its declared version for an MCP
+// under lock, which is what a real handshake does in finalizeConnection.
+func addMockSchema(mgr *ExternalMcpManager, id, schema string, version int) {
+	mgr.mu.Lock()
+	mgr.schemas[id] = json.RawMessage(schema)
+	mgr.schemaVersions[id] = version
+	mgr.mu.Unlock()
+}
+
 // newMockConn creates a mockMcpConn with the given ID and tools.
 // Optionally accepts a sendRequestFunc for tool call interception.
 func newMockConn(id string, tools []mcp.Tool, sendFn func(context.Context, string, interface{}) (json.RawMessage, error)) *mockMcpConn {
@@ -66,11 +75,26 @@ func newMockConn(id string, tools []mcp.Tool, sendFn func(context.Context, strin
 	}
 }
 
-// simpleTools creates a []mcp.Tool from a list of tool names.
+// simpleTools creates a []mcp.Tool from a list of tool names, with NO
+// annotations — which under ADR-011 decision 2 means "mutating", because an
+// absent readOnlyHint is not a claim that a tool is safe.
 func simpleTools(names ...string) []mcp.Tool {
 	tools := make([]mcp.Tool, len(names))
 	for i, name := range names {
 		tools[i] = mcp.Tool{Name: name}
+	}
+	return tools
+}
+
+// readOnlyTools is simpleTools with an explicit annotations.readOnlyHint: true
+// on every tool. Deliberately a SEPARATE helper rather than a default on
+// simpleTools: the whole of decision 2 is that an unannotated tool is refused
+// to a read-only grant, so a helper that quietly annotated everything would
+// make that untestable by making it unreachable.
+func readOnlyTools(names ...string) []mcp.Tool {
+	tools := simpleTools(names...)
+	for i := range tools {
+		tools[i].Annotations = json.RawMessage(`{"readOnlyHint":true}`)
 	}
 	return tools
 }

--- a/project.go
+++ b/project.go
@@ -118,12 +118,22 @@ func validateProjectPath(path string) error {
 // in a self-contradictory shape.
 //
 // A LOCAL project (the zero value — see the Kind field comment) keeps
-// today's rules exactly: validateProjectPath's absolute-path, no-".."
-// checks, nothing else.
+// today's rules: validateProjectPath's absolute-path, no-".." checks, plus
+// the one rule below that is about the allowlist itself rather than about a
+// host directory and therefore belongs to both kinds.
 //
 // A REMOTE project is a capability grant to a client on another machine, not
 // a host directory, so every host-directory-flavored feature must be absent:
 func validateProjectShape(proj *Project) error {
+	// Kind-independent, and first. An over-broad allowed_tools entry is not a
+	// remote-only hazard: for a profile it is a grant of every tool the MCP
+	// has, and for a local project it is an entry the call-time matcher
+	// ignores, i.e. an allowlist that reads as a grant and holds nothing.
+	// Refusing both is how validation and enforcement stay the same rule —
+	// see validateToolPattern.
+	if err := validateAllowedToolPatterns(proj); err != nil {
+		return err
+	}
 	if !proj.IsRemote() {
 		return validateProjectPath(proj.Path)
 	}
@@ -158,20 +168,6 @@ func validateProjectShape(proj *Project) error {
 	// widening it deliberately later is the expected resting state.)
 	if isWildcard(proj.AllowedMcpIDs) {
 		return fmt.Errorf(`remote project must not use the "*" wildcard for allowed_mcp_ids: it would let a future MCP registration silently widen what the remote client can reach; list MCP IDs explicitly`)
-	}
-	// The same argument one level down (ADR-011 decision 2b). Registering a new
-	// TOOL is the same event as registering a new MCP at finer grain, and it
-	// happens far more often — macmcp went from 46 tools to 47 during ADR-010's
-	// own testing. A pattern is fine ("mail_*"), because the layers compose: a
-	// future mail_delete_everything is still refused by a read mode and still
-	// confined by mail_accounts, whose applies_to is the same "mail_*". A bare
-	// "*" composes with nothing; it is the wildcard again.
-	for mcpID, patterns := range proj.AllowedTools {
-		for _, pattern := range patterns {
-			if pattern == "*" {
-				return fmt.Errorf(`remote project must not use the "*" wildcard in allowed_tools for %q: it would let a future tool registration silently widen what the remote client can reach; list tool names or patterns explicitly`, mcpID)
-			}
-		}
 	}
 	// A denylist cannot bound a client, and an inert control is worse than no
 	// control: it reads on the screen as a boundary and enforces nothing that
@@ -230,6 +226,59 @@ func validateProjectShape(proj *Project) error {
 	return nil
 }
 
+// validateAllowedToolPatterns refuses every allowed_tools entry that cannot
+// serve as an allowlist entry, in MCP-name order so a record with two bad
+// patterns names the same one every time.
+func validateAllowedToolPatterns(proj *Project) error {
+	for _, mcpID := range sortedKeys(proj.AllowedTools) {
+		for _, pattern := range proj.AllowedTools[mcpID] {
+			if err := validateToolPattern(mcpID, pattern); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateToolPattern refuses one allowed_tools pattern, on two grounds.
+//
+// It DOES NOT COMPILE. path.Match rejects an unterminated character class, and
+// toolAllowedByPatterns answers "no" for a pattern it cannot compile — so an
+// allowlist of nothing but a broken pattern grants nothing at all. That is the
+// safe direction and a terrible thing to discover from an agent that stopped
+// working. Note this reason belongs to THIS list and not to the matcher: the
+// same uncompilable pattern in a context field's applies_to governs EVERY tool
+// (ContextField.Governs), because fail-closed for a restriction points the
+// other way. A message about what a broken pattern does has to name which of
+// the two lists it is talking about, which is why it is written here rather
+// than beside the shared matcher.
+//
+// It IS TOO BROAD. ADR-011 decision 2b's rule — registering a tool tomorrow
+// must not widen a grant made today — was enforced as a literal compare
+// against "*" while the matcher underneath was path.Match. Tool names contain
+// no "/", so "**", "?*", "*_*", "[a-z]*" and "*e*" each match every tool of an
+// MCP and not one of them is the string "*". A read-only "mail" profile
+// written with ["**"] was measured holding 26 tools across 11 of macMCP's
+// domains, web_fetch among them — the outbound channel decision 2b exists to
+// remove. The refusal is therefore a property of the matcher and not a list of
+// spellings (see overBroadToolPattern); a list of spellings is answered by the
+// next spelling.
+//
+// The wildcard is not replaced by a narrower wildcard: what an operator means
+// by "all the mail tools" is "mail_*", which is admitted, and what they mean
+// by "everything this MCP has" is a request an allowlist deliberately cannot
+// express — for a profile because a future tool would join it unreviewed, for
+// a local project because leaving the list empty already says it.
+func validateToolPattern(mcpID, pattern string) error {
+	if _, err := matchToolPattern(pattern, toolPatternProbes[0]); err != nil {
+		return fmt.Errorf("allowed_tools for %q: pattern %q is not a valid tool pattern (%v); an entry that will not compile matches no tool, so this allowlist would grant less than it reads as", mcpID, pattern, err)
+	}
+	if reason, over := overBroadToolPattern(pattern); over {
+		return fmt.Errorf("allowed_tools for %q: pattern %q is too broad — %s. A tool this MCP gains tomorrow would join the grant with nobody reviewing it, which is the fail-open shape an allowlist exists to close; name the tools, or use a pattern with a real prefix such as %q", mcpID, pattern, reason, "mail_*")
+	}
+	return nil
+}
+
 // permissionPolicyIsEmpty reports whether a policy says nothing at all.
 //
 // It exists because "empty means clear it" is already the update path's rule
@@ -275,17 +324,12 @@ func validateProjectPermissions(proj *Project, surfaces McpSurfaces) error {
 		}
 	}
 
-	// Which tools. matchToolPattern is path.Match, which rejects an
-	// unterminated character class — and toolAllowedByPatterns answers "no" for
-	// a pattern it cannot compile, so an allowlist of nothing but a broken
-	// pattern grants nothing at all. That is the safe direction and a terrible
-	// thing to discover from an agent that stopped working.
-	for _, mcpID := range sortedKeys(proj.AllowedTools) {
-		for _, pattern := range proj.AllowedTools[mcpID] {
-			if _, err := matchToolPattern(pattern, "probe_tool_name"); err != nil {
-				return fmt.Errorf("allowed_tools for %q: pattern %q is not a valid tool pattern (%v); it would match no tool at all", mcpID, pattern, err)
-			}
-		}
+	// Which tools. The same rule validateProjectShape applies, applied again
+	// here because the two are reached by different routes: shape runs on the
+	// create path, this runs on the fully-merged candidate of both HTTP and
+	// IPC. Neither is redundant and both refuse identically.
+	if err := validateAllowedToolPatterns(proj); err != nil {
+		return err
 	}
 
 	// Which resources.

--- a/project.go
+++ b/project.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"slices"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -202,4 +205,158 @@ func validateProjectShape(proj *Project) error {
 		return fmt.Errorf("remote project must not set allowed_models: an allowlist here would either be misread as unrestricted (see modelAllowedForProject) or need a model-scoping story remote projects don't have yet — leave it empty")
 	}
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// The permission set an operator can now type (ADR-011 decisions 2, 2b, 4, 6)
+// ---------------------------------------------------------------------------
+
+// validateProjectPermissions refuses an invalid access mode, an uncompilable
+// tool pattern, and a context value the MCP's own schema will not stand behind.
+// It is called from applyProjectCreate and applyProjectUpdate against the
+// fully-merged candidate, so every surface — the HTTP routes, the IPC handlers
+// the tray uses, and any future one — is refused identically.
+//
+// It exists because of the constraint ADR-011 states as its second: an editor
+// whose easiest failure is a confinement that does not confine is operability
+// DEFEATING security rather than trading against it. A scope value is typed
+// text today, a typo now fails closed (decision 4), and a closed failure is
+// silent from the agent's side — so the moment to catch a value that means
+// nothing is the moment it is written, not the call that later returns nothing.
+//
+// It is separate from validateProjectShape because it needs something that
+// function does not have: what the MCP declared. Shape is answerable from the
+// record alone; whether "mail_accounts" is a field macMCP has, and whether it
+// is one an operator may set, is answerable only from the live surface.
+func validateProjectPermissions(proj *Project, surfaces McpSurfaces) error {
+	// Which operations. AccessMode reads anything that is not exactly "write"
+	// as read, so a stored typo is already fail-closed — but a mode of "wrIte"
+	// that silently means read is a confinement the operator did not choose,
+	// and this is the one place it can still be said out loud.
+	for _, mcpID := range sortedKeys(proj.Access) {
+		mode := proj.Access[mcpID]
+		if mode != AccessRead && mode != AccessWrite {
+			return fmt.Errorf("access for %q must be %q or %q, not %q", mcpID, AccessRead, AccessWrite, mode)
+		}
+	}
+
+	// Which tools. matchToolPattern is path.Match, which rejects an
+	// unterminated character class — and toolAllowedByPatterns answers "no" for
+	// a pattern it cannot compile, so an allowlist of nothing but a broken
+	// pattern grants nothing at all. That is the safe direction and a terrible
+	// thing to discover from an agent that stopped working.
+	for _, mcpID := range sortedKeys(proj.AllowedTools) {
+		for _, pattern := range proj.AllowedTools[mcpID] {
+			if _, err := matchToolPattern(pattern, "probe_tool_name"); err != nil {
+				return fmt.Errorf("allowed_tools for %q: pattern %q is not a valid tool pattern (%v); it would match no tool at all", mcpID, pattern, err)
+			}
+		}
+	}
+
+	// Which resources.
+	for _, mcpID := range sortedKeys(proj.Context) {
+		if err := validateProjectContextForMcp(mcpID, proj.Context[mcpID], surfaces); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateProjectContextForMcp checks one MCP's context blob against what that
+// MCP declared.
+//
+// Three cases, and which one applies is decided by the MCP's own declaration:
+//
+//   - A v2 schema is the case this was written for. Every field name must be
+//     one the MCP declares, every value must conform to the declared fragment,
+//     and a source: "project_path" field is refused outright — relay derives
+//     those from the project's path, so an operator setting one is either
+//     confused about what the field is or is trying to widen a bound relay
+//     controls. SyncProjectToken would overwrite it on the next resync either
+//     way, and a value that silently disappears is worse than a refusal.
+//
+//   - A v1 declaration is refused entirely, because relay knows enough to know
+//     nothing here is operator-set: the v1 branch of SyncProjectToken REPLACES
+//     the whole blob with the derived allowed_dirs. Storing a value there means
+//     storing one that vanishes at the next path or MCP edit.
+//
+//   - No declaration at all — an MCP relay has never connected to, or one that
+//     publishes no contextSchema — cannot be checked, and is permitted with
+//     nothing but an emptiness check. That is the same stance
+//     ValidateProjectGrants takes and for the same reason: this is a coherence
+//     check an operator sees at edit time, not the boundary. Refusing on
+//     missing information would make an MCP that is merely not running
+//     unconfigurable, and the call-time presence re-check still denies.
+func validateProjectContextForMcp(mcpID string, blob json.RawMessage, surfaces McpSurfaces) error {
+	trimmed := strings.TrimSpace(string(blob))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal(blob, &values); err != nil {
+		return fmt.Errorf("context for %q must be an object of field values", mcpID)
+	}
+	if len(values) == 0 {
+		return nil
+	}
+
+	surface := surfaces[mcpID]
+	schema := ParseContextSchema(surface.Schema, surface.SchemaVersion)
+	names := sortedKeys(values)
+
+	if !schema.V2() {
+		if len(surface.Schema) > 0 {
+			return fmt.Errorf("context for %q cannot be set here: it declares a v1 context schema, whose only field relay derives from the project's path — a value written here would be replaced on the next resync", mcpID)
+		}
+		// Unknown MCP. Presence is the only thing that can be checked, and it
+		// is the one that matters: an empty value is how a restrict field says
+		// "refuse everything I govern".
+		for _, name := range names {
+			if !hasScopeValue(values, name) {
+				return fmt.Errorf("context %q for %q: a non-empty value is required", name, mcpID)
+			}
+		}
+		return nil
+	}
+
+	for _, name := range names {
+		f, ok := schema.Field(name)
+		if !ok {
+			return fmt.Errorf("MCP %q declares no context field named %q (it declares: %s)", mcpID, name, declaredFieldList(schema))
+		}
+		if f.FromProjectPath() {
+			return fmt.Errorf("context %q for %q is derived by relay from the project's path and cannot be set by hand", name, mcpID)
+		}
+		if err := f.ValidateValue(values[name]); err != nil {
+			return fmt.Errorf("context for %q: %w", mcpID, err)
+		}
+	}
+	return nil
+}
+
+// declaredFieldList names an MCP's declared fields for a refusal. A refusal
+// that says a name is wrong without saying which are right is a refusal an
+// operator answers by guessing.
+func declaredFieldList(cs ContextSchema) string {
+	if len(cs.Fields) == 0 {
+		return "no fields"
+	}
+	names := make([]string, 0, len(cs.Fields))
+	for _, f := range cs.Fields {
+		names = append(names, strconv.Quote(f.Name))
+	}
+	return strings.Join(names, ", ")
+}
+
+// sortedKeys returns a map's keys in name order, so a refusal naming one of
+// several offending entries names the same one every time. Go's map iteration
+// is randomised per range, and an error message that varies between identical
+// requests is one nobody can write a test against.
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/project.go
+++ b/project.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -14,16 +14,16 @@ import (
 // token. Kept with its original signature so no existing caller or test has
 // to change; it's a thin wrapper over CreateProjectWithTokenKind. Call within
 // store.With.
-func (s *Settings) CreateProjectWithToken(name, path string, mcpIDs, models []string, templates []ChatTemplate, schemas map[string]json.RawMessage) (Project, error) {
-	return s.CreateProjectWithTokenKind(ProjectKindLocal, name, path, mcpIDs, models, templates, schemas)
+func (s *Settings) CreateProjectWithToken(name, path string, mcpIDs, models []string, templates []ChatTemplate, surfaces McpSurfaces) (Project, error) {
+	return s.CreateProjectWithTokenKind(ProjectKindLocal, name, path, mcpIDs, models, templates, surfaces)
 }
 
 // CreateProjectWithTokenKind is CreateProjectWithToken's kind-aware variant.
 // The token's permissions, disabled tools, and context are configured based on
-// the project's allowedMcpIDs and path. schemas maps MCP IDs to their runtime
-// context schemas (from ExternalMcpManager) for filesystem auto-detection.
+// the project's allowedMcpIDs and path. surfaces maps MCP IDs to their runtime
+// schema + tool surface (from ExternalMcpManager) for scope derivation.
 // Call within store.With.
-func (s *Settings) CreateProjectWithTokenKind(kind ProjectKind, name, path string, mcpIDs, models []string, templates []ChatTemplate, schemas map[string]json.RawMessage) (Project, error) {
+func (s *Settings) CreateProjectWithTokenKind(kind ProjectKind, name, path string, mcpIDs, models []string, templates []ChatTemplate, surfaces McpSurfaces) (Project, error) {
 	// See normalizeProjectKind: a local project's stored Kind is always "",
 	// never the literal "local" string, so every local project — however it
 	// was created — serializes identically with no "kind" key.
@@ -48,7 +48,7 @@ func (s *Settings) CreateProjectWithTokenKind(kind ProjectKind, name, path strin
 	if err := validateProjectShape(&candidate); err != nil {
 		return Project{}, err
 	}
-	if err := s.ValidateProjectGrants(&candidate, schemas); err != nil {
+	if err := s.ValidateProjectGrants(&candidate, surfaces); err != nil {
 		return Project{}, err
 	}
 
@@ -71,7 +71,7 @@ func (s *Settings) CreateProjectWithTokenKind(kind ProjectKind, name, path strin
 	}
 
 	s.Projects = append(s.Projects, proj)
-	s.SyncProjectToken(&s.Projects[len(s.Projects)-1], schemas)
+	s.SyncProjectToken(&s.Projects[len(s.Projects)-1], surfaces)
 
 	return proj, nil
 }
@@ -155,6 +155,43 @@ func validateProjectShape(proj *Project) error {
 	// widening it deliberately later is the expected resting state.)
 	if isWildcard(proj.AllowedMcpIDs) {
 		return fmt.Errorf(`remote project must not use the "*" wildcard for allowed_mcp_ids: it would let a future MCP registration silently widen what the remote client can reach; list MCP IDs explicitly`)
+	}
+	// The same argument one level down (ADR-011 decision 2b). Registering a new
+	// TOOL is the same event as registering a new MCP at finer grain, and it
+	// happens far more often — macmcp went from 46 tools to 47 during ADR-010's
+	// own testing. A pattern is fine ("mail_*"), because the layers compose: a
+	// future mail_delete_everything is still refused by a read mode and still
+	// confined by mail_accounts, whose applies_to is the same "mail_*". A bare
+	// "*" composes with nothing; it is the wildcard again.
+	for mcpID, patterns := range proj.AllowedTools {
+		for _, pattern := range patterns {
+			if pattern == "*" {
+				return fmt.Errorf(`remote project must not use the "*" wildcard in allowed_tools for %q: it would let a future tool registration silently widen what the remote client can reach; list tool names or patterns explicitly`, mcpID)
+			}
+		}
+	}
+	// A denylist cannot bound a client, and an inert control is worse than no
+	// control: it reads on the screen as a boundary and enforces nothing that
+	// allowed_tools has not already decided. disabled_tools stays for local
+	// projects, where the caller is the same user on the same machine and
+	// subtracting from everything is coherent; a profile that sets one is
+	// refused here, naming the mechanism that does bound it. (checkToolAccess
+	// still honours a denylist that reaches it by some other route — ignoring
+	// one is the only direction that widens.)
+	//
+	// Only for an MCP this record still grants. A local project that had
+	// fs_bash auto-disabled and is being converted to remote in the same
+	// request that drops the fsmcp grant carries a leftover entry that
+	// SyncProjectToken prunes moments later; refusing on that would block a
+	// legal conversion on the strength of a map key about to be deleted.
+	for mcpID, tools := range proj.DisabledTools {
+		if len(tools) == 0 {
+			continue
+		}
+		if !slices.Contains(proj.AllowedMcpIDs, mcpID) {
+			continue
+		}
+		return fmt.Errorf(`remote project must not set disabled_tools for %q: a denylist grants every tool an MCP gains in future, which is the fail-open shape a grant to another machine must not have — enumerate what it may call in allowed_tools instead`, mcpID)
 	}
 	// modelAllowedForProject (frontend_model_guard.go) treats both len==0 and
 	// ["*"] as "unrestricted" — there is no representation of "no models

--- a/project.go
+++ b/project.go
@@ -47,7 +47,7 @@ func (s *Settings) CreateProjectWithTokenKind(kind ProjectKind, name, path strin
 	// candidate only carries what this function actually knows about; a
 	// direct caller relying solely on this function (as every pre-remote test
 	// does) still gets full path/MCP/model validation.
-	candidate := Project{Kind: kind, Path: path, AllowedMcpIDs: mcpIDs, AllowedModels: models}
+	candidate := Project{Kind: kind, Path: path, AllowedMcpIDs: mcpIDs, AllowedModels: models, ChatTemplates: templates}
 	if err := validateProjectShape(&candidate); err != nil {
 		return Project{}, err
 	}
@@ -196,6 +196,29 @@ func validateProjectShape(proj *Project) error {
 		}
 		return fmt.Errorf(`remote project must not set disabled_tools for %q: a denylist grants every tool an MCP gains in future, which is the fail-open shape a grant to another machine must not have — enumerate what it may call in allowed_tools instead`, mcpID)
 	}
+	// Both of the next two are inert on a record that can hold no session, and
+	// ADR-009 decision 2's rule is that refusing an inert control at the door
+	// is more honest than shipping one that quietly no-ops. They were the last
+	// two fields on a profile that read on screen as a capability and were not
+	// one — the same argument that already removes the path, the skill toggle,
+	// the shell templates, the model allowlist and directory auth.
+	//
+	// A permission policy is a set of gates the CLAUDE CLI applies to a
+	// session it launches. An access profile launches none: it has no path to
+	// launch in, resolvePtyEnv and resolveProjectTemplate both refuse a remote
+	// record outright, and what actually bounds a remote client is the mode,
+	// the tool allowlist and the scope. A default_mode of "bypassPermissions"
+	// sitting on a profile is the worst of it — it reads as a widening that
+	// never happens and cannot be reasoned about from the record alone.
+	if p := proj.PermissionPolicy; p != nil && !permissionPolicyIsEmpty(p) {
+		return fmt.Errorf("remote project must not set permission_policy: those are Claude CLI gates on a session, and an access profile launches none — what bounds a remote client is access, allowed_tools and context")
+	}
+	// A chat template is a preset for starting a chat in that project. Same
+	// argument, one step further along: relay stores them and eve edits them,
+	// and eve has nowhere to offer them for a record with no sessions.
+	if len(proj.ChatTemplates) > 0 {
+		return fmt.Errorf("remote project must not have chat templates: a template is a preset for starting a chat session, and an access profile has no sessions to start")
+	}
 	// modelAllowedForProject (frontend_model_guard.go) treats both len==0 and
 	// ["*"] as "unrestricted" — there is no representation of "no models
 	// listed" that means anything other than "every model is allowed" today.
@@ -205,6 +228,18 @@ func validateProjectShape(proj *Project) error {
 		return fmt.Errorf("remote project must not set allowed_models: an allowlist here would either be misread as unrestricted (see modelAllowedForProject) or need a model-scoping story remote projects don't have yet — leave it empty")
 	}
 	return nil
+}
+
+// permissionPolicyIsEmpty reports whether a policy says nothing at all.
+//
+// It exists because "empty means clear it" is already the update path's rule
+// (applyProjectUpdate stores nil for a policy with no fields set), and a
+// refusal that used a DIFFERENT reading of empty would refuse the very request
+// that clears one — an operator converting a local project to a profile sends
+// the emptied form, and being told "must not set permission_policy" about a
+// policy they just emptied is a wall with no door in it.
+func permissionPolicyIsEmpty(p *PermissionPolicy) bool {
+	return p == nil || (p.DefaultMode == "" && len(p.AllowedTools) == 0 && len(p.DeniedTools) == 0)
 }
 
 // ---------------------------------------------------------------------------

--- a/project_apply.go
+++ b/project_apply.go
@@ -1,7 +1,5 @@
 package main
 
-import "encoding/json"
-
 // projectCreateFields is the transport-agnostic body for creating a project.
 // Both the HTTP POST route and the IPC create handler unmarshal into it so the
 // create orchestration lives in exactly one place (applyProjectCreate).
@@ -18,6 +16,12 @@ type projectCreateFields struct {
 	AllowCwdAuth     bool                `json:"allow_cwd_auth,omitempty"`
 	DisabledTools    map[string][]string `json:"disabled_tools,omitempty"`
 	SessionFolders   []string            `json:"session_folders,omitempty"`
+	// AllowedTools is the per-MCP tool allowlist (ADR-011 decision 2b). It is
+	// carried on the transport DTO because validateProjectShape refuses a
+	// remote-kind record that names "*" here, and refuses one that sets
+	// disabled_tools at all — a refusal that is unreachable if the request
+	// cannot express the field.
+	AllowedTools map[string][]string `json:"allowed_tools,omitempty"`
 }
 
 // projectUpdateFields is the transport-agnostic patch body. Nil pointers mean
@@ -36,15 +40,16 @@ type projectUpdateFields struct {
 	AllowCwdAuth     *bool                `json:"allow_cwd_auth,omitempty"`
 	DisabledTools    *map[string][]string `json:"disabled_tools,omitempty"`
 	SessionFolders   *[]string            `json:"session_folders,omitempty"`
+	AllowedTools     *map[string][]string `json:"allowed_tools,omitempty"`
 }
 
 // applyProjectCreate creates a project and applies its optional policy, skill
 // flag, and disabled-tools map inside a single settings mutation. Call within
 // store.With / withSettings. The caller is responsible for validating the
 // permission policy *before* invoking (so a bad policy never creates a project
-// that has to be rolled back) and for fetching schemas the same way it always
-// has. Returns the fully-resolved project (re-read after the sub-mutations).
-func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]json.RawMessage) (Project, error) {
+// that has to be rolled back) and for fetching the MCP surfaces the same way
+// it always has. Returns the fully-resolved project (re-read after the sub-mutations).
+func applyProjectCreate(s *Settings, f projectCreateFields, surfaces McpSurfaces) (Project, error) {
 	// GenerateSkill, AllowCwdAuth, and ShellTemplates aren't parameters of
 	// CreateProjectWithTokenKind — they're applied by the sub-mutations below,
 	// after the project already exists. Validate the FULL requested shape
@@ -59,11 +64,15 @@ func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]j
 		ShellTemplates: f.ShellTemplates,
 		GenerateSkill:  f.GenerateSkill,
 		AllowCwdAuth:   f.AllowCwdAuth,
+		// Both allowlists are on the candidate because both carry a remote
+		// refusal: a "*" in allowed_tools, and disabled_tools set at all.
+		DisabledTools: f.DisabledTools,
+		AllowedTools:  f.AllowedTools,
 	}
 	if err := validateProjectShape(&candidate); err != nil {
 		return Project{}, err
 	}
-	if err := s.ValidateProjectGrants(&candidate, schemas); err != nil {
+	if err := s.ValidateProjectGrants(&candidate, surfaces); err != nil {
 		return Project{}, err
 	}
 
@@ -71,7 +80,7 @@ func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]j
 		f.Kind, f.Name, f.Path,
 		f.AllowedMcpIDs, f.AllowedModels,
 		f.ChatTemplates,
-		schemas,
+		surfaces,
 	)
 	if err != nil {
 		return Project{}, err
@@ -87,6 +96,9 @@ func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]j
 	}
 	if len(f.SessionFolders) > 0 {
 		s.UpdateProjectSessionFolders(created.ID, f.SessionFolders)
+	}
+	if len(f.AllowedTools) > 0 {
+		s.UpdateProjectAllowedTools(created.ID, f.AllowedTools)
 	}
 	if len(f.ShellTemplates) > 0 {
 		s.UpdateProjectShellTemplates(created.ID, f.ShellTemplates)
@@ -107,7 +119,7 @@ func applyProjectCreate(s *Settings, f projectCreateFields, schemas map[string]j
 // mutated. The caller validates the permission policy up front; schemas is a
 // lazy fetch invoked only when a path/MCP change or a remote-shaped result
 // actually needs it (the common rename stays allocation-free).
-func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas func() map[string]json.RawMessage) (Project, bool, error) {
+func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, surfaces func() McpSurfaces) (Project, bool, error) {
 	proj, _ := s.findProjectByID(id)
 	if proj == nil {
 		return Project{}, false, nil
@@ -140,6 +152,12 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 	if f.AllowCwdAuth != nil {
 		candidate.AllowCwdAuth = *f.AllowCwdAuth
 	}
+	if f.DisabledTools != nil {
+		candidate.DisabledTools = *f.DisabledTools
+	}
+	if f.AllowedTools != nil {
+		candidate.AllowedTools = *f.AllowedTools
+	}
 	if err := validateProjectShape(&candidate); err != nil {
 		return Project{}, true, err
 	}
@@ -157,7 +175,7 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 		}
 	}
 
-	// schemas() is a lazy fetch (real callers wire it to a live MCP-manager
+	// surfaces() is a lazy fetch (real callers wire it to a live MCP-manager
 	// call); fetch it once and reuse for both the grants check and the
 	// existing path/MCP resync below rather than fetching it twice. Grants
 	// only need re-checking when something that could have changed the
@@ -165,9 +183,9 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 	// the MCP set changing on an already/still-remote project. A bare rename
 	// of an already-valid remote project doesn't need to pay for it.
 	needGrantsCheck := candidate.IsRemote() && (f.AllowedMcpIDs != nil || f.Kind != nil)
-	var sc map[string]json.RawMessage
+	var sc McpSurfaces
 	if f.Path != nil || f.AllowedMcpIDs != nil || needGrantsCheck {
-		sc = schemas()
+		sc = surfaces()
 	}
 	if needGrantsCheck {
 		if err := s.ValidateProjectGrants(&candidate, sc); err != nil {
@@ -212,6 +230,9 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, schemas f
 	}
 	if f.SessionFolders != nil {
 		s.UpdateProjectSessionFolders(id, *f.SessionFolders)
+	}
+	if f.AllowedTools != nil {
+		s.UpdateProjectAllowedTools(id, *f.AllowedTools)
 	}
 	if f.DisabledTools != nil {
 		// Replace the entire disabled-tools map: any MCP key omitted from the

--- a/project_apply.go
+++ b/project_apply.go
@@ -1,5 +1,7 @@
 package main
 
+import "encoding/json"
+
 // projectCreateFields is the transport-agnostic body for creating a project.
 // Both the HTTP POST route and the IPC create handler unmarshal into it so the
 // create orchestration lives in exactly one place (applyProjectCreate).
@@ -16,12 +18,16 @@ type projectCreateFields struct {
 	AllowCwdAuth     bool                `json:"allow_cwd_auth,omitempty"`
 	DisabledTools    map[string][]string `json:"disabled_tools,omitempty"`
 	SessionFolders   []string            `json:"session_folders,omitempty"`
-	// AllowedTools is the per-MCP tool allowlist (ADR-011 decision 2b). It is
-	// carried on the transport DTO because validateProjectShape refuses a
-	// remote-kind record that names "*" here, and refuses one that sets
-	// disabled_tools at all — a refusal that is unreachable if the request
-	// cannot express the field.
-	AllowedTools map[string][]string `json:"allowed_tools,omitempty"`
+	// The three fields that make up the permission set an operator can now
+	// type (ADR-011 decisions 2, 2b and 6). Before this they were reachable
+	// only from Go: allowed_tools carried a refusal nothing could trigger,
+	// access did not exist on the wire, and context had never been settable at
+	// all — it was only ever derived, by the one hardcoded rule in
+	// SyncProjectToken (ADR-011 finding 6). A confinement an operator cannot
+	// express is a confinement that does not exist.
+	AllowedTools map[string][]string        `json:"allowed_tools,omitempty"`
+	Access       map[string]string          `json:"access,omitempty"`
+	Context      map[string]json.RawMessage `json:"context,omitempty"`
 }
 
 // projectUpdateFields is the transport-agnostic patch body. Nil pointers mean
@@ -40,7 +46,13 @@ type projectUpdateFields struct {
 	AllowCwdAuth     *bool                `json:"allow_cwd_auth,omitempty"`
 	DisabledTools    *map[string][]string `json:"disabled_tools,omitempty"`
 	SessionFolders   *[]string            `json:"session_folders,omitempty"`
-	AllowedTools     *map[string][]string `json:"allowed_tools,omitempty"`
+	// Pointers for the same nil-means-no-change reason as everything above:
+	// an operator editing a project's name must not clear its scope, and a
+	// cleared scope must be expressible as an empty object rather than being
+	// indistinguishable from an absent one.
+	AllowedTools *map[string][]string        `json:"allowed_tools,omitempty"`
+	Access       *map[string]string          `json:"access,omitempty"`
+	Context      *map[string]json.RawMessage `json:"context,omitempty"`
 }
 
 // applyProjectCreate creates a project and applies its optional policy, skill
@@ -68,8 +80,17 @@ func applyProjectCreate(s *Settings, f projectCreateFields, surfaces McpSurfaces
 		// refusal: a "*" in allowed_tools, and disabled_tools set at all.
 		DisabledTools: f.DisabledTools,
 		AllowedTools:  f.AllowedTools,
+		// And the rest of the permission set, so every refusal in
+		// validateProjectPermissions is reachable from a create as well as
+		// from an edit. A profile whose scope is only checked when it is
+		// changed is one that can be created wrong and never rechecked.
+		Access:  f.Access,
+		Context: f.Context,
 	}
 	if err := validateProjectShape(&candidate); err != nil {
+		return Project{}, err
+	}
+	if err := validateProjectPermissions(&candidate, surfaces); err != nil {
 		return Project{}, err
 	}
 	if err := s.ValidateProjectGrants(&candidate, surfaces); err != nil {
@@ -99,6 +120,14 @@ func applyProjectCreate(s *Settings, f projectCreateFields, surfaces McpSurfaces
 	}
 	if len(f.AllowedTools) > 0 {
 		s.UpdateProjectAllowedTools(created.ID, f.AllowedTools)
+	}
+	if len(f.Access) > 0 {
+		s.UpdateProjectAccess(created.ID, f.Access)
+	}
+	// Last of the three, because it re-runs SyncProjectToken and that pass
+	// prunes by the MCP set the record ends up with.
+	if len(f.Context) > 0 {
+		s.UpdateProjectContext(created.ID, f.Context, surfaces)
 	}
 	if len(f.ShellTemplates) > 0 {
 		s.UpdateProjectShellTemplates(created.ID, f.ShellTemplates)
@@ -158,6 +187,12 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, surfaces 
 	if f.AllowedTools != nil {
 		candidate.AllowedTools = *f.AllowedTools
 	}
+	if f.Access != nil {
+		candidate.Access = *f.Access
+	}
+	if f.Context != nil {
+		candidate.Context = *f.Context
+	}
 	if err := validateProjectShape(&candidate); err != nil {
 		return Project{}, true, err
 	}
@@ -183,9 +218,19 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, surfaces 
 	// the MCP set changing on an already/still-remote project. A bare rename
 	// of an already-valid remote project doesn't need to pay for it.
 	needGrantsCheck := candidate.IsRemote() && (f.AllowedMcpIDs != nil || f.Kind != nil)
+	// The permission set is re-validated whenever the request names any part
+	// of it — and only then. A rename cannot invalidate a scope value, and
+	// making every edit pay for a live MCP surface fetch is what the laziness
+	// here exists to avoid.
+	needPermissionsCheck := f.Access != nil || f.AllowedTools != nil || f.Context != nil
 	var sc McpSurfaces
-	if f.Path != nil || f.AllowedMcpIDs != nil || needGrantsCheck {
+	if f.Path != nil || f.AllowedMcpIDs != nil || needGrantsCheck || needPermissionsCheck {
 		sc = surfaces()
+	}
+	if needPermissionsCheck {
+		if err := validateProjectPermissions(&candidate, sc); err != nil {
+			return Project{}, true, err
+		}
 	}
 	if needGrantsCheck {
 		if err := s.ValidateProjectGrants(&candidate, sc); err != nil {
@@ -233,6 +278,12 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, surfaces 
 	}
 	if f.AllowedTools != nil {
 		s.UpdateProjectAllowedTools(id, *f.AllowedTools)
+	}
+	if f.Access != nil {
+		s.UpdateProjectAccess(id, *f.Access)
+	}
+	if f.Context != nil {
+		s.UpdateProjectContext(id, *f.Context, sc)
 	}
 	if f.DisabledTools != nil {
 		// Replace the entire disabled-tools map: any MCP key omitted from the

--- a/project_apply.go
+++ b/project_apply.go
@@ -86,6 +86,13 @@ func applyProjectCreate(s *Settings, f projectCreateFields, surfaces McpSurfaces
 		// changed is one that can be created wrong and never rechecked.
 		Access:  f.Access,
 		Context: f.Context,
+		// Both of these are applied by sub-mutations AFTER the project
+		// exists, exactly like GenerateSkill and ShellTemplates, so they have
+		// to be on the candidate or their remote refusals would be reachable
+		// only from an edit — i.e. a profile could be CREATED carrying a
+		// permission policy or a chat template and never rechecked.
+		PermissionPolicy: f.PermissionPolicy,
+		ChatTemplates:    f.ChatTemplates,
 	}
 	if err := validateProjectShape(&candidate); err != nil {
 		return Project{}, err
@@ -106,7 +113,7 @@ func applyProjectCreate(s *Settings, f projectCreateFields, surfaces McpSurfaces
 	if err != nil {
 		return Project{}, err
 	}
-	if f.PermissionPolicy != nil {
+	if !permissionPolicyIsEmpty(f.PermissionPolicy) {
 		s.UpdateProjectPermissionPolicy(created.ID, f.PermissionPolicy)
 	}
 	if f.GenerateSkill {
@@ -184,6 +191,19 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, surfaces 
 	if f.DisabledTools != nil {
 		candidate.DisabledTools = *f.DisabledTools
 	}
+	if f.ChatTemplates != nil {
+		candidate.ChatTemplates = *f.ChatTemplates
+	}
+	if f.PermissionPolicy != nil {
+		// Normalised the same way the mutation below normalises it, so the
+		// shape that is VALIDATED is the shape that would be STORED. Without
+		// this, emptying a policy to convert a project to a profile would be
+		// refused on the strength of a value the same request was clearing.
+		candidate.PermissionPolicy = f.PermissionPolicy
+		if permissionPolicyIsEmpty(f.PermissionPolicy) {
+			candidate.PermissionPolicy = nil
+		}
+	}
 	if f.AllowedTools != nil {
 		candidate.AllowedTools = *f.AllowedTools
 	}
@@ -260,9 +280,10 @@ func applyProjectUpdate(s *Settings, id string, f projectUpdateFields, surfaces 
 		s.UpdateProjectShellTemplates(id, *f.ShellTemplates)
 	}
 	if f.PermissionPolicy != nil {
+		// An empty struct (no fields set) clears the policy — the same
+		// reading the candidate above was validated under.
 		policy := f.PermissionPolicy
-		// An empty struct (no fields set) clears the policy.
-		if policy.DefaultMode == "" && len(policy.AllowedTools) == 0 && len(policy.DeniedTools) == 0 {
+		if permissionPolicyIsEmpty(policy) {
 			policy = nil
 		}
 		s.UpdateProjectPermissionPolicy(id, policy)

--- a/project_apply_test.go
+++ b/project_apply_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -122,7 +121,7 @@ func TestApplyProjectUpdate_RemoteRejectsAllowCwdAuthFlip(t *testing.T) {
 	}
 
 	allow := true
-	_, found, err := applyProjectUpdate(s, created.ID, projectUpdateFields{AllowCwdAuth: &allow}, func() map[string]json.RawMessage { return nil })
+	_, found, err := applyProjectUpdate(s, created.ID, projectUpdateFields{AllowCwdAuth: &allow}, func() McpSurfaces { return nil })
 	_ = found
 	if err == nil {
 		t.Fatal("expected rejection of allow_cwd_auth flip on a remote project")
@@ -143,7 +142,7 @@ func TestApplyProjectUpdate_RemoteRejectsWildcardMcps(t *testing.T) {
 	}
 
 	wildcard := []string{"*"}
-	_, _, err = applyProjectUpdate(s, created.ID, projectUpdateFields{AllowedMcpIDs: &wildcard}, func() map[string]json.RawMessage { return nil })
+	_, _, err = applyProjectUpdate(s, created.ID, projectUpdateFields{AllowedMcpIDs: &wildcard}, func() McpSurfaces { return nil })
 	if err == nil {
 		t.Fatal("expected rejection of wildcard allowed_mcp_ids on update for a remote project")
 	}

--- a/project_convert_test.go
+++ b/project_convert_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -55,4 +56,149 @@ func TestProjectConvertLocalToRemote_CannotInheritFilesystemScope(t *testing.T) 
 	if raw, ok := converted.Context["fsmcp"]; ok {
 		t.Fatalf("converted project still carries host filesystem scope: %s", raw)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// The two controls a profile can hold and cannot use (ADR-011 decision 2b's
+// argument, ADR-009 decision 2's rule)
+// ---------------------------------------------------------------------------
+//
+// A permission policy is a set of Claude CLI gates on a session, and a chat
+// template is a preset for starting one. An access profile launches no session
+// — resolvePtyEnv and resolveProjectTemplate both refuse a remote record — so
+// both are inert on one. "Refusing it at the door is more honest than a control
+// that quietly no-ops" is the same rule that already removes the path, the
+// skill toggle, the shell templates, the model allowlist and directory auth,
+// and it is the reason the editor no longer renders either as "inert".
+
+func TestProjectCreateRemote_RejectsPermissionPolicy(t *testing.T) {
+	s := &Settings{Version: 1}
+	_, err := applyProjectCreate(s, projectCreateFields{
+		Name: "Hermes Mail", Kind: ProjectKindRemote,
+		PermissionPolicy: &PermissionPolicy{DefaultMode: "bypassPermissions"},
+	}, nil)
+	if err == nil {
+		t.Fatal("a profile carrying a permission policy was accepted")
+	}
+	if !containsAll(err.Error(), "permission_policy", "access") {
+		t.Errorf("the refusal must name the field and what does bound a client: %v", err)
+	}
+	if len(s.Projects) != 0 {
+		t.Fatalf("a refused create persisted a project: %d", len(s.Projects))
+	}
+}
+
+// An EMPTY policy is not a policy. The update path already reads one as "clear
+// it", so refusing on it would refuse the very request that clears one.
+func TestProjectCreateRemote_AcceptsAnEmptyPermissionPolicy(t *testing.T) {
+	s := &Settings{Version: 1}
+	created, err := applyProjectCreate(s, projectCreateFields{
+		Name: "Hermes Mail", Kind: ProjectKindRemote,
+		PermissionPolicy: &PermissionPolicy{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("an emptied policy was refused as a policy: %v", err)
+	}
+	if created.PermissionPolicy != nil {
+		t.Errorf("an empty policy was stored rather than treated as absent: %+v", created.PermissionPolicy)
+	}
+}
+
+func TestProjectCreateRemote_RejectsChatTemplates(t *testing.T) {
+	s := &Settings{Version: 1}
+	_, err := applyProjectCreate(s, projectCreateFields{
+		Name: "Hermes Mail", Kind: ProjectKindRemote,
+		ChatTemplates: []ChatTemplate{{ID: "t1", Name: "Default", Model: "claude-opus"}},
+	}, nil)
+	if err == nil {
+		t.Fatal("a profile carrying a chat template was accepted")
+	}
+	if !containsAll(err.Error(), "chat templates", "no sessions") {
+		t.Errorf("the refusal does not say why: %v", err)
+	}
+	if len(s.Projects) != 0 {
+		t.Fatalf("a refused create persisted a project: %d", len(s.Projects))
+	}
+	// The lower-level mutator refuses it too, so a caller that reaches past
+	// applyProjectCreate cannot store one either.
+	if _, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Hermes Mail", "", nil, nil,
+		[]ChatTemplate{{ID: "t1", Name: "Default"}}, nil); err == nil {
+		t.Fatal("CreateProjectWithTokenKind stored chat templates on a remote record")
+	}
+}
+
+// The conversion escape hatch, mirroring disabled_tools: an existing local
+// project carrying either one is refused while it still carries it, and the
+// SAME request that clears it converts cleanly. Without this an operator who
+// ever set a policy could never turn that project into a profile — a wall with
+// no door in it.
+func TestProjectConvertLocalToRemote_ClearingTheInertControlsMakesItLegal(t *testing.T) {
+	dir := t.TempDir()
+	s := &Settings{Version: 1}
+	proj, err := s.CreateProjectWithToken("Local", dir, nil, nil,
+		[]ChatTemplate{{ID: "t1", Name: "Default", Model: "claude-opus"}}, nil)
+	if err != nil {
+		t.Fatalf("create local: %v", err)
+	}
+	s.UpdateProjectPermissionPolicy(proj.ID, &PermissionPolicy{DefaultMode: "acceptEdits"})
+
+	remote := ProjectKindRemote
+	empty := ""
+	noSurfaces := func() McpSurfaces { return nil }
+
+	// Flipping kind alone is refused — twice over, once per control.
+	if _, _, err := applyProjectUpdate(s, proj.ID, projectUpdateFields{Kind: &remote, Path: &empty}, noSurfaces); err == nil {
+		t.Fatal("converting a project that still carries a policy and templates was allowed")
+	}
+	after, _ := s.findProjectByID(proj.ID)
+	if after.IsRemote() {
+		t.Fatal("a refused conversion mutated the record")
+	}
+
+	// Clearing both in the same request converts.
+	noTemplates := []ChatTemplate{}
+	if _, _, err := applyProjectUpdate(s, proj.ID, projectUpdateFields{
+		Kind: &remote, Path: &empty,
+		ChatTemplates:    &noTemplates,
+		PermissionPolicy: &PermissionPolicy{},
+	}, noSurfaces); err != nil {
+		t.Fatalf("clearing both should make the conversion legal: %v", err)
+	}
+	converted, _ := s.findProjectByID(proj.ID)
+	if !converted.IsRemote() {
+		t.Fatal("project did not convert")
+	}
+	if converted.PermissionPolicy != nil || len(converted.ChatTemplates) != 0 {
+		t.Fatalf("the converted profile still carries an inert control: policy=%+v templates=%+v",
+			converted.PermissionPolicy, converted.ChatTemplates)
+	}
+}
+
+// A LOCAL project is untouched by any of this: both controls are exactly what
+// they always were.
+func TestProjectLocal_KeepsItsPolicyAndTemplates(t *testing.T) {
+	s := &Settings{Version: 1}
+	created, err := applyProjectCreate(s, projectCreateFields{
+		Name: "Workspace", Path: t.TempDir(),
+		PermissionPolicy: &PermissionPolicy{DefaultMode: "acceptEdits"},
+		ChatTemplates:    []ChatTemplate{{ID: "t1", Name: "Default", Model: "claude-opus"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("a local project was refused: %v", err)
+	}
+	if created.PermissionPolicy == nil || created.PermissionPolicy.DefaultMode != "acceptEdits" {
+		t.Errorf("the local project lost its policy: %+v", created.PermissionPolicy)
+	}
+	if len(created.ChatTemplates) != 1 {
+		t.Errorf("the local project lost its templates: %+v", created.ChatTemplates)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
 }

--- a/project_convert_test.go
+++ b/project_convert_test.go
@@ -13,8 +13,8 @@ import (
 func TestProjectConvertLocalToRemote_CannotInheritFilesystemScope(t *testing.T) {
 	dir := t.TempDir()
 	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "fsmcp", DisplayName: "fsMCP"}}}
-	schemas := func() map[string]json.RawMessage {
-		return map[string]json.RawMessage{"fsmcp": json.RawMessage(`{"allowed_dirs":{"type":"array"}}`)}
+	schemas := func() McpSurfaces {
+		return McpSurfaces{"fsmcp": {Schema: json.RawMessage(`{"allowed_dirs":{"type":"array"}}`)}}
 	}
 
 	proj, err := s.CreateProjectWithToken("Local", dir, []string{"fsmcp"}, nil, nil, schemas())

--- a/project_dto.go
+++ b/project_dto.go
@@ -20,9 +20,15 @@ import "encoding/json"
 // token in its native Projects tab. Only the eve-facing HTTP routes in
 // project_routes.go project through this.
 type projectView struct {
-	ID               string                     `json:"id"`
-	Name             string                     `json:"name"`
-	Path             string                     `json:"path"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Path string `json:"path"`
+	// Kind, and below it Access and AllowedTools, are here because without
+	// them the GET cannot show what the PUT accepted — a UI that cannot render
+	// its own state. Kind additionally decides how everything else on the row
+	// reads: a record with no path, no models and no skill is either an access
+	// profile or a broken project, and only this field says which.
+	Kind             ProjectKind                `json:"kind,omitempty"`
 	AllowedMcpIDs    []string                   `json:"allowed_mcp_ids"`
 	AllowedModels    []string                   `json:"allowed_models"`
 	ChatTemplates    []ChatTemplate             `json:"chat_templates,omitempty"`
@@ -30,6 +36,8 @@ type projectView struct {
 	CreatedAt        string                     `json:"created_at"`
 	DisabledTools    map[string][]string        `json:"disabled_tools,omitempty"`
 	Context          map[string]json.RawMessage `json:"context,omitempty"`
+	AllowedTools     map[string][]string        `json:"allowed_tools,omitempty"`
+	Access           map[string]string          `json:"access,omitempty"`
 	PermissionPolicy *PermissionPolicy          `json:"permission_policy,omitempty"`
 	GenerateSkill    bool                       `json:"generate_skill,omitempty"`
 	AllowCwdAuth     bool                       `json:"allow_cwd_auth,omitempty"`
@@ -41,6 +49,7 @@ func projectToView(p Project) projectView {
 		ID:               p.ID,
 		Name:             p.Name,
 		Path:             p.Path,
+		Kind:             p.Kind,
 		AllowedMcpIDs:    p.AllowedMcpIDs,
 		AllowedModels:    p.AllowedModels,
 		ChatTemplates:    p.ChatTemplates,
@@ -48,6 +57,8 @@ func projectToView(p Project) projectView {
 		CreatedAt:        p.CreatedAt,
 		DisabledTools:    p.DisabledTools,
 		Context:          p.Context,
+		AllowedTools:     p.AllowedTools,
+		Access:           p.Access,
 		PermissionPolicy: p.PermissionPolicy,
 		GenerateSkill:    p.GenerateSkill,
 		AllowCwdAuth:     p.AllowCwdAuth,

--- a/project_permissions_test.go
+++ b/project_permissions_test.go
@@ -1,0 +1,252 @@
+package main
+
+// ADR-011 decisions 2, 2b, 4 and 6: the whole permission set is operator-
+// settable, and every value is validated on save whichever surface produced
+// it. The constraint these tests exist for is the ADR's second: an editor
+// whose easiest failure is a confinement that does not confine is operability
+// DEFEATING security rather than trading against it. A refused value is a
+// value that never becomes a grant somebody trusts.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// v2Surfaces is macMCP's worked example plus fsMCP's v1 declaration, which is
+// what a host running both looks like today.
+func v2Surfaces() McpSurfaces {
+	return McpSurfaces{
+		"macmcp": macmcpSurface(),
+		"fsmcp":  {Schema: json.RawMessage(`{"allowed_dirs":{"type":"array"}}`)},
+	}
+}
+
+func profileWithContext(mcpID, blob string) *Project {
+	return &Project{
+		ID: "p1", Name: "Profile", Kind: ProjectKindRemote,
+		AllowedMcpIDs: []string{mcpID},
+		Context:       map[string]json.RawMessage{mcpID: json.RawMessage(blob)},
+	}
+}
+
+func wantRefusal(t *testing.T, err error, substrings ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a refusal, got none")
+	}
+	for _, want := range substrings {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal should say %q; got: %v", want, err)
+		}
+	}
+}
+
+// A value for a field the MCP does not declare is refused, and the refusal
+// says which fields DO exist — a refusal that says a name is wrong without
+// saying which are right is one an operator answers by guessing.
+func TestValidatePermissions_RefusesUndeclaredField(t *testing.T) {
+	proj := profileWithContext("macmcp", `{"mail_folders":["INBOX"]}`)
+	err := validateProjectPermissions(proj, v2Surfaces())
+	wantRefusal(t, err, "mail_folders", "macmcp", "mail_accounts", "mail_mailboxes")
+}
+
+// The declared fragment is a type contract, not decoration: a string where an
+// array was declared is refused rather than injected as something the MCP will
+// read as one entry or as nothing.
+func TestValidatePermissions_RefusesWrongType(t *testing.T) {
+	proj := profileWithContext("macmcp", `{"mail_accounts":"Bob"}`)
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "mail_accounts", "array")
+
+	proj = profileWithContext("macmcp", `{"mail_accounts":[7]}`)
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "mail_accounts", "string")
+}
+
+// Empty is a refusal on all three sides (decision 4). "No restriction" is not
+// expressible as emptiness, so an empty list stored here would be a grant that
+// reads on screen as confined and refuses every call at runtime.
+func TestValidatePermissions_RefusesEmptyRestrictValue(t *testing.T) {
+	for _, blob := range []string{
+		`{"mail_accounts":[]}`,
+		`{"mail_accounts":null}`,
+		`{"mail_accounts":[""]}`,
+		`{"mail_accounts":["  "]}`,
+	} {
+		proj := profileWithContext("macmcp", blob)
+		wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "mail_accounts")
+	}
+}
+
+// A source: "project_path" field is relay's to derive. An operator setting one
+// is either confused about what the field is or is widening a bound relay
+// controls, and either way SyncProjectToken would overwrite it moments later —
+// a value that silently disappears is worse than a refusal.
+func TestValidatePermissions_RefusesOperatorSuppliedProjectPathField(t *testing.T) {
+	proj := &Project{
+		ID: "p1", Name: "Local", Path: "/tmp/x",
+		AllowedMcpIDs: []string{"macmcp"},
+		Context:       map[string]json.RawMessage{"macmcp": json.RawMessage(`{"write_dirs":["/etc"]}`)},
+	}
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "write_dirs", "path", "cannot be set")
+}
+
+// The mode is a closed set. AccessMode already reads anything that is not
+// exactly "write" as read, so a stored typo is fail-closed — but a typo that
+// silently means read is a confinement the operator did not choose, and this
+// is the only place it can be said out loud.
+func TestValidatePermissions_RefusesUnknownAccessMode(t *testing.T) {
+	proj := &Project{ID: "p1", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"},
+		Access: map[string]string{"macmcp": "readwrite"}}
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "macmcp", "readwrite", "read", "write")
+
+	for _, ok := range []string{AccessRead, AccessWrite} {
+		proj.Access["macmcp"] = ok
+		if err := validateProjectPermissions(proj, v2Surfaces()); err != nil {
+			t.Errorf("mode %q should be accepted: %v", ok, err)
+		}
+	}
+}
+
+// A pattern that will not compile matches NO tool (toolAllowedByPatterns fails
+// closed), so an allowlist of nothing but a broken pattern grants nothing —
+// safe, and a terrible thing to discover from an agent that stopped working.
+func TestValidatePermissions_RefusesUncompilablePattern(t *testing.T) {
+	proj := &Project{ID: "p1", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"},
+		AllowedTools: map[string][]string{"macmcp": {"mail_[", "mail_*"}}}
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "mail_[", "macmcp")
+
+	proj.AllowedTools["macmcp"] = []string{"mail_*", "capture_screenshot"}
+	if err := validateProjectPermissions(proj, v2Surfaces()); err != nil {
+		t.Errorf("a glob and an exact name should both be accepted: %v", err)
+	}
+}
+
+// A v1 MCP has no operator-settable context at all: SyncProjectToken's v1
+// branch REPLACES the whole blob with the derived allowed_dirs, so a value
+// stored here is one that vanishes at the next path or MCP edit.
+func TestValidatePermissions_RefusesContextForV1Schema(t *testing.T) {
+	proj := &Project{ID: "p1", Path: "/tmp/x", AllowedMcpIDs: []string{"fsmcp"},
+		Context: map[string]json.RawMessage{"fsmcp": json.RawMessage(`{"allowed_dirs":["/etc"]}`)}}
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "fsmcp", "v1")
+}
+
+// An MCP relay has never connected to cannot be checked, and is PERMITTED with
+// nothing but an emptiness check. Same stance as ValidateProjectGrants and for
+// the same reason: this is a coherence check an operator sees at edit time,
+// not the boundary. Refusing on missing information would make an MCP that is
+// merely not running unconfigurable, and CallTool's presence re-check still
+// denies.
+func TestValidatePermissions_PermitsUnknownMcpButNotAnEmptyValue(t *testing.T) {
+	proj := profileWithContext("whomcp", `{"anything":["a"]}`)
+	if err := validateProjectPermissions(proj, v2Surfaces()); err != nil {
+		t.Fatalf("an unknown MCP should not be unconfigurable: %v", err)
+	}
+	proj = profileWithContext("whomcp", `{"anything":[]}`)
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "anything", "non-empty")
+}
+
+// A context blob that is not an object at all is refused rather than read as
+// "no fields" — contextValues answers nil for it, which every caller would
+// then treat as an absent scope.
+func TestValidatePermissions_RefusesNonObjectContext(t *testing.T) {
+	proj := profileWithContext("macmcp", `["mail_accounts"]`)
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "macmcp", "object")
+}
+
+// The worked example from the ADR, accepted whole.
+func TestValidatePermissions_AcceptsTheWorkedExample(t *testing.T) {
+	proj := &Project{
+		ID: "prof_hermes_bob_inbox", Name: "Hermes — Bob INBOX (read-only)", Kind: ProjectKindRemote,
+		AllowedMcpIDs: []string{"macmcp"},
+		AllowedTools:  map[string][]string{"macmcp": {"mail_*"}},
+		Access:        map[string]string{"macmcp": AccessRead},
+		Context: map[string]json.RawMessage{
+			"macmcp": json.RawMessage(`{"mail_accounts":["Bob"],"mail_mailboxes":["INBOX"]}`),
+		},
+	}
+	if err := validateProjectPermissions(proj, v2Surfaces()); err != nil {
+		t.Fatalf("ADR-011's own worked example was refused: %v", err)
+	}
+	if err := validateProjectShape(proj); err != nil {
+		t.Fatalf("ADR-011's own worked example failed the shape check: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The mutators
+// ---------------------------------------------------------------------------
+
+// UpdateProjectContext replaces the operator's fields and RE-DERIVES the ones
+// relay owns. Without the re-derivation a local project's write_dirs would
+// disappear the first time someone edited its mail scope, and the two tools
+// that field governs would start refusing with nothing on screen to say why.
+func TestUpdateProjectContext_ReDerivesTheProjectPathField(t *testing.T) {
+	s := &Settings{Version: 1}
+	surfaces := v2Surfaces()
+	proj, err := s.CreateProjectWithToken("Local", "/tmp/proj", []string{"macmcp"}, nil, nil, surfaces)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	before := contextValues(s.Projects[0].Context["macmcp"])
+	if !hasScopeValue(before, "write_dirs") {
+		t.Fatalf("precondition: write_dirs should have been derived, got %s", s.Projects[0].Context["macmcp"])
+	}
+
+	s.UpdateProjectContext(proj.ID, map[string]json.RawMessage{
+		"macmcp": json.RawMessage(`{"mail_accounts":["Alice"]}`),
+	}, surfaces)
+
+	after := contextValues(s.Projects[0].Context["macmcp"])
+	if !hasScopeValue(after, "mail_accounts") {
+		t.Errorf("operator value was not stored: %s", s.Projects[0].Context["macmcp"])
+	}
+	if !hasScopeValue(after, "write_dirs") {
+		t.Errorf("the derived field was destroyed by an operator edit: %s", s.Projects[0].Context["macmcp"])
+	}
+}
+
+// Entries for an MCP the record does not grant are dropped, exactly as
+// UpdateProjectAllowedTools drops them: a mode or a scope for an unreachable
+// MCP reads as an authority the record does not have.
+func TestUpdateProjectAccessAndContext_DropUngrantedMcps(t *testing.T) {
+	s := &Settings{Version: 1}
+	proj, err := s.CreateProjectWithTokenKind(ProjectKindRemote, "Profile", "", []string{"macmcp"}, nil, nil, v2Surfaces())
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	s.UpdateProjectAccess(proj.ID, map[string]string{"macmcp": AccessWrite, "other": AccessWrite})
+	s.UpdateProjectContext(proj.ID, map[string]json.RawMessage{
+		"macmcp": json.RawMessage(`{"mail_accounts":["Bob"]}`),
+		"other":  json.RawMessage(`{"whatever":["x"]}`),
+	}, v2Surfaces())
+
+	got := s.Projects[0]
+	if _, ok := got.Access["other"]; ok {
+		t.Error("a mode was stored for an MCP the profile does not grant")
+	}
+	if _, ok := got.Context["other"]; ok {
+		t.Error("a scope was stored for an MCP the profile does not grant")
+	}
+	if got.Access["macmcp"] != AccessWrite {
+		t.Errorf("granted MCP lost its mode: %#v", got.Access)
+	}
+}
+
+// An unrecognised mode is KEPT rather than dropped. Dropping it would fall
+// back to the default, which for a local project is write — a mutator silently
+// widening a grant on the strength of a typo.
+func TestUpdateProjectAccess_KeepsAnUnknownModeRatherThanWidening(t *testing.T) {
+	s := &Settings{Version: 1}
+	proj, err := s.CreateProjectWithToken("Local", "/tmp/proj", []string{"macmcp"}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	s.UpdateProjectAccess(proj.ID, map[string]string{"macmcp": "wrIte"})
+	if got := s.Projects[0].Access["macmcp"]; got != "wrIte" {
+		t.Fatalf("mode was rewritten or dropped: %q", got)
+	}
+	tok := s.storedTokenForProject(&s.Projects[0], "hash")
+	if mode := tok.AccessMode("macmcp"); mode != AccessRead {
+		t.Errorf("an unrecognised mode must read as %q, got %q", AccessRead, mode)
+	}
+}

--- a/project_permissions_test.go
+++ b/project_permissions_test.go
@@ -85,9 +85,9 @@ func TestValidatePermissions_RefusesOperatorSuppliedProjectPathField(t *testing.
 	proj := &Project{
 		ID: "p1", Name: "Local", Path: "/tmp/x",
 		AllowedMcpIDs: []string{"macmcp"},
-		Context:       map[string]json.RawMessage{"macmcp": json.RawMessage(`{"write_dirs":["/etc"]}`)},
+		Context:       map[string]json.RawMessage{"macmcp": json.RawMessage(`{"file_dirs":["/etc"]}`)},
 	}
-	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "write_dirs", "path", "cannot be set")
+	wantRefusal(t, validateProjectPermissions(proj, v2Surfaces()), "file_dirs", "path", "cannot be set")
 }
 
 // The mode is a closed set. AccessMode already reads anything that is not
@@ -177,7 +177,7 @@ func TestValidatePermissions_AcceptsTheWorkedExample(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // UpdateProjectContext replaces the operator's fields and RE-DERIVES the ones
-// relay owns. Without the re-derivation a local project's write_dirs would
+// relay owns. Without the re-derivation a local project's file_dirs would
 // disappear the first time someone edited its mail scope, and the two tools
 // that field governs would start refusing with nothing on screen to say why.
 func TestUpdateProjectContext_ReDerivesTheProjectPathField(t *testing.T) {
@@ -188,8 +188,8 @@ func TestUpdateProjectContext_ReDerivesTheProjectPathField(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	before := contextValues(s.Projects[0].Context["macmcp"])
-	if !hasScopeValue(before, "write_dirs") {
-		t.Fatalf("precondition: write_dirs should have been derived, got %s", s.Projects[0].Context["macmcp"])
+	if !hasScopeValue(before, "file_dirs") {
+		t.Fatalf("precondition: file_dirs should have been derived, got %s", s.Projects[0].Context["macmcp"])
 	}
 
 	s.UpdateProjectContext(proj.ID, map[string]json.RawMessage{
@@ -200,7 +200,7 @@ func TestUpdateProjectContext_ReDerivesTheProjectPathField(t *testing.T) {
 	if !hasScopeValue(after, "mail_accounts") {
 		t.Errorf("operator value was not stored: %s", s.Projects[0].Context["macmcp"])
 	}
-	if !hasScopeValue(after, "write_dirs") {
+	if !hasScopeValue(after, "file_dirs") {
 		t.Errorf("the derived field was destroyed by an operator edit: %s", s.Projects[0].Context["macmcp"])
 	}
 }

--- a/project_permissions_wire_test.go
+++ b/project_permissions_wire_test.go
@@ -27,7 +27,7 @@ func newV2ProjectRoutesServer(t *testing.T) (string, SettingsStore) {
 		s.ExternalMcps = []ExternalMcp{{ID: "macmcp", DisplayName: "macMCP"}}
 	})
 	mux := http.NewServeMux()
-	RegisterProjectRoutes(mux, store, schemaProviderFunc(v2Surfaces), nil, nil, nil)
+	RegisterProjectRoutes(mux, store, schemaProviderFunc(v2Surfaces), nil, nil, nil, nil)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv.URL, store

--- a/project_permissions_wire_test.go
+++ b/project_permissions_wire_test.go
@@ -1,0 +1,249 @@
+package main
+
+// The permission set has to survive the round trip on BOTH surfaces. ADR-004's
+// model is two co-equal editors over one mutator layer, so a field that only
+// eve can set, or only the tray, is a field an operator will eventually set
+// from the wrong window and watch vanish.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newV2ProjectRoutesServer is newProjectRoutesServer with a LIVE v2 surface
+// (macMCP's worked example) instead of fsMCP's v1 fixture, so the scope
+// validation has a declaration to check against.
+func newV2ProjectRoutesServer(t *testing.T) (string, SettingsStore) {
+	t.Helper()
+	store := NewSettingsStoreAt(t.TempDir())
+	if err := store.EnsureInitialized(); err != nil {
+		t.Fatalf("EnsureInitialized: %v", err)
+	}
+	store.With(func(s *Settings) {
+		s.ExternalMcps = []ExternalMcp{{ID: "macmcp", DisplayName: "macMCP"}}
+	})
+	mux := http.NewServeMux()
+	RegisterProjectRoutes(mux, store, schemaProviderFunc(v2Surfaces), nil, nil, nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL, store
+}
+
+// The profile ADR-011's worked example describes, created over HTTP and read
+// back through projectView. Every field the PUT accepted has to be on the GET:
+// a UI that cannot render its own state is one an operator edits blind.
+func TestProjectRoutes_PermissionSetRoundTrips(t *testing.T) {
+	base, store := newV2ProjectRoutesServer(t)
+
+	resp, body := doJSON(t, "POST", base+"/api/projects", map[string]interface{}{
+		"name":            "Hermes — Bob INBOX (read-only)",
+		"kind":            "remote",
+		"allowed_mcp_ids": []string{"macmcp"},
+		"allowed_tools":   map[string][]string{"macmcp": {"mail_*"}},
+		"access":          map[string]string{"macmcp": "read"},
+		"context": map[string]interface{}{
+			"macmcp": map[string]interface{}{
+				"mail_accounts":  []string{"Bob"},
+				"mail_mailboxes": []string{"INBOX"},
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: status %d: %s", resp.StatusCode, body)
+	}
+	var created projectView
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.Kind != ProjectKindRemote {
+		t.Errorf("kind missing from the view: %q", created.Kind)
+	}
+	if got := created.Access["macmcp"]; got != AccessRead {
+		t.Errorf("access missing from the view: %#v", created.Access)
+	}
+	if got := created.AllowedTools["macmcp"]; len(got) != 1 || got[0] != "mail_*" {
+		t.Errorf("allowed_tools missing from the view: %#v", created.AllowedTools)
+	}
+	if !strings.Contains(string(created.Context["macmcp"]), `"Bob"`) {
+		t.Errorf("context missing from the view: %s", created.Context["macmcp"])
+	}
+
+	// And it is what actually reached settings.json, not just what the
+	// response echoed.
+	stored, _ := store.Get().findProjectByID(created.ID)
+	if stored == nil || stored.Access["macmcp"] != AccessRead {
+		t.Fatalf("the mode did not persist: %#v", stored)
+	}
+
+	// GET renders the same thing.
+	resp, body = doJSON(t, "GET", base+"/api/projects/"+created.ID, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: status %d", resp.StatusCode)
+	}
+	var fetched projectView
+	if err := json.Unmarshal(body, &fetched); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if fetched.Access["macmcp"] != AccessRead || len(fetched.AllowedTools["macmcp"]) != 1 {
+		t.Errorf("GET does not show what the POST accepted: %#v", fetched)
+	}
+
+	// PUT patches one layer and leaves the others alone — nil means no change.
+	resp, body = doJSON(t, "PUT", base+"/api/projects/"+created.ID, map[string]interface{}{
+		"access": map[string]string{"macmcp": "write"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update: status %d: %s", resp.StatusCode, body)
+	}
+	var updated projectView
+	if err := json.Unmarshal(body, &updated); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if updated.Access["macmcp"] != AccessWrite {
+		t.Errorf("mode did not change: %#v", updated.Access)
+	}
+	if len(updated.AllowedTools["macmcp"]) != 1 || !strings.Contains(string(updated.Context["macmcp"]), "INBOX") {
+		t.Errorf("an untouched layer was cleared by a patch of another: %#v", updated)
+	}
+}
+
+// A bad value is refused with a 400 and NOTHING is mutated. The whole point of
+// validating on save is that an invalid confinement never becomes a stored one.
+func TestProjectRoutes_RefusesInvalidPermissionsAndMutatesNothing(t *testing.T) {
+	base, store := newV2ProjectRoutesServer(t)
+
+	resp, body := doJSON(t, "POST", base+"/api/projects", map[string]interface{}{
+		"name": "Profile", "kind": "remote",
+		"allowed_mcp_ids": []string{"macmcp"},
+		"access":          map[string]string{"macmcp": "read"},
+		"context":         map[string]interface{}{"macmcp": map[string]interface{}{"mail_accounts": []string{"Bob"}}},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("seed: status %d: %s", resp.StatusCode, body)
+	}
+	var created projectView
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	for _, bad := range []struct {
+		label string
+		patch map[string]interface{}
+		says  string
+	}{
+		{"undeclared field", map[string]interface{}{"context": map[string]interface{}{"macmcp": map[string]interface{}{"mail_folders": []string{"INBOX"}}}}, "mail_folders"},
+		{"empty scope", map[string]interface{}{"context": map[string]interface{}{"macmcp": map[string]interface{}{"mail_accounts": []string{}}}}, "mail_accounts"},
+		{"derived field", map[string]interface{}{"context": map[string]interface{}{"macmcp": map[string]interface{}{"write_dirs": []string{"/etc"}}}}, "write_dirs"},
+		{"bad mode", map[string]interface{}{"access": map[string]string{"macmcp": "admin"}}, "admin"},
+		{"bad pattern", map[string]interface{}{"allowed_tools": map[string][]string{"macmcp": {"mail_["}}}, "mail_["},
+	} {
+		resp, body := doJSON(t, "PUT", base+"/api/projects/"+created.ID, bad.patch)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%s: status %d, want 400: %s", bad.label, resp.StatusCode, body)
+			continue
+		}
+		if !strings.Contains(string(body), bad.says) {
+			t.Errorf("%s: refusal does not name the problem (%q): %s", bad.label, bad.says, body)
+		}
+		stored, _ := store.Get().findProjectByID(created.ID)
+		if stored == nil || !strings.Contains(string(stored.Context["macmcp"]), "Bob") || stored.Access["macmcp"] != AccessRead {
+			t.Fatalf("%s: a refused patch mutated the stored record: %#v", bad.label, stored)
+		}
+	}
+}
+
+// GET /api/mcps/{id}/scope_fields is how eve renders the same panel the tray
+// does. An MCP relay has never connected to is a 404, not an empty list:
+// "scopes nothing" and "cannot say" are different answers and only one of them
+// lets an editor safely offer no fields.
+func TestProjectRoutes_ScopeFields(t *testing.T) {
+	base, _ := newV2ProjectRoutesServer(t)
+
+	resp, body := doJSON(t, "GET", base+"/api/mcps/macmcp/scope_fields", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.StatusCode, body)
+	}
+	var fields []ScopeFieldView
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(fields) != 3 {
+		t.Fatalf("want macMCP's three restrict fields, got %d: %s", len(fields), body)
+	}
+	byName := map[string]ScopeFieldView{}
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+	// The absent-source-means-operator rule is applied ON THE GO SIDE so no
+	// consumer has to re-derive it.
+	if got := byName["mail_accounts"]; got.Source != ContextSourceOperator || !got.Enumerable || got.Description == "" {
+		t.Errorf("mail_accounts projected wrong: %#v", got)
+	}
+	if got := byName["write_dirs"]; got.Source != ContextSourceProjectPath {
+		t.Errorf("write_dirs must be marked derived, got %q", got.Source)
+	}
+	if got := byName["mail_mailboxes"]; len(got.DependsOn) != 1 || got.DependsOn[0] != "mail_accounts" {
+		t.Errorf("depends_on lost: %#v", got)
+	}
+
+	resp, _ = doJSON(t, "GET", base+"/api/mcps/nosuch/scope_fields", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown MCP: status %d, want 404", resp.StatusCode)
+	}
+}
+
+// The IPC path decodes the SAME DTOs, so it accepts and refuses identically.
+// This is the half a tray-only operator sees.
+func TestIpcUpdateProject_PermissionSetRoundTrips(t *testing.T) {
+	ctx, store, ui, _ := newProjectsIPC(t)
+	ctx.Tools.(*fakeTools).surfaces = v2Surfaces()
+
+	ipcCreateProject(ctx, mustJSON(t, map[string]interface{}{
+		"name": "Profile", "kind": "remote",
+		"allowed_mcp_ids": []string{"macmcp"},
+		"allowed_tools":   map[string][]string{"macmcp": {"mail_*"}},
+		"access":          map[string]string{"macmcp": "read"},
+		"context":         map[string]interface{}{"macmcp": map[string]interface{}{"mail_accounts": []string{"Bob"}}},
+	}))
+	if args, ok := findEvent(ui, "onProjectError"); ok {
+		t.Fatalf("create emitted an error: %v", args)
+	}
+	projects := store.Get().Projects
+	if len(projects) != 1 {
+		t.Fatalf("want 1 project, got %d", len(projects))
+	}
+	id := projects[0].ID
+	if projects[0].Access["macmcp"] != AccessRead || len(projects[0].AllowedTools["macmcp"]) != 1 {
+		t.Fatalf("create did not persist the permission set: %#v", projects[0])
+	}
+
+	ipcUpdateProject(ctx, mustJSON(t, map[string]interface{}{
+		"id":      id,
+		"context": map[string]interface{}{"macmcp": map[string]interface{}{"mail_accounts": []string{"Bob"}, "mail_mailboxes": []string{"INBOX"}}},
+	}))
+	stored, _ := store.Get().findProjectByID(id)
+	if !strings.Contains(string(stored.Context["macmcp"]), "INBOX") {
+		t.Fatalf("update did not persist the scope: %s", stored.Context["macmcp"])
+	}
+
+	// And the same refusal, over IPC, as an error event rather than a 400.
+	ipcUpdateProject(ctx, mustJSON(t, map[string]interface{}{
+		"id":      id,
+		"context": map[string]interface{}{"macmcp": map[string]interface{}{"mail_folders": []string{"x"}}},
+	}))
+	args, ok := findEvent(ui, "onProjectError")
+	if !ok {
+		t.Fatal("an undeclared scope field was accepted over IPC")
+	}
+	if len(args) == 0 || !strings.Contains(fmt.Sprint(args[0]), "mail_folders") {
+		t.Errorf("IPC refusal does not name the field: %v", args)
+	}
+	stored, _ = store.Get().findProjectByID(id)
+	if !strings.Contains(string(stored.Context["macmcp"]), "INBOX") {
+		t.Errorf("a refused IPC patch mutated the record: %s", stored.Context["macmcp"])
+	}
+}

--- a/project_permissions_wire_test.go
+++ b/project_permissions_wire_test.go
@@ -137,7 +137,7 @@ func TestProjectRoutes_RefusesInvalidPermissionsAndMutatesNothing(t *testing.T) 
 	}{
 		{"undeclared field", map[string]interface{}{"context": map[string]interface{}{"macmcp": map[string]interface{}{"mail_folders": []string{"INBOX"}}}}, "mail_folders"},
 		{"empty scope", map[string]interface{}{"context": map[string]interface{}{"macmcp": map[string]interface{}{"mail_accounts": []string{}}}}, "mail_accounts"},
-		{"derived field", map[string]interface{}{"context": map[string]interface{}{"macmcp": map[string]interface{}{"write_dirs": []string{"/etc"}}}}, "write_dirs"},
+		{"derived field", map[string]interface{}{"context": map[string]interface{}{"macmcp": map[string]interface{}{"file_dirs": []string{"/etc"}}}}, "file_dirs"},
 		{"bad mode", map[string]interface{}{"access": map[string]string{"macmcp": "admin"}}, "admin"},
 		{"bad pattern", map[string]interface{}{"allowed_tools": map[string][]string{"macmcp": {"mail_["}}}, "mail_["},
 	} {
@@ -183,8 +183,8 @@ func TestProjectRoutes_ScopeFields(t *testing.T) {
 	if got := byName["mail_accounts"]; got.Source != ContextSourceOperator || !got.Enumerable || got.Description == "" {
 		t.Errorf("mail_accounts projected wrong: %#v", got)
 	}
-	if got := byName["write_dirs"]; got.Source != ContextSourceProjectPath {
-		t.Errorf("write_dirs must be marked derived, got %q", got.Source)
+	if got := byName["file_dirs"]; got.Source != ContextSourceProjectPath {
+		t.Errorf("file_dirs must be marked derived, got %q", got.Source)
 	}
 	if got := byName["mail_mailboxes"]; len(got.DependsOn) != 1 || got.DependsOn[0] != "mail_accounts" {
 		t.Errorf("depends_on lost: %#v", got)

--- a/project_routes.go
+++ b/project_routes.go
@@ -273,6 +273,26 @@ func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps McpSurf
 		writeJSON(w, http.StatusOK, map[string]string{"path": dir})
 	})
 
+	// GET /api/mcps/{id}/scope_fields — the scope: "restrict" fields an MCP
+	// declares, so an editor can render one input per field with the MCP's own
+	// description as help text (ADR-011 decision 6). It is the same projection
+	// the tray's Settings UI is seeded with; ADR-004's two co-equal editors
+	// cannot stay co-equal if only one of them can see what may be narrowed.
+	//
+	// An MCP relay has never connected to has no entry, and that is a 404
+	// rather than an empty list: "this MCP scopes nothing" and "relay cannot
+	// tell you what this MCP scopes" are different answers, and only one of
+	// them means an editor may safely offer no fields.
+	mux.HandleFunc("GET /api/mcps/{id}/scope_fields", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		surfaces := mcps.AllMcpSurfaces()
+		if _, ok := surfaces[id]; !ok {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "MCP not registered or not connected"})
+			return
+		}
+		writeJSON(w, http.StatusOK, surfaces.Schema(id).ScopeFieldViews())
+	})
+
 	// GET /api/mcps/{id}/tools — live tool list for the project picker.
 	// 503 when no provider is wired (test contexts) or 404 when MCP is unknown
 	// / not connected yet.

--- a/project_routes.go
+++ b/project_routes.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 )
 
-// ContextSchemasProvider supplies MCP context schemas required when
-// (re)scoping a project's token. Implemented by *ExternalMcpManager.
-type ContextSchemasProvider interface {
-	AllContextSchemas() map[string]json.RawMessage
+// McpSurfaceProvider supplies what relay knows at runtime about each MCP —
+// context schema, its version, and the tool surface — required when
+// (re)scoping a project's token and when validating its grants.
+// Implemented by *ExternalMcpManager.
+type McpSurfaceProvider interface {
+	AllMcpSurfaces() McpSurfaces
 }
 
 // MCPToolsProvider supplies the live tool list for a registered MCP. The
@@ -73,7 +75,7 @@ func reconcileProjectSkill(ctx context.Context, lister SkillLister, proj Project
 //
 // onChange fires after any successful create/update/delete/rotate so the
 // tray-window state can re-render. nil = no fan-out (tests use this).
-func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps ContextSchemasProvider, tools MCPToolsProvider, skillLister SkillLister, onChange ProjectsChangedFn) {
+func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps McpSurfaceProvider, tools MCPToolsProvider, skillLister SkillLister, onChange ProjectsChangedFn) {
 	notify := func() {
 		if onChange != nil {
 			onChange()
@@ -111,7 +113,7 @@ func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps Context
 		var created Project
 		var createErr error
 		if err := store.With(func(s *Settings) {
-			created, createErr = applyProjectCreate(s, body, mcps.AllContextSchemas())
+			created, createErr = applyProjectCreate(s, body, mcps.AllMcpSurfaces())
 		}); err != nil {
 			slog.Error("create project: save failed", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save settings"})
@@ -152,7 +154,7 @@ func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps Context
 		var found bool
 		var updateErr error
 		if err := store.With(func(s *Settings) {
-			updated, found, updateErr = applyProjectUpdate(s, id, body, mcps.AllContextSchemas)
+			updated, found, updateErr = applyProjectUpdate(s, id, body, mcps.AllMcpSurfaces)
 		}); err != nil {
 			slog.Error("update project: save failed", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save settings"})

--- a/project_routes.go
+++ b/project_routes.go
@@ -24,6 +24,48 @@ type MCPToolsProvider interface {
 	ToolInfos(id string) []ToolInfo
 }
 
+// enumHTTPStatus maps an enumeration outcome onto an HTTP code.
+//
+// The body always carries the precise `status` — a client that must tell
+// "does not implement" from "could not answer right now" reads that field, not
+// the code. What the code is for is the client that reads only codes: a
+// failure must never arrive as a 200 whose empty body could be mistaken for
+// "there are none". So the two MCP failures get 5xx (the upstream refused, or
+// could not answer), relay's own refusals get 4xx, and only a real answer is
+// a 200.
+func enumHTTPStatus(status string) int {
+	switch status {
+	case EnumStatusOK, EnumStatusUnsupported:
+		// Unsupported is a 200 because it is a true, final answer ABOUT the
+		// MCP — "this one does not enumerate" — not a failure to obtain one.
+		// The caller's correct response is to render a text box, permanently.
+		return http.StatusOK
+	case EnumStatusUnknownMcp:
+		return http.StatusNotFound
+	case EnumStatusNotEnumerable:
+		return http.StatusBadRequest
+	case EnumStatusInvalidField:
+		// The MCP refused the request relay built. Relay is the one at fault,
+		// and a 502 says the failure is on this side of the operator.
+		return http.StatusBadGateway
+	default: // EnumStatusUnavailable
+		return http.StatusServiceUnavailable
+	}
+}
+
+// enumerateRequest is the POST body for the enumeration route.
+//
+// POST rather than GET, for a read: `values` is a map from field name to that
+// field's already-chosen value, whose shape is whatever the MCP declared, and
+// there is no query-string encoding of that which does not quietly assume
+// array-of-string. A GET would work today and break on the first MCP that
+// declares something else, which is precisely the domain knowledge ADR-011
+// decision 3 keeps out of relay.
+type enumerateRequest struct {
+	Field  string                     `json:"field"`
+	Values map[string]json.RawMessage `json:"values,omitempty"`
+}
+
 // ProjectsChangedFn is fired after any successful project mutation so the
 // tray UI can refresh. nil = no fan-out.
 type ProjectsChangedFn func()
@@ -67,6 +109,10 @@ func reconcileProjectSkill(ctx context.Context, lister SkillLister, proj Project
 // Settings are persisted on save; cross-process state stays consistent
 // because relay's bridge re-reads settings on every ListProjects/GetProject.
 //
+// enum asks a connected MCP to list a scope field's real values; nil makes
+// POST /api/mcps/{id}/enumerate answer "unavailable" rather than 404, because
+// the field still exists and the editor's fallback is still text entry.
+//
 // skillLister resolves the live tool set for a project token; supplying nil
 // disables out-of-band skill regen.
 //
@@ -75,7 +121,7 @@ func reconcileProjectSkill(ctx context.Context, lister SkillLister, proj Project
 //
 // onChange fires after any successful create/update/delete/rotate so the
 // tray-window state can re-render. nil = no fan-out (tests use this).
-func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps McpSurfaceProvider, tools MCPToolsProvider, skillLister SkillLister, onChange ProjectsChangedFn) {
+func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps McpSurfaceProvider, tools MCPToolsProvider, enum ContextEnumerator, skillLister SkillLister, onChange ProjectsChangedFn) {
 	notify := func() {
 		if onChange != nil {
 			onChange()
@@ -291,6 +337,27 @@ func RegisterProjectRoutes(mux *http.ServeMux, store SettingsStore, mcps McpSurf
 			return
 		}
 		writeJSON(w, http.StatusOK, surfaces.Schema(id).ScopeFieldViews())
+	})
+
+	// POST /api/mcps/{id}/enumerate — ask the MCP for one scope field's real
+	// values (ADR-011 decision 6), so the editor offers a picker instead of a
+	// free-text box whose easiest failure is a confinement that does not
+	// confine. Body: {"field": "...", "values": {"<dependency>": <chosen>}}.
+	//
+	// It sits on the same mux as every other project route, which is the
+	// guard: the frontend socket is 0600 and every request through it is
+	// bearer-checked by frontendBearerAuth. Enumeration is disclosure — the
+	// list of every mail account on this machine — so it belongs behind the
+	// same admin boundary and nowhere near the remote listener, whose dispatch
+	// table is ListTools and CallTool and gains nothing here.
+	mux.HandleFunc("POST /api/mcps/{id}/enumerate", func(w http.ResponseWriter, r *http.Request) {
+		var body enumerateRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+			return
+		}
+		res := enumerateScopeField(r.Context(), mcps.AllMcpSurfaces(), enum, r.PathValue("id"), body.Field, body.Values)
+		writeJSON(w, enumHTTPStatus(res.Status), res)
 	})
 
 	// GET /api/mcps/{id}/tools — live tool list for the project picker.

--- a/project_routes_test.go
+++ b/project_routes_test.go
@@ -34,7 +34,7 @@ func newProjectRoutesServer(t *testing.T) (*httptest.Server, SettingsStore) {
 		}
 	})
 	mux := http.NewServeMux()
-	RegisterProjectRoutes(mux, store, schemaProviderFunc(testSchemas), nil, nil, nil)
+	RegisterProjectRoutes(mux, store, schemaProviderFunc(testSchemas), nil, nil, nil, nil)
 	return httptest.NewServer(mux), store
 }
 
@@ -72,7 +72,7 @@ func newProjectRoutesServerFull(t *testing.T, tools MCPToolsProvider, lister Ski
 		}
 	})
 	mux := http.NewServeMux()
-	RegisterProjectRoutes(mux, store, schemaProviderFunc(testSchemas), tools, lister, onChange)
+	RegisterProjectRoutes(mux, store, schemaProviderFunc(testSchemas), tools, nil, lister, onChange)
 	return httptest.NewServer(mux), store
 }
 

--- a/project_routes_test.go
+++ b/project_routes_test.go
@@ -17,9 +17,9 @@ import (
 
 // schemaProviderFunc adapts a plain function to ContextSchemasProvider
 // so the tests can reuse the existing testSchemas() helper.
-type schemaProviderFunc func() map[string]json.RawMessage
+type schemaProviderFunc func() McpSurfaces
 
-func (f schemaProviderFunc) AllContextSchemas() map[string]json.RawMessage { return f() }
+func (f schemaProviderFunc) AllMcpSurfaces() McpSurfaces { return f() }
 
 func newProjectRoutesServer(t *testing.T) (*httptest.Server, SettingsStore) {
 	t.Helper()

--- a/project_test.go
+++ b/project_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 // testSchemas returns a schema map marking fsmcp as a filesystem MCP.
-func testSchemas() map[string]json.RawMessage {
-	return map[string]json.RawMessage{
-		"fsmcp": json.RawMessage(`{"allowed_dirs":{"type":"array"}}`),
+func testSchemas() McpSurfaces {
+	return McpSurfaces{
+		"fsmcp": {Schema: json.RawMessage(`{"allowed_dirs":{"type":"array"}}`)},
 	}
 }
 
@@ -392,7 +392,7 @@ func TestProjectTokenScoping(t *testing.T) {
 	}
 	tools := unmarshalTools(t, result)
 	if len(tools) != 2 {
-		t.Fatalf("expected 2 tools (fs_read, fs_write — fs_bash disabled), got %d: %v", len(tools), toolNames(tools))
+		t.Fatalf("expected 2 tools (fs_read, fs_write — fs_bash disabled), got %d: %v", len(tools), toolNamesOf(tools))
 	}
 	for _, tool := range tools {
 		if tool.Name == "fs_bash" {
@@ -502,7 +502,7 @@ func TestProjectPersistence(t *testing.T) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-func toolNames(tools []mcp.Tool) []string {
+func toolNamesOf(tools []mcp.Tool) []string {
 	names := make([]string, len(tools))
 	for i, t := range tools {
 		names[i] = t.Name

--- a/remote_server_test.go
+++ b/remote_server_test.go
@@ -38,6 +38,7 @@ type remoteFixture struct {
 	router  *appRouter
 	audit   *AuditRecorder
 	server  *RemoteServer
+	mgr     *ExternalMcpManager
 	project Project
 	bundle  *enrolmentBundle
 	// mcpCalls counts how many times a tool actually reached the (mock) MCP.
@@ -100,6 +101,15 @@ func newRemoteFixture(t *testing.T, opts remoteFixtureOpts) *remoteFixture {
 		}
 		f.project, createErr = s.CreateProjectWithTokenKind(
 			ProjectKindRemote, "Mail", "", []string{"macmcp"}, []string{}, nil, nil)
+		// A profile names the tools it may call (ADR-011 decision 2b); with no
+		// allowed_tools it holds none of them, which is the fail-closed default
+		// and would make every fixture below assert on a denial. These tests
+		// are about the transport, the budget and the audit path, so they grant
+		// the one tool they exercise.
+		s.UpdateProjectAllowedTools(f.project.ID, map[string][]string{"macmcp": {"mail_*"}})
+		if p, _ := s.findProjectByID(f.project.ID); p != nil {
+			f.project = *p
+		}
 		for i := 0; i < opts.extraProjects; i++ {
 			if _, err := s.CreateProjectWithTokenKind(
 				ProjectKindRemote, fmt.Sprintf("Extra %d", i), "", []string{"macmcp"}, []string{}, nil, nil); err != nil {
@@ -110,7 +120,7 @@ func newRemoteFixture(t *testing.T, opts remoteFixtureOpts) *remoteFixture {
 	assertNoErr(t, createErr, "create remote project")
 
 	mgr := NewExternalMcpManager(nil)
-	addMockConn(mgr, "macmcp", newMockConn("macmcp", simpleTools("mail_search"),
+	addMockConn(mgr, "macmcp", newMockConn("macmcp", readOnlyTools("mail_search"),
 		func(context.Context, string, interface{}) (json.RawMessage, error) {
 			f.mcpCalls.Add(1)
 			return json.RawMessage(`{"content":[{"type":"text","text":"3 messages"}]}`), nil
@@ -119,6 +129,7 @@ func newRemoteFixture(t *testing.T, opts remoteFixtureOpts) *remoteFixture {
 	if !opts.disableAudit {
 		f.audit = newTestAudit(t, nil)
 	}
+	f.mgr = mgr
 	f.router = &appRouter{
 		store:    store,
 		tools:    mgr,

--- a/router.go
+++ b/router.go
@@ -106,7 +106,7 @@ func checkToolAccess(tok *StoredToken, mcpID, toolName string, tool *mcp.Tool) e
 }
 
 // readOnlyHintTrue reports whether a tool's annotations declare
-// readOnlyHint: true, EXPLICITLY and as a boolean.
+// readOnlyHint: true, EXPLICITLY, as a boolean, and under that exact spelling.
 //
 // Everything else is "mutating": absent, null, malformed JSON, a string
 // "true", a number 1, or false. That is the whole rule and it is what makes
@@ -114,23 +114,45 @@ func checkToolAccess(tok *StoredToken, mcpID, toolName string, tool *mcp.Tool) e
 // denied to every read-only grant until someone annotates it truthfully,
 // rather than silently granted the way a denylist would grant it.
 //
+// The spelling is read from a map rather than decoded into a struct, and that
+// is the point rather than a style choice. encoding/json matches struct fields
+// CASE-INSENSITIVELY, so a `ReadOnlyHint *bool` field admitted
+// {"ReadOnlyHint":true} and {"readonlyhint":true} — neither of which is the
+// key the MCP specification defines — to every read-only grant, while the
+// comment above said such blobs were treated as mutating. A map lookup is
+// exact, which is what decision 2 asks for: relay's whole claim here is that a
+// mode is decided from a declaration an operator can read and diff, and a
+// buggy or hostile MCP must not be able to widen a grant with a near-miss key
+// that no reviewer reading the spec would recognise as one.
+//
 // It must never panic on a malformed blob: annotations are server-supplied
 // bytes relay has carried unread since the type was written, so this is the
 // first code to trust them with anything, and the first thing an MCP could get
-// wrong. json.Unmarshal into a *bool gives all three answers — error, nil,
-// value — without a type switch that could miss a case.
+// wrong. Unmarshalling the one value into a *bool gives all three answers —
+// error, nil, value — without a type switch that could miss a case.
 func readOnlyHintTrue(tool *mcp.Tool) bool {
 	if tool == nil || len(tool.Annotations) == 0 {
 		return false
 	}
-	var probe struct {
-		ReadOnlyHint *bool `json:"readOnlyHint"`
-	}
-	if err := json.Unmarshal(tool.Annotations, &probe); err != nil {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(tool.Annotations, &fields); err != nil {
 		return false
 	}
-	return probe.ReadOnlyHint != nil && *probe.ReadOnlyHint
+	raw, ok := fields[mcpReadOnlyHintKey]
+	if !ok {
+		return false
+	}
+	var hint *bool
+	if err := json.Unmarshal(raw, &hint); err != nil {
+		return false
+	}
+	return hint != nil && *hint
 }
+
+// mcpReadOnlyHintKey is the annotation key the MCP specification defines, in
+// the specification's spelling. It is a constant so the exactness above is one
+// value rather than a string literal someone later "tidies".
+const mcpReadOnlyHintKey = "readOnlyHint"
 
 // findTool locates a tool definition by name in a list.
 func findTool(tools []mcp.Tool, name string) *mcp.Tool {

--- a/router.go
+++ b/router.go
@@ -26,6 +26,13 @@ type ToolProvider interface {
 	Tools(id string) []mcp.Tool
 	FindToolOwner(name string) (string, *ExternalMcp)
 	CallTool(ctx context.Context, id, name string, args, meta json.RawMessage) (json.RawMessage, error)
+	// McpSurfaceFor is the LIVE declaration: the context schema an MCP
+	// published at its last handshake, that schema's version, and the tools it
+	// exposes now. Read at call time rather than from the stored grant because
+	// the only defence that catches an MCP which grew a scope field AFTER a
+	// grant was validated is one that asks the running server (ADR-011
+	// decision 4).
+	McpSurfaceFor(id string) McpSurface
 }
 
 // ToolManager extends ToolProvider with lifecycle operations for reconciling
@@ -45,15 +52,91 @@ type ServiceReloader interface {
 // the specified MCP and (optionally) tool. Pass empty toolName to check
 // only the MCP-level permission. Operates on the StoredToken directly so it
 // works for both external tokens (from Tokens[]) and project tokens (inline).
-func checkToolAccess(tok *StoredToken, mcpID, toolName string) error {
+//
+// tool is the live definition of toolName, needed for the access-mode check
+// below; pass nil for an MCP-level check. A nil tool with a non-empty toolName
+// means relay could not find the definition, which under a read grant is a
+// denial — see the fail-closed reasoning there.
+func checkToolAccess(tok *StoredToken, mcpID, toolName string, tool *mcp.Tool) error {
 	// Check MCP-level permission.
 	if perm, ok := tok.Permissions[mcpID]; ok && perm == PermOff {
 		return jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, fmt.Errorf("access denied: MCP '%s' is disabled for this token", mcpID))
 	}
-	// Check tool-level disabling.
-	if toolName != "" && tok.DisabledTools != nil {
-		if slices.Contains(tok.DisabledTools[mcpID], toolName) {
-			return jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, fmt.Errorf("access denied: tool '%s' is disabled for this token", toolName))
+	if toolName == "" {
+		return nil
+	}
+	// Which tools (ADR-011 decision 2b). An allowlist, checked before the mode
+	// and before the denylist: a tool this grant does not name is refused
+	// whatever its annotations say and whatever any denylist omits. This is
+	// what keeps a profile named for one mailbox out of capture_screenshot,
+	// shortcuts_run, web_fetch and the address book — all of which the live
+	// "Hermes Mail" enrolment was measured to reach, and none of which the
+	// access mode below would have stopped, because they are honestly
+	// read-only.
+	if !tok.ToolAllowed(mcpID, toolName) {
+		return jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, fmt.Errorf("access denied: tool '%s' is not in the allowed tools for MCP '%s'", toolName, mcpID))
+	}
+	// Which operations (ADR-011 decision 2). Relay applies this rule itself, at
+	// its own chokepoint, and what it decided is visible in the audit log and
+	// in what ListTools returns. What relay does NOT verify is the input: the
+	// classification of a tool as read-only is the MCP's own readOnlyHint, and
+	// an MCP that mislabels a mutating tool defeats the mode. That is still
+	// meaningfully stronger than the resource layer — a false hint is a lie
+	// told in a published tool list an operator can read and diff, whereas an
+	// ignored _meta leaves no trace anywhere.
+	if tok.AccessMode(mcpID) != AccessWrite {
+		if !readOnlyHintTrue(tool) {
+			return jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, fmt.Errorf("access denied: tool '%s' is not annotated read-only and this grant is read-only for MCP '%s'", toolName, mcpID))
+		}
+	}
+	// Tool-level disabling. Last, because it can only ever SUBTRACT from what
+	// the three allowlists already admitted, and because that is the order in
+	// which the layers are easiest to reason about: which MCP, which tools,
+	// which operations, then what an operator switched off by hand.
+	//
+	// Applied to every token kind, not only local ones. validateProjectShape
+	// refuses disabled_tools on a remote-kind record — an inert control is
+	// worse than none — but a record that acquired one by a route validation
+	// did not cover (a hand-edited settings.json) must still have it honoured:
+	// ignoring a denylist is the one direction that widens.
+	if tok.DisabledTools != nil && slices.Contains(tok.DisabledTools[mcpID], toolName) {
+		return jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, fmt.Errorf("access denied: tool '%s' is disabled for this token", toolName))
+	}
+	return nil
+}
+
+// readOnlyHintTrue reports whether a tool's annotations declare
+// readOnlyHint: true, EXPLICITLY and as a boolean.
+//
+// Everything else is "mutating": absent, null, malformed JSON, a string
+// "true", a number 1, or false. That is the whole rule and it is what makes
+// ADR-011 finding 9 safe — a tool added to an MCP after a grant was written is
+// denied to every read-only grant until someone annotates it truthfully,
+// rather than silently granted the way a denylist would grant it.
+//
+// It must never panic on a malformed blob: annotations are server-supplied
+// bytes relay has carried unread since the type was written, so this is the
+// first code to trust them with anything, and the first thing an MCP could get
+// wrong. json.Unmarshal into a *bool gives all three answers — error, nil,
+// value — without a type switch that could miss a case.
+func readOnlyHintTrue(tool *mcp.Tool) bool {
+	if tool == nil || len(tool.Annotations) == 0 {
+		return false
+	}
+	var probe struct {
+		ReadOnlyHint *bool `json:"readOnlyHint"`
+	}
+	if err := json.Unmarshal(tool.Annotations, &probe); err != nil {
+		return false
+	}
+	return probe.ReadOnlyHint != nil && *probe.ReadOnlyHint
+}
+
+// findTool locates a tool definition by name in a list.
+func findTool(tools []mcp.Tool, name string) *mcp.Tool {
+	for i := range tools {
+		if tools[i].Name == name {
+			return &tools[i]
 		}
 	}
 	return nil
@@ -201,13 +284,15 @@ func (r *appRouter) ListTools(ctx context.Context, token string) (json.RawMessag
 
 	// External MCP tools.
 	for _, ext := range settings.ExternalMcps {
-		if !isServiceToken && checkToolAccess(stored, ext.ID, "") != nil {
+		if !isServiceToken && checkToolAccess(stored, ext.ID, "", nil) != nil {
 			continue
 		}
+		note := newScopeNoter(r, stored, ext.ID, isServiceToken)
 		for _, t := range r.tools.Tools(ext.ID) {
-			if !isServiceToken && checkToolAccess(stored, ext.ID, t.Name) != nil {
+			if !isServiceToken && checkToolAccess(stored, ext.ID, t.Name, &t) != nil {
 				continue
 			}
+			note.annotate(&t)
 			tools = append(tools, t)
 		}
 	}
@@ -239,13 +324,20 @@ func (r *appRouter) ListSkillBuckets(ctx context.Context, token string) ([]Skill
 	isServiceToken := stored.Name == serviceTokenName
 	groups := map[string][]mcp.Tool{}
 	for _, ext := range settings.ExternalMcps {
-		if !isServiceToken && checkToolAccess(stored, ext.ID, "") != nil {
+		if !isServiceToken && checkToolAccess(stored, ext.ID, "", nil) != nil {
 			continue
 		}
+		note := newScopeNoter(r, stored, ext.ID, isServiceToken)
 		for _, t := range r.tools.Tools(ext.ID) {
-			if !isServiceToken && checkToolAccess(stored, ext.ID, t.Name) != nil {
+			if !isServiceToken && checkToolAccess(stored, ext.ID, t.Name, &t) != nil {
 				continue
 			}
+			// Membership already mirrors ListTools; the scope note has to
+			// mirror it too, or the skill renderer would describe a tool
+			// surface as unconfined that ListTools describes as confined.
+			// appendScopeNote is idempotent, which is what keeps the two
+			// paths from double-appending if they ever meet.
+			note.annotate(&t)
 			key := t.Category
 			if key == "" {
 				key = ext.DisplayName
@@ -312,8 +404,36 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 	}
 	au.setMcp(extID)
 
+	// The MCP's LIVE declaration, read now rather than taken from the stored
+	// grant. That is the whole point of the third defence below: a grant is
+	// validated once, at edit time, against the schema an MCP published then,
+	// and an MCP that grows a restrict-field afterwards would otherwise keep
+	// serving every existing grant with no scope at all (ADR-011 decision 4).
+	surface := r.tools.McpSurfaceFor(extID)
+	schema := ParseContextSchema(surface.Schema, surface.SchemaVersion)
+
 	if !isServiceToken {
-		if err := checkToolAccess(stored, extID, name); err != nil {
+		if err := checkToolAccess(stored, extID, name, findTool(r.tools.Tools(extID), name)); err != nil {
+			au.done(AuditOutcomeDenied, err)
+			return nil, err
+		}
+		// Presence re-check. `denied` is the right outcome because RELAY made
+		// this decision — no MCP was reached, nothing was probed, and there is
+		// no result to relay (ADR-011 decision 7). It sits ahead of the budget
+		// check because a call with no scope is not a legitimate call whose
+		// pattern of use was refused; it is a call the grant does not cover.
+		//
+		// NOT remote-only, deliberately. Decision 2's asymmetric default
+		// (remote reads, local writes) is not extended to scope, because the
+		// two are different in kind: a MODE has a defensible default in each
+		// direction, and a SCOPE has none — there is no answer to "which
+		// mailbox" relay could pick and be right about. One has a safe wrong
+		// answer; the other does not. So a local project granted an MCP with an
+		// operator-set restrict field must set a value or lose the tools that
+		// field governs. A source: "project_path" field is unaffected, because
+		// SyncProjectToken derives it for a local project and it is therefore
+		// always present.
+		if err := checkScopePresence(schema, contextValues(stored.Context[extID]), extID, name); err != nil {
 			au.done(AuditOutcomeDenied, err)
 			return nil, err
 		}
@@ -351,6 +471,17 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 	// project id so an MCP can attribute the call to a project without
 	// trusting LLM-supplied values. Relay is the project authority here.
 	meta := mergeProjectID(stored.Context[extID], stored.ProjectID)
+
+	// Audit the authority actually in force (ADR-011 decision 7). The grant
+	// alone does not answer "was this call confined?" once an operator has
+	// since edited the profile, and re-reading settings.json at query time
+	// answers a different question. Taken from `meta` — the bytes about to go
+	// on the wire — rather than from the project, so what is recorded is what
+	// was injected. This runs BEFORE au.intent() so a remote call's intent
+	// record carries it.
+	if !isServiceToken {
+		au.setAuthority(stored.AccessMode(extID), scopeFromMeta(schema, meta))
+	}
 
 	// Fail-closed auditing for a remote caller (ADR-010 decision 5). This sits
 	// after auth resolution, so the actor is known and the record is
@@ -401,6 +532,95 @@ func mergeProjectID(base json.RawMessage, projectID string) json.RawMessage {
 		return base
 	}
 	return out
+}
+
+// checkScopePresence is ADR-011 decision 4's third defence: for every
+// scope: "restrict" field in the MCP's live schema that governs this tool,
+// require a non-empty value in the grant's context.
+//
+// Absent and empty are both refusals, and that is the whole rule — relay
+// writes a non-empty value or it refuses the operation, never a placeholder,
+// never [], never null, never the field omitted while the grant stands.
+// "No restriction" is deliberately not expressible as emptiness.
+//
+// A v1 schema is exempt: it declared no scope keywords, so there is nothing
+// here to be present.
+func checkScopePresence(cs ContextSchema, values map[string]json.RawMessage, mcpID, toolName string) error {
+	if !cs.V2() {
+		return nil
+	}
+	for _, f := range cs.GoverningFields(toolName) {
+		if hasScopeValue(values, f.Name) {
+			continue
+		}
+		return jsonrpc.NewCodedError(jsonrpc.CodeUnauthorized, fmt.Errorf(
+			"access denied: MCP '%s' scopes tool '%s' by %q and this grant supplies no value for it",
+			mcpID, toolName, f.Name))
+	}
+	return nil
+}
+
+// scopeFromMeta extracts the injected scope for the audit record: ONLY the
+// fields the MCP declared as scope: "restrict", never the whole context map.
+//
+// _meta is a general channel and a future MCP may pass an API key through it.
+// Logging the map wholesale would make the audit file the place credentials go
+// to be archived. Filtering to declared restrict-fields is both safer and
+// domain-blind — relay is not deciding which keys look sensitive, it is
+// recording only the ones something declared as permissions.
+func scopeFromMeta(cs ContextSchema, meta json.RawMessage) map[string]json.RawMessage {
+	if !cs.V2() {
+		return nil
+	}
+	injected := contextValues(meta)
+	if len(injected) == 0 {
+		return nil
+	}
+	out := make(map[string]json.RawMessage)
+	for _, f := range cs.RestrictFields() {
+		if v, ok := injected[f.Name]; ok {
+			out[f.Name] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// scopeNoter appends ADR-011 decision 8's scope note to the tools in a
+// listing. Built once per MCP per listing so the schema is parsed once rather
+// than per tool.
+//
+// A client is told its own limits here because renderBucketSkillMd is the
+// wrong ONLY place: access profiles have no skills (validateProjectShape
+// refuses GenerateSkill), so the agent this feature exists for would never see
+// it. One implementation reaches the remote listener's ListTools,
+// `relay mcp call --list`, and ListSkillBuckets.
+type scopeNoter struct {
+	schema ContextSchema
+	values map[string]json.RawMessage
+}
+
+func newScopeNoter(r *appRouter, stored *StoredToken, mcpID string, isServiceToken bool) scopeNoter {
+	// A service token holds no project context and is not scoped, so there is
+	// nothing truthful to say about its limits.
+	if isServiceToken || stored == nil {
+		return scopeNoter{}
+	}
+	surface := r.tools.McpSurfaceFor(mcpID)
+	cs := ParseContextSchema(surface.Schema, surface.SchemaVersion)
+	if !cs.V2() {
+		return scopeNoter{}
+	}
+	return scopeNoter{schema: cs, values: contextValues(stored.Context[mcpID])}
+}
+
+func (n scopeNoter) annotate(t *mcp.Tool) {
+	if !n.schema.V2() {
+		return
+	}
+	t.Description = appendScopeNote(t.Description, scopeNoteFor(n.schema, n.values, t.Name))
 }
 
 func (r *appRouter) ValidateAdmin(token string) error {

--- a/router.go
+++ b/router.go
@@ -434,11 +434,24 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 	surface := r.tools.McpSurfaceFor(extID)
 	schema := ParseContextSchema(surface.Schema, surface.SchemaVersion)
 
-	// The _meta this call would run with: the per-token context for this MCP
-	// plus the authenticated project id, so an MCP can attribute the call to a
-	// project without trusting LLM-supplied values. Relay is the project
-	// authority here.
-	meta := mergeProjectID(stored.Context[extID], stored.ProjectID)
+	// The _meta this call would run with: the per-token context for this MCP,
+	// filtered down to fields the LIVE schema still declares, plus the
+	// authenticated project id so an MCP can attribute the call to a project
+	// without trusting LLM-supplied values. Relay is the project authority
+	// here.
+	//
+	// The filter matters because a stored blob outlives the schema that wrote
+	// it: an MCP can rename or drop a field (macMCP's write_dirs -> file_dirs
+	// is exactly this) between when a grant was written and when a call runs,
+	// and relay never rewrites settings.json to match — see the stale-key note
+	// on SyncProjectToken. Without it, a value stored under a name the MCP no
+	// longer recognises still went out on the wire under that name: dead
+	// weight ordinarily, but on an MCP that gives a NEW field the OLD name a
+	// stale value would be handed to logic that never validated it.
+	// filterKnownContextFields is only reached once extID has already resolved
+	// to a live connection (FindToolOwner above), so this can never be the
+	// "MCP is merely down" case that makes pruning stored data unsafe.
+	meta := mergeProjectID(filterKnownContextFields(stored.Context[extID], schema), stored.ProjectID)
 
 	// Audit the authority actually in force (ADR-011 decision 7), BEFORE the
 	// first thing that can refuse.

--- a/router.go
+++ b/router.go
@@ -434,7 +434,33 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 	surface := r.tools.McpSurfaceFor(extID)
 	schema := ParseContextSchema(surface.Schema, surface.SchemaVersion)
 
+	// The _meta this call would run with: the per-token context for this MCP
+	// plus the authenticated project id, so an MCP can attribute the call to a
+	// project without trusting LLM-supplied values. Relay is the project
+	// authority here.
+	meta := mergeProjectID(stored.Context[extID], stored.ProjectID)
+
+	// Audit the authority actually in force (ADR-011 decision 7), BEFORE the
+	// first thing that can refuse.
+	//
+	// It used to be recorded where the call was about to be handed to the MCP,
+	// which is after the tool check, the scope-presence check and the budget —
+	// so `denied` and `throttled` records, the two a security review reads
+	// first, carried no `access` and no `scope` at all, while docs/audit-log.md
+	// says a call_tool record carries what was in force. "Which layer refused
+	// this, and under what mode?" is not answerable from a record that omits
+	// the mode, and `relay audit --outcome denied` was the query it was least
+	// answerable for.
+	//
+	// It is taken from `meta` — the bytes that would go on the wire — rather
+	// than from the project, so a permitted call records what was injected. On
+	// a refusal nothing is injected, and what is recorded is then the authority
+	// the call was judged against, which is the same set of values and is the
+	// question the record is being asked. Assembling meta a few lines earlier
+	// costs one map merge on a path that was going to do it anyway.
 	if !isServiceToken {
+		au.setAuthority(stored.AccessMode(extID), scopeFromMeta(schema, meta))
+
 		if err := checkToolAccess(stored, extID, name, findTool(r.tools.Tools(extID), name)); err != nil {
 			au.done(AuditOutcomeDenied, err)
 			return nil, err
@@ -487,22 +513,6 @@ func (r *appRouter) CallTool(ctx context.Context, name string, args json.RawMess
 			au.done(AuditOutcomeThrottled, err)
 			return nil, err
 		}
-	}
-
-	// Inject per-token context as _meta for this MCP, plus the authenticated
-	// project id so an MCP can attribute the call to a project without
-	// trusting LLM-supplied values. Relay is the project authority here.
-	meta := mergeProjectID(stored.Context[extID], stored.ProjectID)
-
-	// Audit the authority actually in force (ADR-011 decision 7). The grant
-	// alone does not answer "was this call confined?" once an operator has
-	// since edited the profile, and re-reading settings.json at query time
-	// answers a different question. Taken from `meta` — the bytes about to go
-	// on the wire — rather than from the project, so what is recorded is what
-	// was injected. This runs BEFORE au.intent() so a remote call's intent
-	// record carries it.
-	if !isServiceToken {
-		au.setAuthority(stored.AccessMode(extID), scopeFromMeta(schema, meta))
 	}
 
 	// Fail-closed auditing for a remote caller (ADR-010 decision 5). This sits

--- a/router_access_test.go
+++ b/router_access_test.go
@@ -182,9 +182,17 @@ func TestReadOnlyHint_OnlyAnExplicitBooleanTrueCounts(t *testing.T) {
 }
 
 func TestCheckToolAccess_ReadGrantAdmitsOnlyAnnotatedReadOnlyTools(t *testing.T) {
+	// The allowlist is enumerated rather than wildcarded so this test measures
+	// the MODE and nothing else. A pattern wide enough to admit every tool
+	// ("*_*", "**") is refused by both the editor and the matcher now — that is
+	// F1's fix, and writing one here would have this test passing on a grant
+	// nobody can save.
 	tok := &StoredToken{
-		ProjectKind:  ProjectKindRemote,
-		AllowedTools: map[string][]string{"macmcp": {"*_*"}},
+		ProjectKind: ProjectKindRemote,
+		AllowedTools: map[string][]string{"macmcp": {
+			"mail_*", "xmail_*", "capture_*", "web_*", "contacts_*",
+			"messages_*", "shortcuts_*",
+		}},
 	}
 	surface := macmcpToolSurface()
 	admitted := map[string]bool{"mail_search": true, "mail_get_email": true,
@@ -385,10 +393,21 @@ func TestValidateProjectShape_RefusesAWildcardAllowlistOnAProfile(t *testing.T) 
 	if err := validateProjectShape(remote); err != nil {
 		t.Fatalf("a pattern allowlist was refused: %v", err)
 	}
-	// And a local project keeps the wildcard.
+	// A LOCAL project is refused it too, and for a reason that is not the
+	// profile's. The call-time matcher ignores an over-broad entry (see
+	// toolAllowedByPatterns), so a local project holding ["*"] holds NO tools
+	// of that MCP — an allowlist that reads as "everything" and grants
+	// nothing. Accepting it on save would be validation and enforcement
+	// disagreeing again, which is the whole of F2. The way a local project
+	// says "everything" is to have no list at all, which it did before this
+	// field existed and still does.
 	local := &Project{Path: "/tmp/x", AllowedTools: map[string][]string{"macmcp": {"*"}}}
+	if err := validateProjectShape(local); err == nil {
+		t.Fatal(`a local project was allowed allowed_tools: ["*"], which grants it nothing`)
+	}
+	local.AllowedTools = nil
 	if err := validateProjectShape(local); err != nil {
-		t.Fatalf("a local project was refused a wildcard allowlist: %v", err)
+		t.Fatalf("a local project with no allowlist was refused: %v", err)
 	}
 }
 

--- a/router_access_test.go
+++ b/router_access_test.go
@@ -163,6 +163,21 @@ func TestReadOnlyHint_OnlyAnExplicitBooleanTrueCounts(t *testing.T) {
 		{"a string that says true", `{"readOnlyHint":"true"}`, false},
 		{"the number one", `{"readOnlyHint":1}`, false},
 		{"an object", `{"readOnlyHint":{"yes":true}}`, false},
+		// F3. encoding/json matches STRUCT FIELDS case-insensitively, so a
+		// `ReadOnlyHint *bool` field admitted every one of these to a
+		// read-only grant while the doc comment said they were treated as
+		// mutating. None of them is the key the MCP specification defines, and
+		// decision 2's whole claim is that the mode is decided from a
+		// declaration an operator can read and diff — a buggy or hostile MCP
+		// must not be able to widen a grant with a near-miss spelling.
+		{"the spec key in title case", `{"ReadOnlyHint":true}`, false},
+		{"the spec key lowercased", `{"readonlyhint":true}`, false},
+		{"the spec key shouted", `{"READONLYHINT":true}`, false},
+		{"a near miss with an underscore", `{"read_only_hint":true}`, false},
+		// A variant beside the real key does not get a vote either way: the
+		// exact key is the only one read, and here it says false.
+		{"a variant beside an honest false", `{"ReadOnlyHint":true,"readOnlyHint":false}`, false},
+		{"a variant beside an honest true", `{"ReadOnlyHint":false,"readOnlyHint":true}`, true},
 		{"annotations are not an object", `"read-only"`, false},
 		{"annotations are an array", `[true]`, false},
 		{"invalid JSON", `{"readOnlyHint":`, false},
@@ -178,6 +193,30 @@ func TestReadOnlyHint_OnlyAnExplicitBooleanTrueCounts(t *testing.T) {
 	}
 	if readOnlyHintTrue(nil) {
 		t.Error("a nil tool was admitted to a read grant")
+	}
+}
+
+// The same finding at the boundary rather than at the helper: a tool whose
+// only claim to being read-only is a case variant is refused by a read grant,
+// and is not listed to one.
+func TestReadOnlyHint_ACaseVariantDoesNotAdmitAToolToAReadProfile(t *testing.T) {
+	tools := []mcp.Tool{
+		{Name: "mail_search", Description: "Search mail.", Annotations: json.RawMessage(`{"readOnlyHint":true}`)},
+		{Name: "mail_wipe", Description: "Delete everything.", Annotations: json.RawMessage(`{"ReadOnlyHint":true}`)},
+		{Name: "mail_burn", Description: "Delete everything, quietly.", Annotations: json.RawMessage(`{"readonlyhint":true}`)},
+	}
+	r := newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+		tools:        tools,
+	})
+	if got := listedToolNames(t, r); strings.Join(got, ",") != "mail_search" {
+		t.Fatalf("read profile listed %v, want only the honestly annotated tool", got)
+	}
+	for _, tool := range []string{"mail_wipe", "mail_burn"} {
+		if _, err := r.CallTool(context.Background(), tool, json.RawMessage(`{}`), testToken); err == nil {
+			t.Errorf("%s widened a read grant with a spelling the MCP spec does not define", tool)
+		}
 	}
 }
 

--- a/router_access_test.go
+++ b/router_access_test.go
@@ -1,0 +1,455 @@
+package main
+
+// ADR-011 decisions 2 and 2b: the two allowlists relay can enforce by itself —
+// which tools a grant names, and which operations it may perform. Both fail
+// closed, and the negative cases are the point of this file: an unannotated
+// tool is refused, a malformed annotations blob is refused, a profile with no
+// allowed_tools holds nothing, and a "*" never reaches a profile at all.
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	"relaygo/mcp"
+)
+
+// macmcpToolSurface is a scale model of the real thing: mail tools beside the
+// twelve other domains macMCP bundles with them. The annotations are the ones
+// macMCP actually publishes, which is what makes finding 9's measurement
+// reproducible here — capture_screenshot, web_fetch and contacts_list_groups
+// are all honestly read-only, so the access mode alone leaves every one of
+// them reachable from a profile named for a mailbox.
+func macmcpToolSurface() []mcp.Tool {
+	readOnly := json.RawMessage(`{"readOnlyHint":true}`)
+	return []mcp.Tool{
+		{Name: "mail_search", Description: "Search mail.", Annotations: readOnly},
+		{Name: "mail_get_email", Description: "Read one message.", Annotations: readOnly},
+		// No annotations at all — macMCP omits them on mail_move and
+		// mail_mark_read today, and an absent hint is not a claim of safety.
+		{Name: "mail_move", Description: "Move a message."},
+		// Explicitly false.
+		{Name: "mail_send", Description: "Send mail.", Annotations: json.RawMessage(`{"readOnlyHint":false}`)},
+		// A blob that parses as JSON but not as annotations. Must deny, and
+		// must not panic — these are server-supplied bytes relay has carried
+		// unread until now.
+		{Name: "mail_save_attachment", Description: "Write a file.", Annotations: json.RawMessage(`"read-only, honest"`)},
+		// A hint of the wrong type inside a well-formed object.
+		{Name: "mail_get_source", Description: "Fetch raw source.", Annotations: json.RawMessage(`{"readOnlyHint":"true"}`)},
+
+		{Name: "capture_screenshot", Description: "Screenshot the display.", Annotations: readOnly},
+		{Name: "web_fetch", Description: "Fetch a URL.", Annotations: readOnly},
+		{Name: "contacts_list_groups", Description: "List contact groups.", Annotations: readOnly},
+		{Name: "messages_send", Description: "Send an iMessage."},
+		{Name: "shortcuts_run", Description: "Run a Shortcut."},
+		// The anchoring case: "mail_*" must not reach it.
+		{Name: "xmail_send", Description: "Not a mail tool.", Annotations: readOnly},
+	}
+}
+
+type profileOpts struct {
+	kind          ProjectKind
+	allowedTools  map[string][]string
+	access        map[string]string
+	contextValues map[string]json.RawMessage
+	disabled      map[string][]string
+	tools         []mcp.Tool
+	schema        string
+	schemaVersion int
+}
+
+// newProfileRouter builds a router whose single project grants "macmcp" and
+// carries exactly the ADR-011 fields under test.
+func newProfileRouter(t *testing.T, o profileOpts) *appRouter {
+	t.Helper()
+	tools := o.tools
+	if tools == nil {
+		tools = macmcpToolSurface()
+	}
+	proj := Project{
+		ID:            "test-project",
+		Name:          "test",
+		Kind:          o.kind,
+		AllowedMcpIDs: []string{"macmcp"},
+		Token:         testToken,
+		TokenHash:     hashToken(testToken),
+		AllowedTools:  o.allowedTools,
+		Access:        o.access,
+		DisabledTools: o.disabled,
+	}
+	if !proj.IsRemote() {
+		proj.Path = "/tmp/test"
+	}
+	if o.contextValues != nil {
+		blob, err := json.Marshal(o.contextValues)
+		if err != nil {
+			t.Fatalf("marshal context: %v", err)
+		}
+		proj.Context = map[string]json.RawMessage{"macmcp": blob}
+	}
+	s := &Settings{
+		Version:      1,
+		ExternalMcps: []ExternalMcp{{ID: "macmcp", DisplayName: "macMCP"}},
+		Projects:     []Project{proj},
+		AdminSecret:  "supersecretadmin",
+	}
+	mgr := NewExternalMcpManager(nil)
+	addMockConn(mgr, "macmcp", newMockConn("macmcp", tools,
+		okHandler(`{"content":[{"type":"text","text":"ok"}]}`)))
+	if o.schema != "" {
+		addMockSchema(mgr, "macmcp", o.schema, o.schemaVersion)
+	}
+	return newTestRouter(t, s, mgr)
+}
+
+func listedToolNames(t *testing.T, r *appRouter) []string {
+	t.Helper()
+	raw, err := r.ListTools(context.Background(), testToken)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	var names []string
+	for _, tool := range unmarshalTools(t, raw) {
+		names = append(names, tool.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// ---------------------------------------------------------------------------
+// Decision 2: the access mode
+// ---------------------------------------------------------------------------
+
+func TestAccessMode_DefaultsAreAsymmetric(t *testing.T) {
+	// This asymmetry is the decision, not an oversight: a grant to another
+	// machine that nobody has said anything about must not mutate, while every
+	// local project written before this field existed must keep working.
+	remote := &StoredToken{ProjectKind: ProjectKindRemote}
+	if got := remote.AccessMode("macmcp"); got != AccessRead {
+		t.Errorf("remote default = %q, want %q", got, AccessRead)
+	}
+	local := &StoredToken{}
+	if got := local.AccessMode("macmcp"); got != AccessWrite {
+		t.Errorf("local default = %q, want %q", got, AccessWrite)
+	}
+	// A hand-edited value that is not exactly "write" narrows rather than
+	// widens; there is no third mode for it to mean.
+	for _, bogus := range []string{"readwrite", "rw", "WRITE", "", "admin"} {
+		tok := &StoredToken{Access: map[string]string{"macmcp": bogus}}
+		if got := tok.AccessMode("macmcp"); got != AccessRead {
+			t.Errorf("access %q resolved to %q, want %q", bogus, got, AccessRead)
+		}
+	}
+	if got := (&StoredToken{Access: map[string]string{"macmcp": AccessWrite}}).AccessMode("macmcp"); got != AccessWrite {
+		t.Errorf(`explicit "write" resolved to %q`, got)
+	}
+	if got := (*StoredToken)(nil).AccessMode("macmcp"); got != AccessRead {
+		t.Errorf("a nil token resolved to %q, want %q", got, AccessRead)
+	}
+}
+
+func TestReadOnlyHint_OnlyAnExplicitBooleanTrueCounts(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations string
+		want        bool
+	}{
+		{"explicit true", `{"readOnlyHint":true}`, true},
+		{"explicit false", `{"readOnlyHint":false}`, false},
+		{"absent from a real object", `{"title":"Search"}`, false},
+		{"null", `{"readOnlyHint":null}`, false},
+		{"a string that says true", `{"readOnlyHint":"true"}`, false},
+		{"the number one", `{"readOnlyHint":1}`, false},
+		{"an object", `{"readOnlyHint":{"yes":true}}`, false},
+		{"annotations are not an object", `"read-only"`, false},
+		{"annotations are an array", `[true]`, false},
+		{"invalid JSON", `{"readOnlyHint":`, false},
+		{"empty", ``, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := mcp.Tool{Name: "t", Annotations: json.RawMessage(tc.annotations)}
+			if got := readOnlyHintTrue(&tool); got != tc.want {
+				t.Errorf("readOnlyHintTrue(%s) = %v, want %v", tc.annotations, got, tc.want)
+			}
+		})
+	}
+	if readOnlyHintTrue(nil) {
+		t.Error("a nil tool was admitted to a read grant")
+	}
+}
+
+func TestCheckToolAccess_ReadGrantAdmitsOnlyAnnotatedReadOnlyTools(t *testing.T) {
+	tok := &StoredToken{
+		ProjectKind:  ProjectKindRemote,
+		AllowedTools: map[string][]string{"macmcp": {"*_*"}},
+	}
+	surface := macmcpToolSurface()
+	admitted := map[string]bool{"mail_search": true, "mail_get_email": true,
+		"capture_screenshot": true, "web_fetch": true, "contacts_list_groups": true,
+		"xmail_send": true}
+	for _, tool := range surface {
+		err := checkToolAccess(tok, "macmcp", tool.Name, &tool)
+		if admitted[tool.Name] && err != nil {
+			t.Errorf("%s: read grant refused an annotated read-only tool: %v", tool.Name, err)
+		}
+		if !admitted[tool.Name] && err == nil {
+			t.Errorf("%s: read grant admitted a tool that is not annotated read-only", tool.Name)
+		}
+	}
+}
+
+func TestCheckToolAccess_ANilToolDefinitionIsDeniedUnderARead(t *testing.T) {
+	// Relay could not find the definition, so it cannot verify the hint. That
+	// is not a reason to admit.
+	tok := &StoredToken{ProjectKind: ProjectKindRemote, AllowedTools: map[string][]string{"macmcp": {"mail_*"}}}
+	if err := checkToolAccess(tok, "macmcp", "mail_search", nil); err == nil {
+		t.Fatal("a tool whose definition relay could not find was admitted to a read grant")
+	}
+	// And a write grant is unaffected: the mode check is the only thing that
+	// reads annotations.
+	tok.Access = map[string]string{"macmcp": AccessWrite}
+	if err := checkToolAccess(tok, "macmcp", "mail_search", nil); err != nil {
+		t.Fatalf("a write grant was refused for want of an annotation: %v", err)
+	}
+}
+
+func TestListTools_ReadProfileHidesEveryMutatingTool(t *testing.T) {
+	r := newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+	})
+	got := listedToolNames(t, r)
+	want := []string{"mail_get_email", "mail_search"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("read profile listed %v, want %v", got, want)
+	}
+	// The same profile in write mode sees the mutating mail tools too.
+	r = newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+		access:       map[string]string{"macmcp": AccessWrite},
+	})
+	if got := listedToolNames(t, r); len(got) != 6 {
+		t.Fatalf("write profile listed %v, want all six mail_* tools", got)
+	}
+}
+
+func TestCallTool_ReadProfileDeniesAMutatingToolAndAuditsItAsDenied(t *testing.T) {
+	r := newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+	})
+	rec := newTestAudit(t, nil)
+	r.audit = rec
+
+	if _, err := r.CallTool(context.Background(), "mail_send", json.RawMessage(`{}`), testToken); err == nil {
+		t.Fatal("a read-only profile sent mail")
+	}
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("a read-only profile could not search mail: %v", err)
+	}
+
+	events := readLoggedEvents(t, rec)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 audit records, got %d", len(events))
+	}
+	if events[0].Outcome != AuditOutcomeDenied {
+		t.Errorf("refusal recorded as %q, want %q — relay made this decision", events[0].Outcome, AuditOutcomeDenied)
+	}
+	if events[1].Outcome != AuditOutcomeOK || events[1].Access != AccessRead {
+		t.Errorf("permitted call recorded as outcome=%q access=%q", events[1].Outcome, events[1].Access)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Decision 2b: allowed_tools
+// ---------------------------------------------------------------------------
+
+// TestListTools_ProfileNamedForMailDoesNotHoldTheRestOfMacMcp is finding 9's
+// measurement turned into an assertion. The live "Hermes Mail" enrolment was
+// authorized for capture_screenshot, capture_audio, shortcuts_run, web_fetch
+// and contacts_list_groups; every one of those is honestly read-only, so the
+// access mode does not touch them and only an allowlist does.
+func TestListTools_ProfileNamedForMailDoesNotHoldTheRestOfMacMcp(t *testing.T) {
+	r := newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+		access:       map[string]string{"macmcp": AccessWrite},
+	})
+	got := listedToolNames(t, r)
+	for _, name := range got {
+		if !strings.HasPrefix(name, "mail_") {
+			t.Errorf("a mail profile was shown %q", name)
+		}
+	}
+	for _, forbidden := range []string{"capture_screenshot", "web_fetch", "contacts_list_groups", "messages_send", "shortcuts_run"} {
+		if slices.Contains(got, forbidden) {
+			t.Errorf("a mail profile was shown %q", forbidden)
+		}
+		if _, err := r.CallTool(context.Background(), forbidden, json.RawMessage(`{}`), testToken); err == nil {
+			t.Errorf("a mail profile called %q", forbidden)
+		}
+	}
+	// The anchoring case: "mail_*" is not a prefix search over the name.
+	if slices.Contains(got, "xmail_send") {
+		t.Error(`"mail_*" admitted xmail_send`)
+	}
+	if _, err := r.CallTool(context.Background(), "xmail_send", json.RawMessage(`{}`), testToken); err == nil {
+		t.Error(`"mail_*" admitted a call to xmail_send`)
+	}
+}
+
+func TestAllowedTools_AbsentMeansNothingForAProfileAndEverythingLocally(t *testing.T) {
+	// A profile with no allowlist holds no tools: a grant to another machine
+	// must be an enumeration someone typed.
+	r := newProfileRouter(t, profileOpts{kind: ProjectKindRemote, access: map[string]string{"macmcp": AccessWrite}})
+	if got := listedToolNames(t, r); len(got) != 0 {
+		t.Fatalf("a profile with no allowed_tools was shown %v", got)
+	}
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err == nil {
+		t.Fatal("a profile with no allowed_tools called a tool")
+	}
+	// An explicitly empty list is the same as an absent one; there is no
+	// reading under which saving an empty allowlist meant "everything".
+	r = newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {}},
+		access:       map[string]string{"macmcp": AccessWrite},
+	})
+	if got := listedToolNames(t, r); len(got) != 0 {
+		t.Fatalf("a profile with an empty allowed_tools was shown %v", got)
+	}
+
+	// A LOCAL project is unchanged: no allowlist means every tool, with
+	// disabled_tools still subtracting.
+	r = newProfileRouter(t, profileOpts{disabled: map[string][]string{"macmcp": {"shortcuts_run"}}})
+	got := listedToolNames(t, r)
+	if len(got) != len(macmcpToolSurface())-1 {
+		t.Fatalf("local project listed %d tools, want all but the disabled one", len(got))
+	}
+	if slices.Contains(got, "shortcuts_run") {
+		t.Error("disabled_tools stopped subtracting for a local project")
+	}
+	if _, err := r.CallTool(context.Background(), "messages_send", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("a local project was refused a mutating tool: %v", err)
+	}
+}
+
+func TestListSkillBuckets_MirrorsListToolsFiltering(t *testing.T) {
+	// The skill renderer reads this, and a bucket that named a tool ListTools
+	// hides would advertise a capability the caller does not have.
+	r := newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+	})
+	buckets, err := r.ListSkillBuckets(context.Background(), testToken)
+	if err != nil {
+		t.Fatalf("ListSkillBuckets: %v", err)
+	}
+	var bucketed []string
+	for _, b := range buckets {
+		for _, tool := range b.Tools {
+			bucketed = append(bucketed, tool.Name)
+		}
+	}
+	slices.Sort(bucketed)
+	if strings.Join(bucketed, ",") != strings.Join(listedToolNames(t, r), ",") {
+		t.Fatalf("skill buckets hold %v, ListTools shows %v", bucketed, listedToolNames(t, r))
+	}
+}
+
+func TestValidateProjectShape_RefusesAWildcardAllowlistOnAProfile(t *testing.T) {
+	// ADR-009 decision 4's reasoning one level down: registering a new tool is
+	// the same event as registering a new MCP, at finer grain and far more
+	// often.
+	remote := &Project{Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"},
+		AllowedTools: map[string][]string{"macmcp": {"*"}}}
+	err := validateProjectShape(remote)
+	if err == nil {
+		t.Fatal(`a profile was allowed allowed_tools: ["*"]`)
+	}
+	if !strings.Contains(err.Error(), "allowed_tools") || !strings.Contains(err.Error(), "macmcp") {
+		t.Errorf("refusal should name the field and the MCP, got: %v", err)
+	}
+	// A "*" hidden among real patterns is the same wildcard.
+	remote.AllowedTools = map[string][]string{"macmcp": {"mail_*", "*"}}
+	if validateProjectShape(remote) == nil {
+		t.Fatal(`a profile was allowed a "*" beside real patterns`)
+	}
+	// Patterns are fine — the layers compose, so a future mail_delete_everything
+	// is still refused by the mode and still confined by the scope.
+	remote.AllowedTools = map[string][]string{"macmcp": {"mail_*"}}
+	if err := validateProjectShape(remote); err != nil {
+		t.Fatalf("a pattern allowlist was refused: %v", err)
+	}
+	// And a local project keeps the wildcard.
+	local := &Project{Path: "/tmp/x", AllowedTools: map[string][]string{"macmcp": {"*"}}}
+	if err := validateProjectShape(local); err != nil {
+		t.Fatalf("a local project was refused a wildcard allowlist: %v", err)
+	}
+}
+
+func TestValidateProjectShape_RefusesADenylistOnAProfile(t *testing.T) {
+	// An inert control is worse than none: it reads on the screen as a
+	// boundary and decides nothing allowed_tools has not already decided.
+	remote := &Project{Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"},
+		AllowedTools:  map[string][]string{"macmcp": {"mail_*"}},
+		DisabledTools: map[string][]string{"macmcp": {"messages_send"}}}
+	err := validateProjectShape(remote)
+	if err == nil {
+		t.Fatal("a profile was allowed disabled_tools")
+	}
+	if !strings.Contains(err.Error(), "allowed_tools") {
+		t.Errorf("refusal should name the mechanism that does bound a profile, got: %v", err)
+	}
+	// An empty entry is not a denylist.
+	remote.DisabledTools = map[string][]string{"macmcp": {}}
+	if err := validateProjectShape(remote); err != nil {
+		t.Fatalf("an empty disabled_tools entry was refused: %v", err)
+	}
+	// Nor is a leftover for an MCP the record no longer grants — that is what
+	// converting a local fsMCP project to remote produces, and SyncProjectToken
+	// prunes it moments later.
+	remote.DisabledTools = map[string][]string{"fsmcp": {v1FsBashTool}}
+	if err := validateProjectShape(remote); err != nil {
+		t.Fatalf("a leftover denylist for an ungranted MCP was refused: %v", err)
+	}
+}
+
+func TestCheckToolAccess_ADenylistStillNarrowsWhereverItCameFrom(t *testing.T) {
+	// validateProjectShape refuses disabled_tools on a profile, but a record
+	// that acquired one by a route validation did not cover must still have it
+	// honoured: ignoring a denylist is the one direction that widens.
+	tok := &StoredToken{
+		ProjectKind:   ProjectKindRemote,
+		AllowedTools:  map[string][]string{"macmcp": {"mail_*"}},
+		Access:        map[string]string{"macmcp": AccessWrite},
+		DisabledTools: map[string][]string{"macmcp": {"mail_send"}},
+	}
+	tool := mcp.Tool{Name: "mail_send"}
+	if err := checkToolAccess(tok, "macmcp", "mail_send", &tool); err == nil {
+		t.Fatal("a hand-edited denylist on a profile was ignored")
+	}
+}
+
+func TestCheckToolAccess_ServiceTokensAreUnaffected(t *testing.T) {
+	// Service tokens bypass checkToolAccess entirely in the router, exactly as
+	// before. Assert it through the router rather than the helper, since that
+	// is where the bypass lives.
+	r := newProfileRouter(t, profileOpts{kind: ProjectKindRemote})
+	svcToken := "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss"
+	r.serviceTokens.Register(hashToken(svcToken))
+	raw, err := r.ListTools(context.Background(), svcToken)
+	if err != nil {
+		t.Fatalf("ListTools as service: %v", err)
+	}
+	if got := len(unmarshalTools(t, raw)); got != len(macmcpToolSurface()) {
+		t.Fatalf("service token saw %d tools, want all %d", got, len(macmcpToolSurface()))
+	}
+	if _, err := r.CallTool(context.Background(), "messages_send", json.RawMessage(`{}`), svcToken); err != nil {
+		t.Fatalf("service token was refused a tool: %v", err)
+	}
+}

--- a/router_access_test.go
+++ b/router_access_test.go
@@ -58,6 +58,10 @@ type profileOpts struct {
 	tools         []mcp.Tool
 	schema        string
 	schemaVersion int
+	// enrolments put the profile behind a remote identity, which is what a
+	// per-enrolment budget is keyed on. Empty means no remote caller can be
+	// budgeted, which is every test that only cares about the grant.
+	enrolments []Enrolment
 }
 
 // newProfileRouter builds a router whose single project grants "macmcp" and
@@ -93,6 +97,7 @@ func newProfileRouter(t *testing.T, o profileOpts) *appRouter {
 		Version:      1,
 		ExternalMcps: []ExternalMcp{{ID: "macmcp", DisplayName: "macMCP"}},
 		Projects:     []Project{proj},
+		Enrolments:   o.enrolments,
 		AdminSecret:  "supersecretadmin",
 	}
 	mgr := NewExternalMcpManager(nil)

--- a/router_scope_test.go
+++ b/router_scope_test.go
@@ -163,6 +163,123 @@ func TestAudit_RecordsTheModeAndOnlyTheDeclaredRestrictFields(t *testing.T) {
 	}
 }
 
+// F4. A `denied` or `throttled` record carries the authority the call was
+// refused under, because those are the two records a security review reads
+// first and "which layer refused this, and under what mode?" is not answerable
+// from a record that omits the mode.
+//
+// setAuthority used to run where _meta was assembled, which is AFTER the tool
+// check, the scope-presence check and the budget — so every one of those three
+// refusals wrote a record with no `access` and no `scope` at all, while
+// docs/audit-log.md says a call_tool record carries what was in force. Live,
+// `relay audit --outcome denied` showed neither field on any record.
+func TestAudit_ARefusalCarriesTheAuthorityItWasRefusedUnder(t *testing.T) {
+	scoped := map[string]json.RawMessage{"mail_accounts": json.RawMessage(`["Bob"]`)}
+
+	cases := []struct {
+		name    string
+		tool    string
+		opts    profileOpts
+		outcome string
+	}{
+		{
+			// Refused by the tool allowlist — the layer F1 is about.
+			name: "a tool the allowlist does not name", tool: "web_fetch",
+			opts: profileOpts{kind: ProjectKindRemote,
+				allowedTools:  map[string][]string{"macmcp": {"mail_*"}},
+				contextValues: scoped, schema: scopedSchema, schemaVersion: 2},
+			outcome: AuditOutcomeDenied,
+		},
+		{
+			// Refused by the mode: mail_send is not annotated read-only.
+			name: "a mutating tool under a read grant", tool: "mail_send",
+			opts: profileOpts{kind: ProjectKindRemote,
+				allowedTools:  map[string][]string{"macmcp": {"mail_*"}},
+				contextValues: scoped, schema: scopedSchema, schemaVersion: 2},
+			outcome: AuditOutcomeDenied,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newProfileRouter(t, tc.opts)
+			rec := newTestAudit(t, nil)
+			r.audit = rec
+
+			if _, err := r.CallTool(context.Background(), tc.tool, json.RawMessage(`{}`), testToken); err == nil {
+				t.Fatalf("%s was not refused", tc.tool)
+			}
+			ev := lastEvent(t, rec)
+			if ev.Outcome != tc.outcome {
+				t.Fatalf("outcome = %q, want %q", ev.Outcome, tc.outcome)
+			}
+			if ev.Access != AccessRead {
+				t.Errorf("access = %q, want %q — a refusal must say what mode was in force", ev.Access, AccessRead)
+			}
+			if string(ev.Scope["mail_accounts"]) != `["Bob"]` {
+				t.Errorf("scope = %v, want the value the grant carried", ev.Scope)
+			}
+		})
+	}
+
+	// A grant with no value at all is refused by the presence check, and that
+	// record still has to say which mode it was refused under — the scope is
+	// empty because there was none, which is the finding itself and must be
+	// distinguishable from the field simply not being recorded.
+	t.Run("a grant missing its scope value", func(t *testing.T) {
+		r := newProfileRouter(t, profileOpts{kind: ProjectKindRemote,
+			allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+			access:       map[string]string{"macmcp": AccessWrite},
+			schema:       scopedSchema, schemaVersion: 2})
+		rec := newTestAudit(t, nil)
+		r.audit = rec
+
+		if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err == nil {
+			t.Fatal("a call with no scope value was allowed")
+		}
+		ev := lastEvent(t, rec)
+		if ev.Outcome != AuditOutcomeDenied {
+			t.Fatalf("outcome = %q, want %q", ev.Outcome, AuditOutcomeDenied)
+		}
+		if ev.Access != AccessWrite {
+			t.Errorf("access = %q, want %q", ev.Access, AccessWrite)
+		}
+		if len(ev.Scope) != 0 {
+			t.Errorf("scope = %v, want nothing recorded for a grant that carried none", ev.Scope)
+		}
+	})
+
+	// And the budget refusal, which is the other outcome relay decides by
+	// itself. Both records a review filters on now carry the authority.
+	t.Run("a call over its enrolment budget", func(t *testing.T) {
+		r := newProfileRouter(t, profileOpts{kind: ProjectKindRemote,
+			allowedTools:  map[string][]string{"macmcp": {"mail_*"}},
+			contextValues: scoped, schema: scopedSchema, schemaVersion: 2,
+			enrolments: []Enrolment{{
+				ClientID:    "hermes-mail",
+				Fingerprint: budgetFingerprint("hermes-mail"),
+				ProjectIDs:  []string{"test-project"},
+				Budget:      EnrolmentBudget{WindowSeconds: 60, MaxCalls: 1, MaxResultBytes: 1 << 20},
+			}}})
+		rec := newTestAudit(t, nil)
+		r.audit = rec
+
+		ctx := budgetCtx("hermes-mail")
+		if _, err := r.CallTool(ctx, "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+			t.Fatalf("the first call was refused: %v", err)
+		}
+		if _, err := r.CallTool(ctx, "mail_search", json.RawMessage(`{}`), testToken); err == nil {
+			t.Fatal("the call over the budget succeeded")
+		}
+		ev := lastEvent(t, rec)
+		if ev.Outcome != AuditOutcomeThrottled {
+			t.Fatalf("outcome = %q, want %q", ev.Outcome, AuditOutcomeThrottled)
+		}
+		if ev.Access != AccessRead || string(ev.Scope["mail_accounts"]) != `["Bob"]` {
+			t.Errorf("throttled record carried access=%q scope=%v, want the authority in force", ev.Access, ev.Scope)
+		}
+	})
+}
+
 func TestAudit_ScopeViolationIsAFieldAndNotAnOutcome(t *testing.T) {
 	// ADR-008 already places this case: tool_error means the call completed
 	// and the MCP answered no. Promoting it to an outcome would inflate a

--- a/router_scope_test.go
+++ b/router_scope_test.go
@@ -104,6 +104,55 @@ func TestCallTool_ThePresenceCheckIsNotRemoteOnly(t *testing.T) {
 	}
 }
 
+// TestCallTool_AStaleContextKeyIsNeverInjectedIntoMeta pins the migration
+// hazard an MCP renaming a context field leaves behind: a stored blob outlives
+// the schema that wrote it (macMCP's write_dirs -> file_dirs is the concrete
+// case), relay never rewrites settings.json to match, and _meta is a general
+// channel a caller cannot audit from the outside. The one guarantee that has
+// to hold regardless is that a key the LIVE schema no longer declares is never
+// put on the wire under its old name.
+func TestCallTool_AStaleContextKeyIsNeverInjectedIntoMeta(t *testing.T) {
+	var capturedMeta json.RawMessage
+	capture := func(_ context.Context, _ string, params interface{}) (json.RawMessage, error) {
+		if m, ok := params.(map[string]interface{}); ok {
+			if raw, err := json.Marshal(m["_meta"]); err == nil {
+				capturedMeta = raw
+			}
+		}
+		return json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`), nil
+	}
+
+	proj := Project{
+		ID: "test-project", Name: "test", Kind: ProjectKindRemote,
+		AllowedMcpIDs: []string{"macmcp"}, Token: testToken, TokenHash: hashToken(testToken),
+		AllowedTools: map[string][]string{"macmcp": {"mail_*"}},
+		Access:       map[string]string{"macmcp": AccessWrite},
+		// The stored blob still carries a field the live schema below no
+		// longer declares — exactly what is left behind by a rename.
+		Context: map[string]json.RawMessage{
+			"macmcp": json.RawMessage(`{"mail_accounts":["Bob"],"write_dirs":["/etc"]}`),
+		},
+	}
+	s := &Settings{
+		Version: 1, ExternalMcps: []ExternalMcp{{ID: "macmcp", DisplayName: "macMCP"}},
+		Projects: []Project{proj}, AdminSecret: "supersecretadmin",
+	}
+	mgr := NewExternalMcpManager(nil)
+	addMockConn(mgr, "macmcp", newMockConn("macmcp", macmcpToolSurface(), capture))
+	addMockSchema(mgr, "macmcp", scopedSchema, 2)
+	r := newTestRouter(t, s, mgr)
+
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("call refused: %v", err)
+	}
+	if strings.Contains(string(capturedMeta), "write_dirs") {
+		t.Errorf("a context key the live schema no longer declares reached _meta: %s", capturedMeta)
+	}
+	if !strings.Contains(string(capturedMeta), "mail_accounts") {
+		t.Errorf("a field the live schema DOES declare was dropped too: %s", capturedMeta)
+	}
+}
+
 func TestCallTool_AV1SchemaImposesNoPresenceRequirement(t *testing.T) {
 	// A declaration that never opted into the vocabulary declared no scope
 	// keywords, so there is nothing here to be present.

--- a/router_scope_test.go
+++ b/router_scope_test.go
@@ -1,0 +1,313 @@
+package main
+
+// ADR-011 decisions 4, 7 and 8, at the chokepoint: the call-time presence
+// re-check, what the audit record says about the authority a call ran with,
+// and the scope note a client is told its own limits through.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"relaygo/bridge"
+)
+
+// scopedSchema is macMCP's declaration with the two operator fields only, so a
+// test can turn a scope requirement on without also needing a project path.
+const scopedSchema = `{
+  "mail_accounts": {
+    "type": "array", "items": {"type": "string"},
+    "description": "Mail accounts this client may read from or send as",
+    "scope": "restrict", "source": "operator",
+    "applies_to": ["mail_*"], "enumerable": true
+  }
+}`
+
+func scopedProfile(t *testing.T, kind ProjectKind, values map[string]json.RawMessage) *appRouter {
+	t.Helper()
+	return newProfileRouter(t, profileOpts{
+		kind:          kind,
+		allowedTools:  map[string][]string{"macmcp": {"mail_*", "web_fetch"}},
+		access:        map[string]string{"macmcp": AccessWrite},
+		contextValues: values,
+		schema:        scopedSchema,
+		schemaVersion: 2,
+	})
+}
+
+// TestCallTool_DeniesWhenTheLiveSchemaDeclaresAScopeTheGrantDoesNotSupply is
+// the case the whole third defence exists for: the grant was validated against
+// a schema that had no restrict field, the MCP was upgraded, and nothing
+// re-ran validation. Only a check against the LIVE schema catches it.
+func TestCallTool_DeniesWhenTheLiveSchemaDeclaresAScopeTheGrantDoesNotSupply(t *testing.T) {
+	r := scopedProfile(t, ProjectKindRemote, nil)
+	rec := newTestAudit(t, nil)
+	r.audit = rec
+
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err == nil {
+		t.Fatal("a call governed by an unsupplied scope field was allowed")
+	} else if !strings.Contains(err.Error(), "mail_accounts") {
+		t.Errorf("refusal should name the field the grant is missing, got: %v", err)
+	}
+
+	// A tool the field does not govern is untouched: applies_to is what
+	// selects, and web_fetch is outside "mail_*".
+	if _, err := r.CallTool(context.Background(), "web_fetch", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("an ungoverned tool was refused for want of a scope: %v", err)
+	}
+
+	events := readLoggedEvents(t, rec)
+	if len(events) != 2 || events[0].Outcome != AuditOutcomeDenied {
+		t.Fatalf("scope refusal recorded as %+v", events[0].Outcome)
+	}
+}
+
+func TestCallTool_DeniesAnEmptyScopeValueTheSameAsAnAbsentOne(t *testing.T) {
+	// Absent and empty are both refusals: "no restriction" is deliberately not
+	// expressible as emptiness, so a stored [] must not read as a grant that
+	// confines nothing.
+	for _, empty := range []string{`[]`, `null`, `""`, `{}`} {
+		r := scopedProfile(t, ProjectKindRemote, map[string]json.RawMessage{
+			"mail_accounts": json.RawMessage(empty),
+		})
+		if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err == nil {
+			t.Errorf("scope value %s was accepted as a restriction", empty)
+		}
+	}
+}
+
+func TestCallTool_AllowsWhenTheScopeIsSupplied(t *testing.T) {
+	r := scopedProfile(t, ProjectKindRemote, map[string]json.RawMessage{
+		"mail_accounts": json.RawMessage(`["Bob"]`),
+	})
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("a properly scoped call was refused: %v", err)
+	}
+}
+
+// TestCallTool_ThePresenceCheckIsNotRemoteOnly pins ADR-011 decision 4's
+// deliberate part. The asymmetric default in decision 2 is not extended here,
+// because a mode has a defensible default in each direction and a scope has
+// none — there is no answer to "which mailbox" relay could pick and be right
+// about.
+func TestCallTool_ThePresenceCheckIsNotRemoteOnly(t *testing.T) {
+	local := scopedProfile(t, ProjectKindLocal, nil)
+	if _, err := local.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err == nil {
+		t.Fatal("a local project reached a scope-declaring tool with no scope set")
+	}
+	local = scopedProfile(t, ProjectKindLocal, map[string]json.RawMessage{
+		"mail_accounts": json.RawMessage(`["Bob"]`),
+	})
+	if _, err := local.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("a local project with a scope set was still refused: %v", err)
+	}
+}
+
+func TestCallTool_AV1SchemaImposesNoPresenceRequirement(t *testing.T) {
+	// A declaration that never opted into the vocabulary declared no scope
+	// keywords, so there is nothing here to be present.
+	r := newProfileRouter(t, profileOpts{
+		allowedTools:  map[string][]string{"macmcp": {"mail_*"}},
+		schema:        scopedSchema,
+		schemaVersion: 0,
+	})
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("a v1 schema imposed a presence requirement: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Decision 7: what the record says about the authority
+// ---------------------------------------------------------------------------
+
+func TestAudit_RecordsTheModeAndOnlyTheDeclaredRestrictFields(t *testing.T) {
+	// _meta is a general channel and a future MCP may pass an API key through
+	// it. Logging Context[extID] wholesale would make the audit file the place
+	// credentials go to be archived.
+	r := scopedProfile(t, ProjectKindRemote, map[string]json.RawMessage{
+		"mail_accounts": json.RawMessage(`["Bob"]`),
+		"api_key":       json.RawMessage(`"sk-do-not-log-me"`),
+	})
+	rec := newTestAudit(t, nil)
+	r.audit = rec
+
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	events := readLoggedEvents(t, rec)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(events))
+	}
+	ev := events[0]
+	if ev.Access != AccessWrite {
+		t.Errorf("access recorded as %q, want %q", ev.Access, AccessWrite)
+	}
+	if string(ev.Scope["mail_accounts"]) != `["Bob"]` {
+		t.Errorf("scope did not record the injected value: %v", ev.Scope)
+	}
+	if _, leaked := ev.Scope["api_key"]; leaked {
+		t.Error("a context field the schema does not declare as a restriction was archived in the audit log")
+	}
+	if _, leaked := ev.Scope["project_id"]; leaked {
+		t.Error("project_id was recorded as a resource scope")
+	}
+	// Serialize the whole line: the on-disk contract is what external tooling
+	// greps, and a credential must not appear anywhere in it.
+	line, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	if strings.Contains(string(line), "sk-do-not-log-me") {
+		t.Fatalf("a credential reached the audit line: %s", line)
+	}
+}
+
+func TestAudit_ScopeViolationIsAFieldAndNotAnOutcome(t *testing.T) {
+	// ADR-008 already places this case: tool_error means the call completed
+	// and the MCP answered no. Promoting it to an outcome would inflate a
+	// small enum that --outcome, the CLI table and the UI pill all key on.
+	cases := []struct {
+		name   string
+		result string
+		want   bool
+	}{
+		{"the marker", `{"content":[],"isError":true,"_meta":{"scope_violation":true}}`, true},
+		{"namespaced", `{"content":[],"isError":true,"_meta":{"relay/scope_violation":true}}`, true},
+		{"false", `{"content":[],"isError":true,"_meta":{"scope_violation":false}}`, false},
+		{"a string", `{"content":[],"isError":true,"_meta":{"scope_violation":"yes"}}`, false},
+		{"no marker", `{"content":[],"isError":true}`, false},
+		{"marker without isError", `{"content":[],"_meta":{"scope_violation":true}}`, false},
+		{"_meta is not an object", `{"content":[],"isError":true,"_meta":7}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newProfileRouter(t, profileOpts{
+				allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+				tools:        macmcpToolSurface(),
+			})
+			addMockConn(r.tools.(*ExternalMcpManager), "macmcp",
+				newMockConn("macmcp", macmcpToolSurface(), okHandler(tc.result)))
+			rec := newTestAudit(t, nil)
+			r.audit = rec
+
+			if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+				t.Fatalf("CallTool: %v", err)
+			}
+			ev := readLoggedEvents(t, rec)[0]
+			if ev.ScopeViolation != tc.want {
+				t.Errorf("scope_violation = %v, want %v", ev.ScopeViolation, tc.want)
+			}
+			// Whatever the marker says, an in-protocol refusal is a tool_error
+			// and nothing else.
+			if strings.Contains(tc.result, `"isError":true`) && ev.Outcome != AuditOutcomeToolError {
+				t.Errorf("outcome = %q, want %q", ev.Outcome, AuditOutcomeToolError)
+			}
+		})
+	}
+}
+
+func TestAudit_RemoteIntentCarriesTheAuthorityBeforeTheMcpRuns(t *testing.T) {
+	// The intent record is the one written before the call. An authority
+	// recorded only on the completion would be missing from exactly the record
+	// that survives a crash mid-call.
+	f := newRemoteFixture(t, remoteFixtureOpts{})
+	assertNoErr(t, f.store.With(func(s *Settings) {
+		proj, _ := s.findProjectByID(f.project.ID)
+		proj.Context = map[string]json.RawMessage{
+			"macmcp": json.RawMessage(`{"mail_accounts":["Bob"]}`),
+		}
+	}), "set the profile's scope")
+	addMockSchema(f.mgr, "macmcp", scopedSchema, 2)
+
+	c := f.dial()
+	if resp := c.roundTrip(`{"type":"CallTool","name":"mail_search"}`); resp.Type != bridge.RespResult {
+		t.Fatalf("scoped remote call refused: %s %s", resp.Type, resp.Message)
+	}
+	events := readLoggedEvents(t, f.audit)
+	var intent *AuditEvent
+	for i := range events {
+		if events[i].Phase == AuditPhaseIntent {
+			intent = &events[i]
+		}
+	}
+	if intent == nil {
+		t.Fatal("no intent record")
+	}
+	if intent.Access != AccessRead {
+		t.Errorf("intent access = %q, want %q (a profile defaults to read)", intent.Access, AccessRead)
+	}
+	if string(intent.Scope["mail_accounts"]) != `["Bob"]` {
+		t.Errorf("intent scope = %v", intent.Scope)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Decision 8: the scope note
+// ---------------------------------------------------------------------------
+
+func TestListTools_AppendsTheScopeNoteToGovernedToolsOnly(t *testing.T) {
+	r := scopedProfile(t, ProjectKindRemote, map[string]json.RawMessage{
+		"mail_accounts": json.RawMessage(`["Bob"]`),
+	})
+	raw, err := r.ListTools(context.Background(), testToken)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	seen := map[string]string{}
+	for _, tool := range unmarshalTools(t, raw) {
+		seen[tool.Name] = tool.Description
+	}
+	mail, ok := seen["mail_search"]
+	if !ok {
+		t.Fatal("mail_search was not listed")
+	}
+	if !strings.HasPrefix(mail, "Search mail.") {
+		t.Errorf("the tool's own description was lost: %q", mail)
+	}
+	for _, want := range []string{scopeNotePrefix, "Mail accounts this client may read from or send as", "Bob"} {
+		if !strings.Contains(mail, want) {
+			t.Errorf("scope note %q missing %q", mail, want)
+		}
+	}
+	if web, ok := seen["web_fetch"]; ok && strings.Contains(web, scopeNotePrefix) {
+		t.Errorf("an ungoverned tool got a scope note: %q", web)
+	}
+}
+
+func TestListSkillBuckets_CarriesTheSameNoteWithoutDoubling(t *testing.T) {
+	r := scopedProfile(t, ProjectKindRemote, map[string]json.RawMessage{
+		"mail_accounts": json.RawMessage(`["Bob"]`),
+	})
+	// Both list paths read the same live tool objects. Calling one after the
+	// other is exactly the sequence that would double-append if the note were
+	// written onto shared state instead of onto each path's own copy.
+	if _, err := r.ListTools(context.Background(), testToken); err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	buckets, err := r.ListSkillBuckets(context.Background(), testToken)
+	if err != nil {
+		t.Fatalf("ListSkillBuckets: %v", err)
+	}
+	found := false
+	for _, b := range buckets {
+		for _, tool := range b.Tools {
+			if tool.Name != "mail_search" {
+				continue
+			}
+			found = true
+			if n := strings.Count(tool.Description, scopeNotePrefix); n != 1 {
+				t.Errorf("scope note appears %d times: %q", n, tool.Description)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("mail_search was not bucketed")
+	}
+	// And the live tool list itself was not mutated by either pass.
+	for _, tool := range r.tools.Tools("macmcp") {
+		if strings.Contains(tool.Description, scopeNotePrefix) {
+			t.Fatalf("a listing wrote its note back onto the MCP's own tool list: %q", tool.Description)
+		}
+	}
+}

--- a/settings.go
+++ b/settings.go
@@ -507,7 +507,7 @@ func (s *Settings) UpdateProjectAccess(id string, access map[string]string) {
 // SyncProjectToken runs so every source: "project_path" field is re-derived on
 // top of it. That ordering is what makes a wholesale replace safe: the operator
 // cannot set a derived field (validateProjectPermissions refuses it), so a
-// replace would otherwise DELETE one — and a project whose write_dirs silently
+// replace would otherwise DELETE one — and a project whose file_dirs silently
 // disappeared when its mail scope was edited would lose the two tools that
 // field governs, fail-closed and unexplained. mergeContextField, which
 // SyncProjectToken uses, puts each derived field back without touching the
@@ -569,6 +569,32 @@ func (s *Settings) SetProjectAllowCwdAuth(id string, allow bool) {
 // relay writes the project's path into every field declaring
 // source: "project_path" because the schema asked it to (ADR-011 decision 5).
 // The v1 branch below is the one exception and is scheduled for removal.
+//
+// Deliberately NOT done here: pruning a stored field the live schema no
+// longer declares. macMCP renaming write_dirs to file_dirs is the concrete
+// case — a project synced under the old name keeps a "write_dirs" entry in
+// its stored context.macmcp blob forever, unreachable (nothing governs by
+// that name any more) but not deleted. Two reasons that is the right call
+// rather than a gap:
+//
+//   - surfaces is exactly as reliable as "is this MCP running right now".
+//     An MCP that is merely down — restarting, mid-upgrade, network-flaky if
+//     remote — reports no schema at all, which is bit-for-bit the same shape
+//     as "this schema now declares zero fields". Pruning on that signal would
+//     delete an operator's stored values because a process happened to be
+//     down at sync time, which is a worse failure than a harmless stale key:
+//     ADR-009's reasoning (see the remote-project guard a few lines below)
+//     applies here too.
+//   - it does not need doing here to be safe. A stale key cannot be set by an
+//     operator (validateProjectContextForMcp refuses any name the live schema
+//     does not currently declare, at write time), so the only way one exists
+//     is a schema that changed after the value was written — and it is inert:
+//     filterKnownContextFields drops any key CallTool's _meta injection does
+//     not find in the schema of the MCP it just confirmed is live, so a
+//     stale key is never sent to an MCP under its old name. It just sits in
+//     settings.json, harmlessly, until an operator re-saves that project's
+//     context (UpdateProjectContext replaces the blob) or removes the value
+//     by hand.
 func (s *Settings) SyncProjectToken(proj *Project, surfaces McpSurfaces) {
 	if proj.Context == nil {
 		proj.Context = make(map[string]json.RawMessage)

--- a/settings.go
+++ b/settings.go
@@ -461,6 +461,81 @@ func (s *Settings) UpdateProjectAllowedTools(id string, allowed map[string][]str
 	proj.AllowedTools = cleaned
 }
 
+// UpdateProjectAccess replaces a project's per-MCP operation mode (ADR-011
+// decision 2). Entries naming an MCP the project is not granted are dropped
+// rather than stored, exactly as UpdateProjectAllowedTools drops them: a mode
+// for an MCP this record cannot reach reads as an authority it does not have,
+// and SyncProjectToken prunes them on every resync anyway.
+//
+// An unrecognised mode is stored as given rather than dropped or corrected.
+// Dropping it would fall back to the DEFAULT, which for a local project is
+// write — a mutator silently widening a grant on the strength of a typo. What
+// StoredToken.AccessMode does with a value it does not recognise is read it as
+// read-only, so keeping it is the fail-closed direction; the loud refusal is
+// validateProjectPermissions, at the surfaces an operator actually types into.
+//
+// Does not save; use within store.With.
+func (s *Settings) UpdateProjectAccess(id string, access map[string]string) {
+	proj, _ := s.findProjectByID(id)
+	if proj == nil {
+		return
+	}
+	if len(access) == 0 {
+		proj.Access = nil
+		return
+	}
+	cleaned := make(map[string]string, len(access))
+	for mcpID, mode := range access {
+		if !isWildcard(proj.AllowedMcpIDs) && !slices.Contains(proj.AllowedMcpIDs, mcpID) {
+			continue
+		}
+		cleaned[mcpID] = mode
+	}
+	if len(cleaned) == 0 {
+		proj.Access = nil
+		return
+	}
+	proj.Access = cleaned
+}
+
+// UpdateProjectContext replaces a project's per-MCP context values — the
+// resource scope an operator sets (ADR-011 decisions 4 and 6). Until this
+// existed, Context was only ever DERIVED, by SyncProjectToken, and there was no
+// operator path to it at all (ADR-011 finding 6).
+//
+// The map an operator supplies replaces what was there, and then
+// SyncProjectToken runs so every source: "project_path" field is re-derived on
+// top of it. That ordering is what makes a wholesale replace safe: the operator
+// cannot set a derived field (validateProjectPermissions refuses it), so a
+// replace would otherwise DELETE one — and a project whose write_dirs silently
+// disappeared when its mail scope was edited would lose the two tools that
+// field governs, fail-closed and unexplained. mergeContextField, which
+// SyncProjectToken uses, puts each derived field back without touching the
+// operator's.
+//
+// surfaces is what that re-derivation needs; passing nil means no derivation,
+// which is the pre-ADR-011 contract for a caller with no live MCP manager.
+//
+// Does not save; use within store.With.
+func (s *Settings) UpdateProjectContext(id string, values map[string]json.RawMessage, surfaces McpSurfaces) {
+	proj, _ := s.findProjectByID(id)
+	if proj == nil {
+		return
+	}
+	cleaned := make(map[string]json.RawMessage, len(values))
+	for mcpID, blob := range values {
+		if !isWildcard(proj.AllowedMcpIDs) && !slices.Contains(proj.AllowedMcpIDs, mcpID) {
+			continue
+		}
+		if len(contextValues(blob)) == 0 {
+			continue
+		}
+		cleaned[mcpID] = blob
+	}
+	proj.Context = cleaned
+	s.SyncProjectToken(proj, surfaces)
+}
+
 // SetProjectGenerateSkill toggles the GenerateSkill flag. Extracted from the
 // HTTP route so the IPC path can reuse the same mutation without duplicating
 // the lookup. Does not save; use within store.With.

--- a/settings.go
+++ b/settings.go
@@ -291,7 +291,7 @@ func (s *Settings) UpdateProjectKind(id string, kind ProjectKind) {
 	// client reaches — a host directory, its allowed_dirs context, cwd auth —
 	// rather than a loud error. Refuse silently here so a bypass of the
 	// validated path cannot produce it (ADR-010 decision 3).
-	if kind != ProjectKindRemote && proj.IsRemote() && len(s.EnrolmentsGrantingProject(id)) > 0 {
+	if !kind.IsRemote() && proj.IsRemote() && len(s.EnrolmentsGrantingProject(id)) > 0 {
 		return
 	}
 	proj.Kind = kind

--- a/settings.go
+++ b/settings.go
@@ -217,15 +217,15 @@ func (s *Settings) RemoveProject(id string) {
 
 // UpdateProjectMcps updates the allowed MCP IDs for a project and syncs
 // the associated token's permissions and context.
-// schemas maps MCP IDs to their runtime context schemas.
+// surfaces maps MCP IDs to their runtime schema + tool surface.
 // Does not save; use within store.With.
-func (s *Settings) UpdateProjectMcps(id string, mcpIDs []string, schemas map[string]json.RawMessage) {
+func (s *Settings) UpdateProjectMcps(id string, mcpIDs []string, surfaces McpSurfaces) {
 	proj, _ := s.findProjectByID(id)
 	if proj == nil {
 		return
 	}
 	proj.AllowedMcpIDs = mcpIDs
-	s.SyncProjectToken(proj, schemas)
+	s.SyncProjectToken(proj, surfaces)
 }
 
 // UpdateProjectModels updates the allowed models for a project.
@@ -249,9 +249,9 @@ func (s *Settings) UpdateProjectName(id string, name string) {
 }
 
 // UpdateProjectPath updates a project's path and syncs token context.
-// schemas maps MCP IDs to their runtime context schemas.
+// surfaces maps MCP IDs to their runtime schema + tool surface.
 // Does not save; use within store.With.
-func (s *Settings) UpdateProjectPath(id string, path string, schemas map[string]json.RawMessage) {
+func (s *Settings) UpdateProjectPath(id string, path string, surfaces McpSurfaces) {
 	proj, _ := s.findProjectByID(id)
 	if proj == nil {
 		return
@@ -268,7 +268,7 @@ func (s *Settings) UpdateProjectPath(id string, path string, schemas map[string]
 		return
 	}
 	proj.Path = path
-	s.SyncProjectToken(proj, schemas)
+	s.SyncProjectToken(proj, surfaces)
 }
 
 // UpdateProjectKind changes a project's kind. Does not save; use within
@@ -422,6 +422,45 @@ func (s *Settings) UpdateProjectDisabledTools(id, mcpID string, disabled []strin
 	proj.DisabledTools[mcpID] = cleaned
 }
 
+// UpdateProjectAllowedTools replaces a project's per-MCP tool allowlist
+// (ADR-011 decision 2b). Entries naming an MCP the project is not granted are
+// dropped rather than stored: a stale allowlist reads as a grant and is not
+// one, and SyncProjectToken already prunes them on every resync.
+// Does not save; use within store.With.
+func (s *Settings) UpdateProjectAllowedTools(id string, allowed map[string][]string) {
+	proj, _ := s.findProjectByID(id)
+	if proj == nil {
+		return
+	}
+	if len(allowed) == 0 {
+		proj.AllowedTools = nil
+		return
+	}
+	cleaned := make(map[string][]string, len(allowed))
+	for mcpID, patterns := range allowed {
+		if !isWildcard(proj.AllowedMcpIDs) && !slices.Contains(proj.AllowedMcpIDs, mcpID) {
+			continue
+		}
+		list := make([]string, 0, len(patterns))
+		seen := make(map[string]bool, len(patterns))
+		for _, p := range patterns {
+			if p == "" || seen[p] {
+				continue
+			}
+			seen[p] = true
+			list = append(list, p)
+		}
+		if len(list) > 0 {
+			cleaned[mcpID] = list
+		}
+	}
+	if len(cleaned) == 0 {
+		proj.AllowedTools = nil
+		return
+	}
+	proj.AllowedTools = cleaned
+}
+
 // SetProjectGenerateSkill toggles the GenerateSkill flag. Extracted from the
 // HTTP route so the IPC path can reuse the same mutation without duplicating
 // the lookup. Does not save; use within store.With.
@@ -446,9 +485,16 @@ func (s *Settings) SetProjectAllowCwdAuth(id string, allow bool) {
 // SyncProjectToken updates the project's disabled tools and context to match
 // its current allowedMcpIDs and path. Permissions are derived at auth time
 // from AllowedMcpIDs, so they're not stored.
-// schemas maps MCP IDs to their runtime context schemas (from ExternalMcpManager).
-// If schemas is nil, filesystem auto-detection is skipped.
-func (s *Settings) SyncProjectToken(proj *Project, schemas map[string]json.RawMessage) {
+//
+// surfaces maps MCP IDs to what relay knows about them at runtime (from
+// ExternalMcpManager). A nil map skips derivation entirely, which is the
+// pre-ADR-011 contract for a caller with no live MCP manager wired.
+//
+// The derivation is driven by the SCHEMA, not by a field name relay knows:
+// relay writes the project's path into every field declaring
+// source: "project_path" because the schema asked it to (ADR-011 decision 5).
+// The v1 branch below is the one exception and is scheduled for removal.
+func (s *Settings) SyncProjectToken(proj *Project, surfaces McpSurfaces) {
 	if proj.Context == nil {
 		proj.Context = make(map[string]json.RawMessage)
 	}
@@ -475,57 +521,165 @@ func (s *Settings) SyncProjectToken(proj *Project, schemas map[string]json.RawMe
 			delete(proj.DisabledTools, id)
 		}
 	}
+	for id := range proj.Access {
+		if !allowed[id] {
+			delete(proj.Access, id)
+		}
+	}
+	for id := range proj.AllowedTools {
+		if !allowed[id] {
+			delete(proj.AllowedTools, id)
+		}
+	}
 	// Defence in depth: a remote project has no Path, and BOTH ways to handle
-	// that are unsafe — writing allowed_dirs: [""] hands a downstream MCP an
-	// empty root to interpret (a Node MCP's path.resolve("") resolves to ITS
-	// OWN cwd, which can be far more permissive than intended), and omitting
+	// that are unsafe — writing a path-derived field as [""] hands a downstream
+	// MCP an empty root to interpret (a Node MCP's path.resolve("") resolves to
+	// ITS OWN cwd, which can be far more permissive than intended), and omitting
 	// the field lets the MCP fall back to its own default, which may be
 	// unrestricted. Relay can't see how a given MCP interprets either, so
 	// remote projects skip this derivation entirely — never just when
 	// validation happens to catch it. ValidateProjectGrants is supposed to
-	// refuse granting a path-scoped MCP to a remote project before this ever
-	// runs; this guard is what keeps a bypass of that check from turning into
-	// a silent filesystem-scope widening instead of a loud one.
+	// refuse granting an MCP whose whole tool surface needs a path to a remote
+	// project before this ever runs; this guard is what keeps a bypass of that
+	// check from turning into a silent scope widening instead of a loud one.
+	//
+	// Stated generically now (ADR-011 decision 5): NEVER derive a
+	// source: "project_path" field for a remote-kind record, unconditionally,
+	// before the loop. The reasoning is ADR-009's and is unchanged — the
+	// failure mode is a silent widening, and schemas are discovered at runtime,
+	// so an MCP can grow such a field after a grant was already validated.
 	if proj.IsRemote() {
 		return
 	}
 	for _, mcpID := range mcpIDs {
-		if schemaHasField(schemas[mcpID], "allowed_dirs") {
+		surface := surfaces[mcpID]
+		schema := ParseContextSchema(surface.Schema, surface.SchemaVersion)
+
+		if schema.V2() {
+			derived := 0
+			for _, f := range schema.ProjectPathFields() {
+				value, err := json.Marshal(projectPathValue(f, proj.Path))
+				if err != nil {
+					continue
+				}
+				proj.Context[mcpID] = mergeContextField(proj.Context[mcpID], f.Name, value)
+				derived++
+			}
+			// DEFERRED (ADR-011): fs_bash auto-disable stays a hardcoded tool
+			// name here. Moving it into the schema as a default_disabled_tools
+			// declaration is the same ADR-006 violation as the old
+			// allowed_dirs branch, but it is not resource scoping, so it is
+			// explicitly out of ADR-011's scope. Keyed off "this MCP scopes
+			// something to the project path" rather than off the field's name,
+			// which is the most domain-blind form available without the schema
+			// change.
+			if derived > 0 {
+				s.disableToolByDefault(proj, mcpID, v1FsBashTool)
+			}
+			continue
+		}
+
+		// v1 compatibility, for one release. This is the last place in relay
+		// that knows a field name; see v1AllowedDirsField. An MCP that declares
+		// no contextSchemaVersion is handled exactly as it was before ADR-011,
+		// nested-schema tolerance (issue #17) included.
+		if schemaHasField(surface.Schema, v1AllowedDirsField) {
 			ctx, _ := json.Marshal(map[string]interface{}{
-				"allowed_dirs": []string{proj.Path},
+				v1AllowedDirsField: []string{proj.Path},
 			})
 			proj.Context[mcpID] = ctx
-			// Disable fs_bash by default for filesystem MCPs.
-			if !slices.Contains(proj.DisabledTools[mcpID], "fs_bash") {
-				proj.DisabledTools[mcpID] = append(proj.DisabledTools[mcpID], "fs_bash")
-			}
+			s.disableToolByDefault(proj, mcpID, v1FsBashTool)
 		}
 	}
 }
 
-// ValidateProjectGrants rejects a remote project's MCP grant list if it
-// includes any MCP whose runtime context schema declares allowed_dirs — i.e.
-// an MCP that expects to be scoped to a filesystem path. A remote project has
-// no Path (validateProjectShape enforces that), so granting it a path-scoped
-// MCP would leave SyncProjectToken with no safe way to derive allowed_dirs
-// (see the comment there). The grant itself is refused up front instead,
-// naming the offending MCP so the caller knows what to remove.
+// projectPathValue renders the project's path in the shape the field declared.
+// An array-typed field gets a one-element list, a string-typed one gets the
+// bare path. Anything else gets the list, which is what every path-scoped MCP
+// relay has met declares and the only shape that can carry more than one root
+// later.
+func projectPathValue(f ContextField, path string) interface{} {
+	if f.Type == "string" {
+		return path
+	}
+	return []string{path}
+}
+
+// mergeContextField sets one field inside an MCP's context blob, leaving every
+// other field alone. The old code replaced the whole blob, which was harmless
+// while relay derived exactly one field and destructive as soon as an operator
+// can set others beside it (ADR-011 decision 6).
+func mergeContextField(base json.RawMessage, name string, value json.RawMessage) json.RawMessage {
+	m := contextValues(base)
+	if m == nil {
+		m = map[string]json.RawMessage{}
+	}
+	m[name] = value
+	out, err := json.Marshal(m)
+	if err != nil {
+		return base
+	}
+	return out
+}
+
+// disableToolByDefault adds a tool to a project's disabled list once.
+func (s *Settings) disableToolByDefault(proj *Project, mcpID, tool string) {
+	if !slices.Contains(proj.DisabledTools[mcpID], tool) {
+		proj.DisabledTools[mcpID] = append(proj.DisabledTools[mcpID], tool)
+	}
+}
+
+// ValidateProjectGrants refuses a grant that would leave an MCP with no usable
+// tools (ADR-011 decision 5).
+//
+// This replaces the old rule, which asked the wrong question: it refused a
+// remote project any MCP declaring the literal field "allowed_dirs", encoding
+// "filesystem" where it meant "derived from the project's path". The general
+// question is asked here instead.
+//
+// A remote-kind record has no Path, so a source: "project_path" field cannot be
+// supplied for one. By ADR-011 decision 4 every tool that field governs then
+// refuses. If the field's applies_to covers EVERY tool the MCP exposes, the
+// grant buys nothing and is refused, naming the MCP and why. If it covers only
+// some — macMCP, where only mail_save_attachment and mail_get_source are
+// governed — the grant is permitted and precisely those tools lose out. That
+// is ADR-011 finding 1's fix, arriving as a consequence of the model rather
+// than as a special case.
+//
+// Note what this is and is not. It is a coherence check an operator sees at
+// edit time, not the security boundary: the boundary is SyncProjectToken
+// refusing to derive the value (above) and CallTool refusing the call
+// (appRouter.CallTool's presence re-check). So where the information needed to
+// answer is missing — relay has never connected to the MCP, so it does not know
+// what tools it exposes — this permits, and the call-time check still denies.
+// Refusing on missing information would turn an MCP that is merely not running
+// into an un-grantable one.
 //
 // Local projects are exempt: a path-scoped MCP granted to a local project is
 // exactly the expected case, and SyncProjectToken fills in its real Path.
-//
-// schemas is the same runtime context-schema map SyncProjectToken consumes.
-// A nil/missing entry can't declare allowed_dirs, so passing nil schemas
-// (e.g. a test with no MCP manager wired) is a no-op here, matching
-// SyncProjectToken's "schemas nil => skip filesystem auto-detection" contract
-// rather than failing closed on missing information.
-func (s *Settings) ValidateProjectGrants(proj *Project, schemas map[string]json.RawMessage) error {
+func (s *Settings) ValidateProjectGrants(proj *Project, surfaces McpSurfaces) error {
 	if !proj.IsRemote() {
 		return nil
 	}
 	for _, mcpID := range proj.AllowedMcpIDs {
-		if schemaHasField(schemas[mcpID], "allowed_dirs") {
-			return fmt.Errorf("remote project cannot be granted %q: it is a filesystem-scoped MCP (declares allowed_dirs) and a remote project has no path to scope it to", mcpID)
+		surface := surfaces[mcpID]
+		schema := ParseContextSchema(surface.Schema, surface.SchemaVersion)
+
+		if schema.V2() {
+			for _, f := range schema.ProjectPathFields() {
+				if !f.GovernsAll(surface.Tools) {
+					continue
+				}
+				return fmt.Errorf("remote project cannot be granted %q: its %q scope is derived from the project's path, it governs every tool this MCP exposes, and a remote project has no path — the grant would leave no usable tools", mcpID, f.Name)
+			}
+			continue
+		}
+
+		// v1 compatibility, for one release: an MCP that declares
+		// allowed_dirs and no version is refused exactly as before, without
+		// consulting a tool list it has no way to qualify.
+		if schemaHasField(surface.Schema, v1AllowedDirsField) {
+			return fmt.Errorf("remote project cannot be granted %q: it is a filesystem-scoped MCP (declares %s) and a remote project has no path to scope it to", mcpID, v1AllowedDirsField)
 		}
 	}
 	return nil
@@ -534,20 +688,22 @@ func (s *Settings) ValidateProjectGrants(proj *Project, schemas map[string]json.
 // schemaHasField reports whether a context schema declares a given field, in
 // either shape an MCP might reasonably use.
 //
-// fsMCP declares its context flat — {"allowed_dirs": {...}} — but the ordinary
-// JSON-Schema shape nests the same declaration under "properties", and relay's
-// own test fixtures use that form. Checking only the flat shape made the answer
-// depend on how an MCP happened to spell an identical declaration.
+// THIS IS THE V1 PATH ONLY. A v2 schema (contextSchemaVersion >= 2) is parsed
+// by ParseContextSchema and never reaches here; this exists because fsMCP as
+// shipped declares its context flat — {"allowed_dirs": {...}} — with no
+// version, while the ordinary JSON-Schema shape nests the same declaration
+// under "properties", and relay's own test fixtures use that form. Checking
+// only the flat shape made the answer depend on how an MCP happened to spell an
+// identical declaration.
 //
 // Getting that wrong fails OPEN, which is why both shapes are checked here
-// rather than a shape being mandated elsewhere. This function is the first of
-// ADR-009 decision 3's two defences: it is what stops a filesystem-scoped MCP
-// being granted to a pathless remote project. A false negative does not merely
-// skip a warning — the grant is allowed, the second defence then correctly
-// declines to derive allowed_dirs for a remote project, the MCP receives no
-// value at all, and an MCP that reads an absent allowlist as "unrestricted"
-// (fsMCP does) hands a client on another machine the whole host filesystem.
-// ADR-009 names that exact sequence as the thing this check exists to prevent.
+// rather than a shape being mandated elsewhere. A false negative does not
+// merely skip a warning — the grant is allowed, the second defence then
+// correctly declines to derive a path-scoped field for a remote project, the
+// MCP receives no value at all, and an MCP that reads an absent allowlist as
+// "unrestricted" (fsMCP does) hands a client on another machine the whole host
+// filesystem. ADR-009 names that exact sequence as the thing this check exists
+// to prevent.
 func schemaHasField(schema json.RawMessage, field string) bool {
 	if len(schema) == 0 {
 		return false
@@ -700,9 +856,12 @@ func (s *Settings) storedTokenForProject(proj *Project, hash string) *StoredToke
 		return &StoredToken{
 			Name:          "project:" + proj.Name,
 			ProjectID:     proj.ID,
+			ProjectKind:   proj.Kind,
 			Hash:          hash,
 			DisabledTools: proj.DisabledTools,
 			Context:       proj.Context,
+			Access:        proj.Access,
+			AllowedTools:  proj.AllowedTools,
 		}
 	}
 	// Explicit list: only store PermOff entries (deny-set).
@@ -719,9 +878,12 @@ func (s *Settings) storedTokenForProject(proj *Project, hash string) *StoredToke
 	return &StoredToken{
 		Name:          "project:" + proj.Name,
 		ProjectID:     proj.ID,
+		ProjectKind:   proj.Kind,
 		Hash:          hash,
 		Permissions:   perms,
 		DisabledTools: proj.DisabledTools,
 		Context:       proj.Context,
+		Access:        proj.Access,
+		AllowedTools:  proj.AllowedTools,
 	}
 }

--- a/settings_enrolments_ui_test.go
+++ b/settings_enrolments_ui_test.go
@@ -93,7 +93,7 @@ func TestRemoteTab_GrantsRenderAsProjectNames(t *testing.T) {
 	}
 }
 
-// A grant naming a project that no longer exists is SHOWN, marked, not
+// A grant naming an access profile that no longer exists is SHOWN, marked, not
 // silently dropped: an enrolment holding something relay cannot resolve is
 // exactly the row an operator needs to see before deciding to revoke.
 func TestRemoteTab_DanglingGrantIsShownNotHidden(t *testing.T) {
@@ -104,8 +104,8 @@ func TestRemoteTab_DanglingGrantIsShownNotHidden(t *testing.T) {
 	}]`, remoteEnabled)
 	html := evalString(t, vm, `window.renderEnrolments()`)
 
-	if !strings.Contains(html, "p_deleted") || !strings.Contains(html, "unknown project") {
-		t.Errorf("a grant naming a missing project was not surfaced\n%s", html)
+	if !strings.Contains(html, "p_deleted") || !strings.Contains(html, "unknown access profile") {
+		t.Errorf("a grant naming a missing access profile was not surfaced\n%s", html)
 	}
 	if !strings.Contains(html, "enrol-grant dangling") {
 		t.Error("dangling grant did not get its own class, so it reads like a normal grant")
@@ -231,13 +231,13 @@ func TestRemoteTab_OnlyRemoteProjectsAreOffered(t *testing.T) {
 	}
 }
 
-// With no remote project to grant, the form says where to make one rather than
+// With no access profile to grant, the form says where to make one rather than
 // showing an empty list that looks broken.
 func TestRemoteTab_NoRemoteProjectsExplainsWhere(t *testing.T) {
 	vm := seedRemoteVM(t, `[{id:'p_work', name:'Workspace', path:'/w', allowed_mcp_ids:['*'], allowed_models:['*'], disabled_tools:{}}]`, `[]`, remoteEnabled)
 	html := evalString(t, vm, `(function(){ window.newEnrolment(); return window.renderEnrolmentForm(); })()`)
-	if !strings.Contains(html, "No remote projects exist yet") || !strings.Contains(html, "Projects") {
-		t.Errorf("empty grant picker does not say where to create a remote project\n%s", html)
+	if !strings.Contains(html, "No access profiles exist yet") || !strings.Contains(html, "Projects") {
+		t.Errorf("empty grant picker does not say where to create an access profile\n%s", html)
 	}
 }
 
@@ -278,7 +278,7 @@ func TestRemoteTab_CreatePayloadShape(t *testing.T) {
 func TestRemoteTab_ZeroGrantsIsAllowedAndAnnounced(t *testing.T) {
 	vm := seedRemoteVM(t, enrolProjectsFixture, `[]`, remoteEnabled)
 	html := evalString(t, vm, `(function(){ window.newEnrolment(); return window.renderEnrolmentForm(); })()`)
-	if !strings.Contains(html, "can reach no project until one is added") {
+	if !strings.Contains(html, "can reach no access profile until one is added") {
 		t.Errorf("form does not say what a grantless enrolment means\n%s", html)
 	}
 }

--- a/settings_html.go
+++ b/settings_html.go
@@ -32,12 +32,23 @@ func mustMarshalJSON(label string, v interface{}) string {
 // picker; it's preseeded so the first paint of a project edit form doesn't
 // have to round-trip an IPC for every allowed MCP. Pass nil in tests that
 // don't exercise the picker.
-func renderSettingsHTML(settings *Settings, runningIDs []string, toolCache map[string][]ToolInfo) string {
+//
+// scopeFields is the same idea for ADR-011's per-MCP permission panel: the
+// scope: "restrict" fields each MCP declares, so the editor can render one
+// input per field with the MCP's own description as help text. It is seeded
+// rather than fetched because it is small (a handful of fields per MCP) and
+// because the PROJECT LIST needs it too — a row has to say "needs a scope
+// value" without anyone opening the editor first, and a list that had to
+// round-trip for that would render the reassuring answer first.
+func renderSettingsHTML(settings *Settings, runningIDs []string, toolCache map[string][]ToolInfo, scopeFields map[string][]ScopeFieldView) string {
 	if runningIDs == nil {
 		runningIDs = []string{}
 	}
 	if toolCache == nil {
 		toolCache = map[string][]ToolInfo{}
+	}
+	if scopeFields == nil {
+		scopeFields = map[string][]ScopeFieldView{}
 	}
 	projects := settings.Projects
 	if projects == nil {
@@ -63,6 +74,7 @@ func renderSettingsHTML(settings *Settings, runningIDs []string, toolCache map[s
 		"__RUNNING_IDS_JSON__", mustMarshalJSON("running_ids", runningIDs),
 		"__PROJECTS_JSON__", mustMarshalJSON("projects", projects),
 		"__MCP_TOOL_CACHE_JSON__", mustMarshalJSON("mcp_tool_cache", toolCache),
+		"__MCP_SCOPE_FIELDS_JSON__", mustMarshalJSON("mcp_scope_fields", scopeFields),
 		"__ENROLMENTS_JSON__", mustMarshalJSON("enrolments", enrolments),
 		"__REMOTE_JSON__", mustMarshalJSON("remote", remote),
 		"__ENROLMENT_BUDGET_DEFAULTS_JSON__", mustMarshalJSON("enrolment_budget_defaults", enrolmentBudgetDefaults()),

--- a/settings_projects_test.go
+++ b/settings_projects_test.go
@@ -32,10 +32,10 @@ func newProjectsTestStore(t *testing.T) SettingsStore {
 
 // fsSchemas returns a schemas map where fsmcp declares allowed_dirs (the
 // trigger for filesystem auto-detection in SyncProjectToken).
-func fsSchemas() map[string]json.RawMessage {
-	return map[string]json.RawMessage{
-		"fsmcp":  json.RawMessage(`{"allowed_dirs": {"type": "array"}}`),
-		"macmcp": json.RawMessage(`{}`),
+func fsSchemas() McpSurfaces {
+	return McpSurfaces{
+		"fsmcp":  {Schema: json.RawMessage(`{"allowed_dirs": {"type": "array"}}`)},
+		"macmcp": {Schema: json.RawMessage(`{}`)},
 	}
 }
 

--- a/settings_projects_ui_test.go
+++ b/settings_projects_ui_test.go
@@ -437,11 +437,13 @@ func TestLocalProjectFormUnchanged(t *testing.T) {
 	}
 }
 
-// TestProjectListBadgesRemote covers renderProjects: a remote project gets a
-// visible badge and local projects don't. Also pins that a LOCAL project with
-// zero explicit MCP grants keeps showing the plain "0" count (unchanged),
-// while a REMOTE project with zero grants shows the friendlier "no tools
-// granted" instead of looking broken/empty-by-accident.
+// TestProjectListBadgesRemote covers renderProjects: a remote-kind record gets
+// a visible badge naming it an ACCESS PROFILE (ADR-011 decision 1) and local
+// projects don't. Also pins what a record granting no MCP says: the row states
+// that it reaches nothing, in the noun that record deserves, rather than
+// rendering a count an operator has to interpret. The count itself is gone —
+// "MCPs: 1" beside a client that can read every mailbox on the machine is the
+// failure ADR-011 exists to fix, and it was rendered from this function.
 func TestProjectListBadgesRemote(t *testing.T) {
 	vm := newAppVM(t)
 	script := `(function(){
@@ -455,13 +457,15 @@ func TestProjectListBadgesRemote(t *testing.T) {
 		var badgeCount = (html.match(/proj-badge-remote/g) || []).length;
 		return JSON.stringify({
 			badgeCount: badgeCount,
-			remoteShowsNoTools: html.indexOf('no tools granted') >= 0,
-			localZeroStillShowsPlainZero: /MCPs: <strong>0<\/strong>/.test(html)
+			remoteSaysProfileReachesNothing: html.indexOf('this access profile reaches nothing') >= 0,
+			localSaysProjectReachesNothing: html.indexOf('this project reaches nothing') >= 0,
+			noBareMcpCount: !/MCPs: <strong>/.test(html)
 		});
 	})()`
 	got := evalString(t, vm, script)
 	for _, want := range []string{
-		`"badgeCount":1`, `"remoteShowsNoTools":true`, `"localZeroStillShowsPlainZero":true`,
+		`"badgeCount":1`, `"remoteSaysProfileReachesNothing":true`,
+		`"localSaysProjectReachesNothing":true`, `"noBareMcpCount":true`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("project list remote badge: missing %s in %s", want, got)

--- a/settings_scope_picker_ui_test.go
+++ b/settings_scope_picker_ui_test.go
@@ -413,7 +413,7 @@ func TestScopePicker_ProjectPathFieldStillReadOnly(t *testing.T) {
 	if !strings.Contains(html, `readonly value="/Users/x/work"`) {
 		t.Errorf("the derived field stopped rendering read-only\n%s", html)
 	}
-	if strings.Contains(html, `toggleScopeFieldPicker('macmcp', 'write_dirs')`) {
+	if strings.Contains(html, `toggleScopeFieldPicker('macmcp', 'file_dirs')`) {
 		t.Error("a picker was offered for a value relay derives")
 	}
 }

--- a/settings_scope_picker_ui_test.go
+++ b/settings_scope_picker_ui_test.go
@@ -1,0 +1,456 @@
+package main
+
+// The enumeration picker, under goja (ADR-011 decision 6).
+//
+// Decision 6 exists because of the ADR's second constraint: typing "INBOX" by
+// hand is the error-prone step, and under decision 4 a typo fails CLOSED — the
+// agent silently gets nothing, which is safe and baffling. A picker removes the
+// typo. What it must not do is introduce a worse failure in its place, and
+// there are two of those:
+//
+//   - rendering a FAILED call as an empty list, which tells an operator there
+//     are no mailboxes on a machine full of them;
+//   - dropping a stored value the MCP no longer offers, which silently widens
+//     or narrows a profile because something was renamed on the host.
+//
+// Most of this file is about those two.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+// The same worked example the rest of the suite uses, plus one operator field
+// the MCP does NOT declare enumerable — the case that must keep its text box.
+const pickerFieldsFixture = `{
+	macmcp: [
+		{name:'mail_accounts', type:'array', item_type:'string', description:'Mail accounts this client may read from or send as', source:'operator', applies_to:['mail_*'], enumerable:true},
+		{name:'mail_mailboxes', type:'array', item_type:'string', description:'Mailbox paths within those accounts this client may reach', source:'operator', applies_to:['mail_*'], enumerable:true, depends_on:['mail_accounts']},
+		{name:'mail_note', type:'string', description:'A note the MCP will not list values for', source:'operator', applies_to:['mail_*']}
+	]
+}`
+
+const pickerProjectsFixture = `[
+	{id:'p_bob', name:'Hermes — Bob INBOX', kind:'remote', path:'', allowed_mcp_ids:['macmcp'], allowed_models:[],
+	 allowed_tools:{macmcp:['mail_*']}, access:{macmcp:'read'},
+	 context:{macmcp:{mail_accounts:['Bob'], mail_mailboxes:['INBOX','Projects/Archive']}}, disabled_tools:{}}
+]`
+
+// seedPickerVM opens p_bob in the editor with the picker fixture loaded.
+func seedPickerVM(t *testing.T) *goja.Runtime {
+	t.Helper()
+	vm := newAppVM(t)
+	script := `(function(){
+		window.__sent = [];
+		window.webkit = { messageHandlers: { ipc: { postMessage: function(m){ window.__sent.push(String(m)); } } } };
+		window.state.page = 'projects';
+		window.state.externalMcps = [{id:'macmcp', display_name:'macMCP'}];
+		window.state.mcpScopeFields = ` + pickerFieldsFixture + `;
+		window.state.projects = ` + pickerProjectsFixture + `;
+		window.editProject('p_bob');
+		return true;
+	})()`
+	if _, err := vm.RunString(script); err != nil {
+		t.Fatalf("seeding picker state: %v", err)
+	}
+	return vm
+}
+
+// answer delivers one ContextEnumResult the way relay does, then re-renders.
+func answer(t *testing.T, vm *goja.Runtime, json string) string {
+	t.Helper()
+	return evalString(t, vm, `(function(){
+		window.onScopeFieldEnumerated(`+json+`);
+		return window.renderProjectForm();
+	})()`)
+}
+
+func openField(t *testing.T, vm *goja.Runtime, field string) string {
+	t.Helper()
+	return evalString(t, vm, `(function(){
+		window.toggleScopeFieldPicker('macmcp', '`+field+`');
+		return window.renderProjectForm();
+	})()`)
+}
+
+func sentMessages(t *testing.T, vm *goja.Runtime) string {
+	t.Helper()
+	// Joined rather than JSON.stringify'd: these are already JSON strings, and
+	// stringifying the array again escapes every quote in them.
+	return evalString(t, vm, `window.__sent.join("\n")`)
+}
+
+// ---------------------------------------------------------------------------
+// When it is asked for
+// ---------------------------------------------------------------------------
+
+// Enumeration is a live call into another process. It happens when an operator
+// OPENS a control — not on a paint, not on a keystroke — and it is cached per
+// (mcp, field, dependency values) for the life of the form.
+func TestScopePicker_FetchesOnOpenAndCaches(t *testing.T) {
+	vm := seedPickerVM(t)
+
+	if sent := sentMessages(t, vm); strings.Contains(sent, "enumerate_scope_field") {
+		t.Fatalf("opening the editor enumerated something: %s", sent)
+	}
+
+	html := openField(t, vm, "mail_accounts")
+	sent := sentMessages(t, vm)
+	if !strings.Contains(sent, `"type":"enumerate_scope_field"`) || !strings.Contains(sent, `"field":"mail_accounts"`) {
+		t.Fatalf("opening the picker did not ask for values: %s", sent)
+	}
+	if strings.Count(sent, "enumerate_scope_field") != 1 {
+		t.Errorf("one open, %d requests: %s", strings.Count(sent, "enumerate_scope_field"), sent)
+	}
+	if !strings.Contains(html, "Listing values from macmcp") {
+		t.Errorf("the wait is not shown as a wait\n%s", html)
+	}
+
+	answer(t, vm, `{mcp_id:'macmcp', field:'mail_accounts', status:'ok', values:[{value:'Alice',label:'Alice'},{value:'Bob',label:'Bob'}]}`)
+
+	// Closing and reopening does not re-ask: the answer is cached for the life
+	// of the form.
+	openField(t, vm, "mail_accounts")
+	openField(t, vm, "mail_accounts")
+	if n := strings.Count(sentMessages(t, vm), "enumerate_scope_field"); n != 1 {
+		t.Errorf("re-opening a cached field made %d requests, want 1", n)
+	}
+}
+
+// The values are real values, the stored one is ticked, and ticking another
+// writes it through the same storage the text box uses — so harvest, clearing
+// and the "needs a scope value" banner all keep working untouched.
+func TestScopePicker_ChoosingWritesTheStoredValue(t *testing.T) {
+	vm := seedPickerVM(t)
+	openField(t, vm, "mail_accounts")
+	html := answer(t, vm, `{mcp_id:'macmcp', field:'mail_accounts', status:'ok', values:[{value:'Alice',label:'Alice'},{value:'Bob',label:'Bob (work)'}]}`)
+
+	if !strings.Contains(html, "Bob (work)") {
+		t.Errorf("the MCP's own label is not shown\n%s", html)
+	}
+	// Bob is stored, so Bob is ticked and Alice is not.
+	got := evalString(t, vm, `(function(){
+		var out = [];
+		for (var i = 0; i < window.state._scopeBind.length; i++) out.push(window.state._scopeBind[i].value);
+		return JSON.stringify(out);
+	})()`)
+	if got != `["Alice","Bob"]` {
+		t.Fatalf("bindings = %s, want both offered values", got)
+	}
+	if strings.Count(html, " checked ") != 1 {
+		t.Errorf("want exactly the stored value ticked\n%s", html)
+	}
+
+	// Tick Alice: the stored value becomes both, through the same text the
+	// box edits.
+	payload := evalString(t, vm, `(function(){
+		window.toggleProjScopeValueAt(0, true);
+		document.getElementById('projName').value = 'Hermes — Bob INBOX';
+		return JSON.stringify(window.harvestProjectForm().context);
+	})()`)
+	if !strings.Contains(payload, `"mail_accounts":["Bob","Alice"]`) {
+		t.Fatalf("ticking a value did not reach the payload: %s", payload)
+	}
+
+	// Untick Bob: it goes, and nothing else does.
+	payload = evalString(t, vm, `(function(){
+		window.toggleProjScopeValueAt(1, false);
+		document.getElementById('projName').value = 'Hermes — Bob INBOX';
+		return JSON.stringify(window.harvestProjectForm().context);
+	})()`)
+	if !strings.Contains(payload, `"mail_accounts":["Alice"]`) {
+		t.Fatalf("unticking removed the wrong thing: %s", payload)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The behaviour that matters most
+// ---------------------------------------------------------------------------
+
+// A stored value the MCP no longer offers stays VISIBLE and stays SELECTED,
+// flagged as unrecognised. An account renamed on the host must not quietly
+// widen or narrow a profile by disappearing from a form, and a value that
+// vanishes from the editor is a value the next save deletes.
+func TestScopePicker_AStoredValueNoLongerOfferedSurvives(t *testing.T) {
+	vm := seedPickerVM(t)
+	openField(t, vm, "mail_mailboxes")
+	// The MCP offers INBOX and something else; "Projects/Archive" — which this
+	// profile is confined to — is gone.
+	html := answer(t, vm, `{mcp_id:'macmcp', field:'mail_mailboxes', status:'ok', values:[{value:'INBOX',label:'INBOX'},{value:'Sent',label:'Sent'}]}`)
+
+	if !strings.Contains(html, "Projects/Archive") {
+		t.Fatalf("a stored value the MCP no longer offers vanished from the form\n%s", html)
+	}
+	if !strings.Contains(html, "unrecognised") {
+		t.Errorf("the value is shown but not flagged as one the MCP does not offer\n%s", html)
+	}
+	if !strings.Contains(html, "does not offer Projects/Archive") {
+		t.Errorf("the flag does not name the value\n%s", html)
+	}
+	// It is ticked — it is in force — and it survives a save untouched.
+	payload := evalString(t, vm, `(function(){
+		document.getElementById('projName').value = 'Hermes — Bob INBOX';
+		return JSON.stringify(window.harvestProjectForm().context);
+	})()`)
+	if !strings.Contains(payload, `"mail_mailboxes":["INBOX","Projects/Archive"]`) {
+		t.Fatalf("an unrecognised value did not survive the save: %s", payload)
+	}
+	// And it is removable, deliberately, by unticking it.
+	payload = evalString(t, vm, `(function(){
+		var idx = -1;
+		for (var i = 0; i < window.state._scopeBind.length; i++)
+			if (window.state._scopeBind[i].value === 'Projects/Archive') idx = i;
+		window.toggleProjScopeValueAt(idx, false);
+		document.getElementById('projName').value = 'Hermes — Bob INBOX';
+		return JSON.stringify(window.harvestProjectForm().context);
+	})()`)
+	if strings.Contains(payload, "Projects/Archive") {
+		t.Fatalf("unticking an unrecognised value did not remove it: %s", payload)
+	}
+}
+
+// A FAILED call is never rendered as an empty list. Each degraded case keeps
+// text entry so an operator is never blocked, and each says something
+// different, because the operator's next action differs in each.
+func TestScopePicker_DegradedCases(t *testing.T) {
+	cases := []struct {
+		name       string
+		clearFirst bool // no stored value, so an empty answer really is empty
+		answer     string
+		wantText   []string
+		wantNoText []string
+		wantBox    bool
+	}{
+		{
+			name:   "the MCP does not implement enumeration (-32601)",
+			answer: `{mcp_id:'macmcp', field:'mail_accounts', status:'unsupported', values:null, error:'macmcp does not implement context/enumerate'}`,
+			// Degrades to the text box, silently: no error, no retry button,
+			// nothing for the operator to act on beyond typing the value.
+			wantText:   []string{"cannot list this field's values", "setProjScopeText('macmcp', 'mail_accounts', this.value)"},
+			wantNoText: []string{"Try again", "bug in relay"},
+			wantBox:    true,
+		},
+		{
+			name:   "relay asked for a field the MCP will not enumerate (-32602)",
+			answer: `{mcp_id:'macmcp', field:'mail_accounts', status:'invalid_field', values:null, error:'no enumerable field named mail_accounts'}`,
+			// Surfaced, not degraded away: it is a relay bug and saying so is
+			// the only thing that gets it fixed.
+			wantText:   []string{"bug in relay", "no enumerable field named mail_accounts"},
+			wantNoText: []string{"Try again"},
+			wantBox:    true,
+		},
+		{
+			name:   "the MCP could not answer right now",
+			answer: `{mcp_id:'macmcp', field:'mail_accounts', status:'unavailable', values:null, error:'could not read accounts: Mail timed out'}`,
+			wantText: []string{
+				"Could not list values from macmcp",
+				"could not read accounts: Mail timed out",
+				"This is not an empty list",
+				"Try again",
+			},
+			wantBox: true,
+		},
+		{
+			name:       "the MCP answered, and there really are none",
+			clearFirst: true,
+			answer:     `{mcp_id:'macmcp', field:'mail_accounts', status:'ok', values:[]}`,
+			// The one case where "there are none" is the truth. No error, no
+			// retry, and no text box: the MCP answered.
+			wantText:   []string{"offers no values for this field", "not a failure"},
+			wantNoText: []string{"Try again", "Could not list"},
+			wantBox:    false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			vm := seedPickerVM(t)
+			if c.clearFirst {
+				evalString(t, vm, `(function(){ window.setProjScopeText('macmcp', 'mail_accounts', ''); return ''; })()`)
+			}
+			openField(t, vm, "mail_accounts")
+			html := answer(t, vm, c.answer)
+
+			for _, want := range c.wantText {
+				if !strings.Contains(html, want) {
+					t.Errorf("missing %q\n%s", want, html)
+				}
+			}
+			for _, unwanted := range c.wantNoText {
+				if strings.Contains(html, unwanted) {
+					t.Errorf("unexpectedly present: %q\n%s", unwanted, html)
+				}
+			}
+			// A failure NEVER renders as a list of choices — that is the
+			// rendering that means "there are none".
+			if !c.wantBox && strings.Contains(html, "proj-scope-choices") {
+				t.Errorf("an empty answer drew an empty choice list\n%s", html)
+			}
+			if c.wantBox {
+				if !strings.Contains(html, "setProjScopeText('macmcp', 'mail_accounts'") {
+					t.Errorf("a degraded picker left the operator with no way to set a value\n%s", html)
+				}
+				if strings.Contains(html, "proj-scope-choices") {
+					t.Errorf("a failed call drew choices\n%s", html)
+				}
+			}
+			// The stored value is still on screen and still stored, whatever
+			// went wrong — in the picker's summary, or in the text box the
+			// degraded cases fall back to. A confinement must never vanish
+			// because the MCP that lists its values would not answer.
+			if !c.clearFirst && !strings.Contains(html, "Bob") {
+				t.Errorf("the stored value disappeared behind a failure\n%s", html)
+			}
+		})
+	}
+}
+
+// -32601 is a fact about the MCP, not about one field: every field of it
+// degrades, and nothing asks again. That is "silently and permanently".
+func TestScopePicker_UnsupportedIsPermanentForTheWholeMcp(t *testing.T) {
+	vm := seedPickerVM(t)
+	openField(t, vm, "mail_accounts")
+	answer(t, vm, `{mcp_id:'macmcp', field:'mail_accounts', status:'unsupported', values:null}`)
+
+	before := strings.Count(sentMessages(t, vm), "enumerate_scope_field")
+	html := openField(t, vm, "mail_mailboxes")
+	if n := strings.Count(sentMessages(t, vm), "enumerate_scope_field"); n != before {
+		t.Errorf("relay re-asked an MCP that already said it does not enumerate (%d requests, was %d)", n, before)
+	}
+	if strings.Contains(html, "Choose values") {
+		t.Errorf("a picker was still offered for an MCP that cannot list values\n%s", html)
+	}
+	if !strings.Contains(html, "setProjScopeText('macmcp', 'mail_mailboxes', this.value)") {
+		t.Errorf("the other field did not fall back to text entry\n%s", html)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dependency order
+// ---------------------------------------------------------------------------
+
+// mail_mailboxes is read WITHIN the chosen accounts, so the request carries
+// them — and changing the account choice re-reads the list rather than leaving
+// a stale one on screen under a new account's name.
+func TestScopePicker_DependencyOrder(t *testing.T) {
+	vm := seedPickerVM(t)
+	openField(t, vm, "mail_mailboxes")
+
+	sent := sentMessages(t, vm)
+	if !strings.Contains(sent, `"values":{"mail_accounts":["Bob"]}`) {
+		t.Fatalf("the mailbox list was not read within the chosen account: %s", sent)
+	}
+	answer(t, vm, `{mcp_id:'macmcp', field:'mail_mailboxes', status:'ok', values:[{value:'INBOX'},{value:'Projects/Archive'}]}`)
+
+	// Now the account choice changes. The old list is not the answer to the
+	// new question, so it must not stay on screen as if it were.
+	html := evalString(t, vm, `(function(){
+		window.setProjScopeText('macmcp', 'mail_accounts', 'Alice');
+		window.refreshDependentScopeFields('macmcp', 'mail_accounts');
+		return window.renderProjectForm();
+	})()`)
+	sent = sentMessages(t, vm)
+	if !strings.Contains(sent, `"values":{"mail_accounts":["Alice"]}`) {
+		t.Fatalf("changing the account did not re-read the mailbox list: %s", sent)
+	}
+	if !strings.Contains(html, "Listing values from macmcp") {
+		t.Errorf("the stale list stayed on screen while the new one was read\n%s", html)
+	}
+}
+
+// An UNCHOSEN dependency lists across everything rather than showing an empty
+// picker. That is the state the control opens in, so getting it wrong means an
+// operator's first sight of the feature is an empty list — and macMCP, which
+// reads an empty filter as "all", would never even be asked the narrowing
+// question this side invented.
+func TestScopePicker_UnchosenDependencyListsAcrossEverything(t *testing.T) {
+	vm := seedPickerVM(t)
+	// Clear the account choice, then open the field that depends on it.
+	evalString(t, vm, `(function(){ window.setProjScopeText('macmcp', 'mail_accounts', ''); return ''; })()`)
+	openField(t, vm, "mail_mailboxes")
+
+	sent := sentMessages(t, vm)
+	if strings.Contains(sent, "mail_accounts") {
+		t.Fatalf("an unchosen dependency was sent anyway; a server may read it as 'match nothing': %s", sent)
+	}
+	if !strings.Contains(sent, `"values":{}`) {
+		t.Errorf("want an empty values object, got: %s", sent)
+	}
+
+	// And the answer — every account's mailboxes — renders as the choices.
+	html := answer(t, vm, `{mcp_id:'macmcp', field:'mail_mailboxes', status:'ok', values:[{value:'Alice/INBOX'},{value:'Bob/INBOX'}]}`)
+	for _, want := range []string{"Alice/INBOX", "Bob/INBOX"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("with no account chosen the picker does not list across all accounts: missing %q\n%s", want, html)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The rest of the panel is unchanged
+// ---------------------------------------------------------------------------
+
+// A field the MCP does not declare enumerable keeps its text box, with no
+// picker, no fetch and no error.
+func TestScopePicker_NonEnumerableFieldIsUnchanged(t *testing.T) {
+	vm := seedPickerVM(t)
+	html := evalString(t, vm, `window.renderProjectForm()`)
+	if !strings.Contains(html, `setProjScopeText('macmcp', 'mail_note', this.value)`) {
+		t.Errorf("a non-enumerable field lost its text input\n%s", html)
+	}
+	if strings.Contains(html, `toggleScopeFieldPicker('macmcp', 'mail_note')`) {
+		t.Errorf("a picker was offered for a field the MCP cannot list\n%s", html)
+	}
+}
+
+// The read-only rendering of a source: "project_path" field is untouched — it
+// is derived, not chosen, and there is nothing to pick.
+func TestScopePicker_ProjectPathFieldStillReadOnly(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "p_local")
+	html := evalString(t, vm, `window.renderProjectForm()`)
+	if !strings.Contains(html, `readonly value="/Users/x/work"`) {
+		t.Errorf("the derived field stopped rendering read-only\n%s", html)
+	}
+	if strings.Contains(html, `toggleScopeFieldPicker('macmcp', 'write_dirs')`) {
+		t.Error("a picker was offered for a value relay derives")
+	}
+}
+
+// A repaint driven by an arriving answer must not eat what someone was typing.
+// The name lives only in the DOM until harvest, and this is the one render in
+// the editor that is not triggered by a click.
+func TestScopePicker_AnArrivingAnswerDoesNotEatTheNameBeingTyped(t *testing.T) {
+	vm := seedPickerVM(t)
+	openField(t, vm, "mail_accounts")
+	got := evalString(t, vm, `(function(){
+		document.getElementById('projName').value = 'Hermes — Alice, half-typed';
+		window.onScopeFieldEnumerated({mcp_id:'macmcp', field:'mail_accounts', status:'ok', values:[{value:'Alice'}]});
+		return window.state.projectForm.name;
+	})()`)
+	if got != "Hermes — Alice, half-typed" {
+		t.Fatalf("the repaint lost the name being typed: %q", got)
+	}
+}
+
+// A cross-product scope makes duplicate values normal: every account has an
+// INBOX, and the mailbox value is account-independent (ADR-011's worked
+// example). Two boxes holding the same value would tick and untick together,
+// which reads as a bug, so they are one choice carrying both labels.
+func TestScopePicker_OneValueIsOneChoiceHoweverOftenItIsOffered(t *testing.T) {
+	vm := seedPickerVM(t)
+	evalString(t, vm, `(function(){ window.setProjScopeText('macmcp', 'mail_mailboxes', ''); return ''; })()`)
+	openField(t, vm, "mail_mailboxes")
+	html := answer(t, vm, `{mcp_id:'macmcp', field:'mail_mailboxes', status:'ok', values:[
+		{value:'INBOX', label:'INBOX (Alice)'},
+		{value:'INBOX', label:'INBOX (Bob)'},
+		{value:'Projects/Archive', label:'Projects/Archive (Bob)'}]}`)
+
+	if n := strings.Count(html, "toggleProjScopeValueAt("); n != 2 {
+		t.Errorf("want 2 choices for 2 distinct values, got %d\n%s", n, html)
+	}
+	if !strings.Contains(html, "INBOX (Alice) · INBOX (Bob)") {
+		t.Errorf("the labels of a collapsed duplicate were thrown away\n%s", html)
+	}
+}

--- a/settings_scope_test.go
+++ b/settings_scope_test.go
@@ -1,0 +1,218 @@
+package main
+
+// ADR-011 decision 5: source replaces the hardcoded field name, and the grant
+// question becomes "would this leave the MCP with no usable tools?"
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// fsmcpSurface is fsMCP once it declares v2: one project_path field with no
+// applies_to, which governs every tool it has.
+func fsmcpSurface() McpSurface {
+	return McpSurface{
+		Schema:        json.RawMessage(fsmcpV2Schema),
+		SchemaVersion: 2,
+		Tools:         []string{"fs_read", "fs_write", "fs_list", "fs_bash"},
+	}
+}
+
+// macmcpSurface is macMCP's worked example: three restrict fields, only one of
+// them project_path, and that one governs exactly two of the tools.
+func macmcpSurface() McpSurface {
+	return McpSurface{
+		Schema:        json.RawMessage(macmcpSchema),
+		SchemaVersion: 2,
+		Tools: []string{
+			"mail_search", "mail_get_email", "mail_send", "mail_move",
+			"mail_save_attachment", "mail_get_source",
+			"capture_screenshot", "contacts_list_groups", "messages_send",
+		},
+	}
+}
+
+func remoteProjectGranting(ids ...string) *Project {
+	return &Project{ID: "p1", Name: "Profile", Kind: ProjectKindRemote, AllowedMcpIDs: ids}
+}
+
+func TestValidateProjectGrants_RefusesAnMcpWhoseEveryToolNeedsTheProjectPath(t *testing.T) {
+	// The old rule refused fsMCP because it declared a field called
+	// "allowed_dirs". The new one refuses it because a profile has no path,
+	// every fs tool is governed by the field that path would fill, and so the
+	// grant would buy nothing at all. Same answer, derived instead of encoded.
+	s := &Settings{}
+	err := s.ValidateProjectGrants(remoteProjectGranting("fsmcp"), McpSurfaces{"fsmcp": fsmcpSurface()})
+	if err == nil {
+		t.Fatal("a profile was granted an MCP whose every tool needs a project path")
+	}
+	for _, want := range []string{"fsmcp", v1AllowedDirsField, "no usable tools"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal should say %q; got: %v", want, err)
+		}
+	}
+}
+
+func TestValidateProjectGrants_PermitsAnMcpThatKeepsUsableTools(t *testing.T) {
+	// macMCP's write_dirs governs mail_save_attachment and mail_get_source
+	// only, so the MCP stays grantable and precisely those two lose their
+	// filesystem write. This is ADR-011 finding 1's fix arriving as a
+	// consequence of the model rather than as a special case.
+	s := &Settings{}
+	if err := s.ValidateProjectGrants(remoteProjectGranting("macmcp"), McpSurfaces{"macmcp": macmcpSurface()}); err != nil {
+		t.Fatalf("a profile was refused macMCP, which retains 7 usable tools: %v", err)
+	}
+	// And both together still fail on the one that cannot work.
+	err := s.ValidateProjectGrants(remoteProjectGranting("macmcp", "fsmcp"),
+		McpSurfaces{"macmcp": macmcpSurface(), "fsmcp": fsmcpSurface()})
+	if err == nil || !strings.Contains(err.Error(), "fsmcp") {
+		t.Fatalf("the refusal should name fsmcp and not macmcp; got: %v", err)
+	}
+}
+
+func TestValidateProjectGrants_PermitsWhenTheToolSurfaceIsUnknown(t *testing.T) {
+	// This is a coherence check an operator sees at edit time, not the
+	// boundary — SyncProjectToken's guard and CallTool's presence check are.
+	// Refusing on missing information would make an MCP that is merely not
+	// running un-grantable.
+	surface := macmcpSurface()
+	surface.Tools = nil
+	s := &Settings{}
+	if err := s.ValidateProjectGrants(remoteProjectGranting("macmcp"), McpSurfaces{"macmcp": surface}); err != nil {
+		t.Fatalf("a grant was refused because relay had not connected to the MCP: %v", err)
+	}
+	if err := s.ValidateProjectGrants(remoteProjectGranting("macmcp"), nil); err != nil {
+		t.Fatalf("a grant was refused with no surfaces at all: %v", err)
+	}
+}
+
+func TestValidateProjectGrants_LocalProjectsAreExempt(t *testing.T) {
+	local := &Project{ID: "p1", Path: "/tmp/x", AllowedMcpIDs: []string{"fsmcp"}}
+	s := &Settings{}
+	if err := s.ValidateProjectGrants(local, McpSurfaces{"fsmcp": fsmcpSurface()}); err != nil {
+		t.Fatalf("a local project was refused a path-scoped MCP: %v", err)
+	}
+}
+
+func TestSyncProjectToken_DerivesEveryProjectPathFieldTheSchemaDeclares(t *testing.T) {
+	// Relay writes the path because the SCHEMA asked for it, not because relay
+	// recognised the name. The field here is called write_dirs and relay has
+	// never heard of it.
+	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "macmcp"}}}
+	proj := &Project{ID: "p1", Path: "/tmp/project", AllowedMcpIDs: []string{"macmcp"}}
+	s.SyncProjectToken(proj, McpSurfaces{"macmcp": macmcpSurface()})
+
+	values := contextValues(proj.Context["macmcp"])
+	if string(values["write_dirs"]) != `["/tmp/project"]` {
+		t.Fatalf("write_dirs = %s, want the project path", values["write_dirs"])
+	}
+	// The operator-supplied fields are NOT invented. Relay has no answer to
+	// "which mailbox" and must not guess one.
+	if _, invented := values["mail_accounts"]; invented {
+		t.Errorf("relay invented a value for an operator-supplied scope field: %s", values["mail_accounts"])
+	}
+}
+
+func TestSyncProjectToken_DerivationDoesNotClobberOperatorSetFields(t *testing.T) {
+	// The old code replaced the whole context blob, which was harmless while
+	// relay derived exactly one field and destructive as soon as an operator
+	// can set others beside it.
+	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "macmcp"}}}
+	proj := &Project{
+		ID: "p1", Path: "/tmp/project", AllowedMcpIDs: []string{"macmcp"},
+		Context: map[string]json.RawMessage{
+			"macmcp": json.RawMessage(`{"mail_accounts":["Bob"],"mail_mailboxes":["INBOX"]}`),
+		},
+	}
+	s.SyncProjectToken(proj, McpSurfaces{"macmcp": macmcpSurface()})
+
+	values := contextValues(proj.Context["macmcp"])
+	if string(values["mail_accounts"]) != `["Bob"]` {
+		t.Errorf("an operator-set scope was lost on resync: %v", values)
+	}
+	if string(values["write_dirs"]) != `["/tmp/project"]` {
+		t.Errorf("the derived field was not written beside it: %v", values)
+	}
+}
+
+func TestSyncProjectToken_ARemoteRecordNeverGetsAProjectPathField(t *testing.T) {
+	// Defence in depth, stated generically. ValidateProjectGrants is supposed
+	// to refuse a grant this could apply to; this guard is what keeps a bypass
+	// of that check from turning a silent widening into a loud failure.
+	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "macmcp"}}}
+	proj := &Project{ID: "p1", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"}}
+	s.SyncProjectToken(proj, McpSurfaces{"macmcp": macmcpSurface()})
+	if raw, ok := proj.Context["macmcp"]; ok {
+		t.Fatalf("a profile was handed a derived scope: %s", raw)
+	}
+}
+
+func TestSyncProjectToken_DisablesFsBashForAnyPathScopedMcp(t *testing.T) {
+	// DEFERRED by ADR-011: this is still a hardcoded tool name. It is now keyed
+	// off "this MCP scopes something to the project path" rather than off the
+	// field's name, which is the most domain-blind form available without the
+	// schema change.
+	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "fsmcp"}}}
+	proj := &Project{ID: "p1", Path: "/tmp/project", AllowedMcpIDs: []string{"fsmcp"}}
+	s.SyncProjectToken(proj, McpSurfaces{"fsmcp": fsmcpSurface()})
+	if len(proj.DisabledTools["fsmcp"]) != 1 || proj.DisabledTools["fsmcp"][0] != v1FsBashTool {
+		t.Fatalf("fs_bash was not auto-disabled: %v", proj.DisabledTools)
+	}
+	// Idempotent across resyncs.
+	s.SyncProjectToken(proj, McpSurfaces{"fsmcp": fsmcpSurface()})
+	if len(proj.DisabledTools["fsmcp"]) != 1 {
+		t.Fatalf("a resync duplicated the entry: %v", proj.DisabledTools)
+	}
+}
+
+func TestSyncProjectToken_PrunesTheNewAllowlistsForRevokedMcps(t *testing.T) {
+	// A stale entry for an MCP the project no longer grants reads as a grant
+	// and is not one.
+	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "macmcp"}, {ID: "fsmcp"}}}
+	proj := &Project{
+		ID: "p1", Path: "/tmp/project", AllowedMcpIDs: []string{"macmcp"},
+		Access:       map[string]string{"macmcp": AccessWrite, "fsmcp": AccessWrite},
+		AllowedTools: map[string][]string{"macmcp": {"mail_*"}, "fsmcp": {"fs_*"}},
+	}
+	s.SyncProjectToken(proj, McpSurfaces{"macmcp": macmcpSurface()})
+	if _, stale := proj.Access["fsmcp"]; stale {
+		t.Error("an access mode survived for an MCP the project no longer grants")
+	}
+	if _, stale := proj.AllowedTools["fsmcp"]; stale {
+		t.Error("an allowlist survived for an MCP the project no longer grants")
+	}
+	if _, kept := proj.AllowedTools["macmcp"]; !kept {
+		t.Error("the granted MCP's allowlist was pruned")
+	}
+}
+
+func TestSyncProjectToken_V1SchemaStillGetsTheAllowedDirsBranch(t *testing.T) {
+	// One release of compatibility, unchanged: an MCP that declares no
+	// contextSchemaVersion is handled exactly as it was.
+	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "fsmcp"}}}
+	proj := &Project{ID: "p1", Path: "/tmp/project", AllowedMcpIDs: []string{"fsmcp"}}
+	s.SyncProjectToken(proj, McpSurfaces{"fsmcp": {Schema: json.RawMessage(`{"allowed_dirs":{"type":"array"}}`)}})
+	if string(proj.Context["fsmcp"]) != `{"allowed_dirs":["/tmp/project"]}` {
+		t.Fatalf("v1 derivation changed shape: %s", proj.Context["fsmcp"])
+	}
+}
+
+func TestUpdateProjectAllowedTools_DropsEntriesForUngrantedMcps(t *testing.T) {
+	s := &Settings{Projects: []Project{{ID: "p1", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"}}}}
+	s.UpdateProjectAllowedTools("p1", map[string][]string{
+		"macmcp": {"mail_*", "mail_*", ""},
+		"fsmcp":  {"fs_read"},
+	})
+	proj, _ := s.findProjectByID("p1")
+	if len(proj.AllowedTools) != 1 {
+		t.Fatalf("allowlist kept an entry for an ungranted MCP: %v", proj.AllowedTools)
+	}
+	if got := proj.AllowedTools["macmcp"]; len(got) != 1 || got[0] != "mail_*" {
+		t.Fatalf("duplicates and blanks were not cleaned: %v", got)
+	}
+	s.UpdateProjectAllowedTools("p1", nil)
+	if proj, _ := s.findProjectByID("p1"); proj.AllowedTools != nil {
+		t.Fatalf("clearing the allowlist left %v", proj.AllowedTools)
+	}
+}

--- a/settings_scope_test.go
+++ b/settings_scope_test.go
@@ -55,7 +55,7 @@ func TestValidateProjectGrants_RefusesAnMcpWhoseEveryToolNeedsTheProjectPath(t *
 }
 
 func TestValidateProjectGrants_PermitsAnMcpThatKeepsUsableTools(t *testing.T) {
-	// macMCP's write_dirs governs mail_save_attachment and mail_get_source
+	// macMCP's file_dirs governs mail_save_attachment and mail_get_source
 	// only, so the MCP stays grantable and precisely those two lose their
 	// filesystem write. This is ADR-011 finding 1's fix arriving as a
 	// consequence of the model rather than as a special case.
@@ -97,15 +97,15 @@ func TestValidateProjectGrants_LocalProjectsAreExempt(t *testing.T) {
 
 func TestSyncProjectToken_DerivesEveryProjectPathFieldTheSchemaDeclares(t *testing.T) {
 	// Relay writes the path because the SCHEMA asked for it, not because relay
-	// recognised the name. The field here is called write_dirs and relay has
+	// recognised the name. The field here is called file_dirs and relay has
 	// never heard of it.
 	s := &Settings{ExternalMcps: []ExternalMcp{{ID: "macmcp"}}}
 	proj := &Project{ID: "p1", Path: "/tmp/project", AllowedMcpIDs: []string{"macmcp"}}
 	s.SyncProjectToken(proj, McpSurfaces{"macmcp": macmcpSurface()})
 
 	values := contextValues(proj.Context["macmcp"])
-	if string(values["write_dirs"]) != `["/tmp/project"]` {
-		t.Fatalf("write_dirs = %s, want the project path", values["write_dirs"])
+	if string(values["file_dirs"]) != `["/tmp/project"]` {
+		t.Fatalf("file_dirs = %s, want the project path", values["file_dirs"])
 	}
 	// The operator-supplied fields are NOT invented. Relay has no answer to
 	// "which mailbox" and must not guess one.
@@ -131,7 +131,7 @@ func TestSyncProjectToken_DerivationDoesNotClobberOperatorSetFields(t *testing.T
 	if string(values["mail_accounts"]) != `["Bob"]` {
 		t.Errorf("an operator-set scope was lost on resync: %v", values)
 	}
-	if string(values["write_dirs"]) != `["/tmp/project"]` {
+	if string(values["file_dirs"]) != `["/tmp/project"]` {
 		t.Errorf("the derived field was not written beside it: %v", values)
 	}
 }

--- a/settings_scope_ui_test.go
+++ b/settings_scope_ui_test.go
@@ -1,0 +1,387 @@
+package main
+
+// The operator half of ADR-011, under goja: the per-MCP permission panel, the
+// authority summary on a list row, and the "needs a scope value" warning.
+//
+// These are UI tests because the ADR's second constraint is a UI constraint —
+// "an operator must be able to express [a confinement] without it being easy
+// to make a mistake", and a configuration UI that is hard to get right defeats
+// the security constraint rather than trading against it. The server refuses a
+// bad value (project_permissions_test.go); this file is about whether the
+// screen tells an operator the truth about what a grant permits.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+// macMCP's worked example as the UI receives it: what Go's ScopeFieldView
+// projects, with `source` already normalised.
+const scopeFieldsFixture = `{
+	macmcp: [
+		{name:'mail_accounts', type:'array', item_type:'string', description:'Mail accounts this client may read from or send as', source:'operator', applies_to:['mail_*'], enumerable:true},
+		{name:'mail_mailboxes', type:'array', item_type:'string', description:'Mailbox paths within those accounts this client may reach', source:'operator', applies_to:['mail_*'], enumerable:true, depends_on:['mail_accounts']},
+		{name:'write_dirs', type:'array', item_type:'string', description:'Directories this client may write files into', source:'project_path', applies_to:['mail_save_attachment','mail_get_source']}
+	],
+	quietmcp: []
+}`
+
+const scopeMcpsFixture = `[{id:'macmcp', display_name:'macMCP'}, {id:'quietmcp', display_name:'Quiet MCP'}]`
+
+// seedScopeVM loads the bundle with a live v2 schema and one record open in
+// the editor.
+func seedScopeVM(t *testing.T, projectsJSON, editingID string) *goja.Runtime {
+	t.Helper()
+	vm := newAppVM(t)
+	script := `(function(){
+		window.__sent = [];
+		window.webkit = { messageHandlers: { ipc: { postMessage: function(m){ window.__sent.push(String(m)); } } } };
+		window.state.page = 'projects';
+		window.state.externalMcps = ` + scopeMcpsFixture + `;
+		window.state.mcpScopeFields = ` + scopeFieldsFixture + `;
+		window.state.projects = ` + projectsJSON + `;
+		window.state.editingProjectId = null;
+		window.state.projectForm = null;
+		` + editingScript(editingID) + `
+		return true;
+	})()`
+	if _, err := vm.RunString(script); err != nil {
+		t.Fatalf("seeding scope state: %v", err)
+	}
+	return vm
+}
+
+func editingScript(id string) string {
+	if id == "" {
+		return ""
+	}
+	return `window.editProject('` + id + `');`
+}
+
+// A profile with a full permission set, and one with none of it — the second
+// is what every existing remote grant looks like the moment this ships.
+const scopeProjectsFixture = `[
+	{id:'p_bob', name:'Hermes — Bob INBOX', kind:'remote', path:'', allowed_mcp_ids:['macmcp'], allowed_models:[],
+	 allowed_tools:{macmcp:['mail_*']}, access:{macmcp:'read'},
+	 context:{macmcp:{mail_accounts:['Bob'], mail_mailboxes:['INBOX']}}, disabled_tools:{}},
+	{id:'p_bare', name:'Hermes Mail', kind:'remote', path:'', allowed_mcp_ids:['macmcp'], allowed_models:[], disabled_tools:{}},
+	{id:'p_local', name:'Workspace', path:'/Users/x/work', allowed_mcp_ids:['macmcp'], allowed_models:['*'],
+	 context:{macmcp:{write_dirs:['/Users/x/work'], mail_accounts:['Alice']}}, disabled_tools:{}}
+]`
+
+// ---------------------------------------------------------------------------
+// The list row
+// ---------------------------------------------------------------------------
+
+// A row says what the client can DO — mode, tools, scope — not how many MCPs
+// it names. "MCPs: 1" beside a client that can read every mailbox on the
+// machine is the failure this ADR exists to fix, and it was rendered here.
+func TestProjectList_ShowsEffectiveAuthority(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "")
+	html := evalString(t, vm, `window.renderProjects()`)
+
+	for _, want := range []string{
+		`>read<`,             // the mode, in force
+		`mail_*`,             // the tools it may call
+		"mail_accounts: Bob", // the resources it may reach
+		"mail_mailboxes: INBOX",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("list row does not show %q\n%s", want, html)
+		}
+	}
+	// The bare profile: no allowed_tools means NO tools, and the row says so
+	// rather than leaving an empty space that reads as "unrestricted".
+	if !strings.Contains(html, "no tools") {
+		t.Error("a profile with no allowed_tools does not say it holds none")
+	}
+	// A local project defaults to write; a profile defaults to read. The
+	// asymmetry is the whole of ADR-011 decision 2 and it has to be visible.
+	if !strings.Contains(html, `>write<`) {
+		t.Error("the local project's default write mode is not shown")
+	}
+}
+
+// "N profiles need a scope value for macmcp" — the operator-facing half of
+// loud-and-closed. The client-facing half is a `denied` at call time, which is
+// silent from this side.
+func TestProjectList_NamesAMissingScopeValue(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "")
+	html := evalString(t, vm, `window.renderProjects()`)
+
+	if !strings.Contains(html, "proj-scope-gap") {
+		t.Fatalf("no missing-scope banner at all\n%s", html)
+	}
+	for _, want := range []string{"Hermes Mail", "macmcp", "mail_accounts", "mail_mailboxes"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("the banner does not name %q", want)
+		}
+	}
+	// The complete profile is not in the banner, and the incomplete one is
+	// marked on its own row too.
+	if !strings.Contains(html, "needs a scope value for") {
+		t.Error("the incomplete row itself carries no warning")
+	}
+	gaps := evalString(t, vm, `JSON.stringify(window.projScopeGaps(window.state.projects[0]))`)
+	if gaps != "[]" {
+		t.Errorf("a fully-scoped profile was reported as incomplete: %s", gaps)
+	}
+	// A local project missing a value is named too: decision 4 is not
+	// remote-only, and the live wildcard "Relay" project is the case.
+	local := evalString(t, vm, `JSON.stringify(window.projScopeGaps(window.state.projects[2]))`)
+	if !strings.Contains(local, "mail_mailboxes") {
+		t.Errorf("a local project missing a scope value was not reported: %s", local)
+	}
+}
+
+// Regen Skill cannot do anything for a profile — validateProjectShape refuses
+// generate_skill on a remote record and the handler refuses a record with no
+// path — so the button is absent rather than present and inert. ADR-009
+// decision 2's argument applies to the control as much as to the flag.
+func TestProjectList_NoRegenSkillButtonForAProfile(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "")
+	html := evalString(t, vm, `window.renderProjects()`)
+	if n := strings.Count(html, "regenProjectSkill("); n != 1 {
+		t.Errorf("want exactly one Regen Skill button (the local project), got %d\n%s", n, html)
+	}
+	if strings.Contains(html, `regenProjectSkill('p_bob')`) || strings.Contains(html, `regenProjectSkill('p_bare')`) {
+		t.Error("a profile was offered a control that cannot do anything")
+	}
+}
+
+// A remote-kind record is an ACCESS PROFILE everywhere an operator reads it.
+func TestProjectList_CallsAProfileAProfile(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "")
+	html := evalString(t, vm, `window.renderProjects()`)
+	if !strings.Contains(html, "Access profile") {
+		t.Error("the badge does not name a remote record an access profile")
+	}
+	if !strings.Contains(html, "no host directory") {
+		t.Error("a profile's row still reads as a project with a missing path")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The editor
+// ---------------------------------------------------------------------------
+
+// The panel is the whole authority in one place: which operations, which
+// tools, which resources.
+func TestProjectForm_PermissionPanel(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "p_bob")
+	html := evalString(t, vm, `window.renderProjectForm()`)
+
+	for _, want := range []string{
+		"Operations",
+		`setProjAccess('macmcp', 'read')`,
+		`setProjAccess('macmcp', 'write')`,
+		"Tools",
+		`setProjAllowedToolsText('macmcp', this.value)`,
+		"Resource scope",
+		// Each field, with the MCP's OWN description as help text and its
+		// declared type named — an operator typing into a box has to be told
+		// what shape belongs in it.
+		"mail_accounts",
+		"Mail accounts this client may read from or send as",
+		"list of strings, one per line",
+		`setProjScopeText('macmcp', 'mail_accounts', this.value)`,
+		// The dependency the MCP declared, so an operator knows one field is
+		// read within the other.
+		"Values here are read within mail_accounts",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("permission panel is missing %q\n%s", want, html)
+		}
+	}
+	// The existing values are in the boxes, one per line.
+	if !strings.Contains(html, ">Bob</textarea>") || !strings.Contains(html, ">INBOX</textarea>") {
+		t.Error("stored scope values are not rendered back into their inputs")
+	}
+}
+
+// A source: "project_path" field is READ-ONLY and shows the derived value: an
+// operator has to see that the bound exists without being able to type in it.
+func TestProjectForm_ProjectPathFieldIsReadOnly(t *testing.T) {
+	// Local: the bound exists and its value is on screen.
+	vm := seedScopeVM(t, scopeProjectsFixture, "p_local")
+	html := evalString(t, vm, `window.renderProjectForm()`)
+	if !strings.Contains(html, `readonly value="/Users/x/work"`) {
+		t.Errorf("the derived write_dirs value is not shown read-only\n%s", html)
+	}
+	if strings.Contains(html, `setProjScopeText('macmcp', 'write_dirs'`) {
+		t.Error("a derived field was rendered as an editable input")
+	}
+
+	// Profile: there is nothing to derive, and the panel says the tools that
+	// field governs are refused — the intended outcome, not a gap to fill in.
+	vm = seedScopeVM(t, scopeProjectsFixture, "p_bob")
+	html = evalString(t, vm, `window.renderProjectForm()`)
+	for _, want := range []string{"no host directory", "mail_save_attachment", "is refused"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("the profile's derived field does not explain itself: missing %q\n%s", want, html)
+		}
+	}
+}
+
+// A profile gets two grant states, not three: the third is a denylist, and
+// validateProjectShape refuses disabled_tools on a remote record outright.
+func TestProjectForm_ProfileHasNoDenylistTriState(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "p_bob")
+	html := evalString(t, vm, `window.renderProjectForm()`)
+	if strings.Contains(html, "Selected</button>") {
+		t.Error("a profile was offered the disabled_tools tri-state, which the server refuses")
+	}
+	for _, want := range []string{"Granted</button>", "Not granted</button>"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("profile grant control is missing %q", want)
+		}
+	}
+}
+
+// An MCP that declares nothing narrowable says so, and one relay has never
+// connected to says something DIFFERENT — "scopes nothing" and "cannot say"
+// must not read the same, because only the first means an editor may safely
+// offer no fields.
+func TestProjectForm_TellsSilenceFromIgnorance(t *testing.T) {
+	vm := seedScopeVM(t, `[{id:'p1', name:'P', kind:'remote', path:'', allowed_mcp_ids:['quietmcp','ghostmcp'], allowed_models:[], disabled_tools:{}}]`, "p1")
+	vm.RunString(`window.state.externalMcps = [{id:'quietmcp', display_name:'Quiet MCP'}, {id:'ghostmcp', display_name:'Ghost MCP'}];`)
+	html := evalString(t, vm, `window.renderProjectForm()`)
+	if !strings.Contains(html, "declares nothing narrowable") {
+		t.Error("an MCP with no restrict fields does not say so")
+	}
+	if !strings.Contains(html, "has not connected to this MCP") {
+		t.Error("an MCP relay has never seen is not distinguished from one that scopes nothing")
+	}
+}
+
+// What the editor SENDS. Typed text becomes the three maps relay stores, and a
+// derived field is never sent — relay owns it and refuses an operator copy.
+func TestProjectForm_HarvestsThePermissionSet(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "p_bob")
+	got := evalString(t, vm, `(function(){
+		window.setProjAccess('macmcp', 'write');
+		window.setProjAllowedToolsText('macmcp', 'mail_*\n mail_send \n\n');
+		window.setProjScopeText('macmcp', 'mail_accounts', 'Alice\nBob\n');
+		window.setProjScopeText('macmcp', 'mail_mailboxes', '  INBOX  ');
+		document.getElementById('projName').value = 'Hermes — Bob INBOX';
+		return JSON.stringify(window.harvestProjectForm());
+	})()`)
+
+	for _, want := range []string{
+		`"access":{"macmcp":"write"}`,
+		`"allowed_tools":{"macmcp":["mail_*","mail_send"]}`,
+		`"mail_accounts":["Alice","Bob"]`,
+		`"mail_mailboxes":["INBOX"]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("harvested payload missing %s in %s", want, got)
+		}
+	}
+	if strings.Contains(got, "write_dirs") {
+		t.Errorf("the editor sent a field relay derives and refuses: %s", got)
+	}
+}
+
+// Clearing a scope value SENDS the clearance rather than omitting the field.
+// context is a pointer on the update DTO — an omitted map means "no change",
+// so an editor that dropped an emptied field could never clear one.
+func TestProjectForm_ClearingAScopeValueIsSent(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "p_bob")
+	got := evalString(t, vm, `(function(){
+		window.setProjScopeText('macmcp', 'mail_accounts', '');
+		document.getElementById('projName').value = 'X';
+		return JSON.stringify(window.harvestProjectForm());
+	})()`)
+	if strings.Contains(got, "mail_accounts") {
+		t.Errorf("a cleared value was still sent: %s", got)
+	}
+	if !strings.Contains(got, `"context":{`) {
+		t.Errorf("context was omitted entirely, which reads as 'no change': %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The Remote Clients tab
+// ---------------------------------------------------------------------------
+
+// ADR-011 decision 1: the enrolment listing gains the profile's EFFECTIVE
+// authority inline, so "what can this client do" is answered in one place
+// without mentally joining two records. That is the real cost of keeping two
+// records and it is paid here, in the UI.
+func TestRemoteTab_ShowsEffectiveAuthorityInline(t *testing.T) {
+	vm := seedRemoteVM(t, scopeProjectsFixture, `[{
+		client_id:'hermes-bob', fingerprint:'`+enrolFingerprint+`',
+		project_ids:['p_bob','p_bare'], budget:{window_seconds:60,max_calls:60,max_result_bytes:1024},
+		created_at:'2026-08-20T09:14:00Z'
+	}]`, remoteEnabled)
+	if _, err := vm.RunString(`window.state.externalMcps = ` + scopeMcpsFixture + `; window.state.mcpScopeFields = ` + scopeFieldsFixture + `;`); err != nil {
+		t.Fatalf("seed schema: %v", err)
+	}
+	html := evalString(t, vm, `window.renderEnrolments()`)
+
+	for _, want := range []string{
+		"Hermes — Bob INBOX", // the profile's name, as before
+		`>read<`,             // and now what it permits
+		"mail_accounts: Bob",
+		"no tools", // the bare profile, which grants nothing
+		"needs a scope value for",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("enrolment card does not answer 'what can this client do': missing %q\n%s", want, html)
+		}
+	}
+}
+
+// The editor's payload has to decode into the DTOs the routes and the IPC
+// handlers share. Every field on projectUpdateFields is optional and an
+// unrecognised key is silently ignored, so a tag mismatch here would look
+// exactly like an operator's edit not sticking — which is the failure mode
+// this whole change exists to remove. This is TestRemoteProjectPayloadFromSettingsUI
+// with the real harvest output rather than a hand-written copy of it.
+func TestProjectForm_PayloadDecodesIntoTheSharedDTOs(t *testing.T) {
+	vm := seedScopeVM(t, scopeProjectsFixture, "p_bob")
+	raw := evalString(t, vm, `(function(){
+		window.setProjAccess('macmcp', 'read');
+		window.setProjAllowedToolsText('macmcp', 'mail_*');
+		window.setProjScopeText('macmcp', 'mail_accounts', 'Bob');
+		window.setProjScopeText('macmcp', 'mail_mailboxes', 'INBOX');
+		document.getElementById('projName').value = 'Hermes — Bob INBOX';
+		return JSON.stringify(window.harvestProjectForm());
+	})()`)
+
+	var create projectCreateFields
+	if err := json.Unmarshal([]byte(raw), &create); err != nil {
+		t.Fatalf("editor payload did not decode as a create: %v\n%s", err, raw)
+	}
+	if create.Access["macmcp"] != AccessRead {
+		t.Errorf(`"access" did not reach projectCreateFields.Access — check the json tag: %#v`, create.Access)
+	}
+	if len(create.AllowedTools["macmcp"]) != 1 {
+		t.Errorf(`"allowed_tools" did not reach the DTO: %#v`, create.AllowedTools)
+	}
+	if !strings.Contains(string(create.Context["macmcp"]), "INBOX") {
+		t.Errorf(`"context" did not reach the DTO: %s`, create.Context["macmcp"])
+	}
+
+	var update projectUpdateFields
+	if err := json.Unmarshal([]byte(raw), &update); err != nil {
+		t.Fatalf("editor payload did not decode as an update: %v", err)
+	}
+	if update.Access == nil || update.Context == nil || update.AllowedTools == nil {
+		t.Fatalf("a pointer field stayed nil, which the update path reads as 'no change': %#v", update)
+	}
+
+	// And the round trip: what the editor sends is accepted by the mutator
+	// layer both surfaces call.
+	s := &Settings{Version: 1}
+	created, err := applyProjectCreate(s, create, v2Surfaces())
+	if err != nil {
+		t.Fatalf("the editor's own payload was refused by applyProjectCreate: %v", err)
+	}
+	if created.Access["macmcp"] != AccessRead || !strings.Contains(string(created.Context["macmcp"]), "Bob") {
+		t.Errorf("the permission set did not survive the create: %#v", created)
+	}
+}

--- a/settings_scope_ui_test.go
+++ b/settings_scope_ui_test.go
@@ -187,7 +187,9 @@ func TestProjectForm_PermissionPanel(t *testing.T) {
 		"mail_accounts",
 		"Mail accounts this client may read from or send as",
 		"list of strings, one per line",
-		`setProjScopeText('macmcp', 'mail_accounts', this.value)`,
+		// Both mail fields declare enumerable, so both get the picker rather
+		// than a box to type a mailbox name into (ADR-011 decision 6).
+		`toggleScopeFieldPicker('macmcp', 'mail_accounts')`,
 		// The dependency the MCP declared, so an operator knows one field is
 		// read within the other.
 		"Values here are read within mail_accounts",
@@ -196,9 +198,17 @@ func TestProjectForm_PermissionPanel(t *testing.T) {
 			t.Errorf("permission panel is missing %q\n%s", want, html)
 		}
 	}
-	// The existing values are in the boxes, one per line.
-	if !strings.Contains(html, ">Bob</textarea>") || !strings.Contains(html, ">INBOX</textarea>") {
-		t.Error("stored scope values are not rendered back into their inputs")
+	// The stored values are on screen WITHOUT anything being opened: what is
+	// stored is what confines the client, so it is never behind a disclosure.
+	if !strings.Contains(html, `<div class="proj-scope-summary">Bob</div>`) ||
+		!strings.Contains(html, `<div class="proj-scope-summary">INBOX</div>`) {
+		t.Errorf("stored scope values are not shown on the closed panel\n%s", html)
+	}
+	// And nothing was enumerated by merely rendering the form: a live call
+	// into another process is not something a paint does.
+	sent := evalString(t, vm, `JSON.stringify(window.__sent)`)
+	if strings.Contains(sent, "enumerate_scope_field") {
+		t.Errorf("rendering the editor fired a live enumeration: %s", sent)
 	}
 }
 

--- a/settings_scope_ui_test.go
+++ b/settings_scope_ui_test.go
@@ -24,7 +24,7 @@ const scopeFieldsFixture = `{
 	macmcp: [
 		{name:'mail_accounts', type:'array', item_type:'string', description:'Mail accounts this client may read from or send as', source:'operator', applies_to:['mail_*'], enumerable:true},
 		{name:'mail_mailboxes', type:'array', item_type:'string', description:'Mailbox paths within those accounts this client may reach', source:'operator', applies_to:['mail_*'], enumerable:true, depends_on:['mail_accounts']},
-		{name:'write_dirs', type:'array', item_type:'string', description:'Directories this client may write files into', source:'project_path', applies_to:['mail_save_attachment','mail_get_source']}
+		{name:'file_dirs', type:'array', item_type:'string', description:'Directories this client may write files into', source:'project_path', applies_to:['mail_save_attachment','mail_get_source']}
 	],
 	quietmcp: []
 }`
@@ -69,7 +69,7 @@ const scopeProjectsFixture = `[
 	 context:{macmcp:{mail_accounts:['Bob'], mail_mailboxes:['INBOX']}}, disabled_tools:{}},
 	{id:'p_bare', name:'Hermes Mail', kind:'remote', path:'', allowed_mcp_ids:['macmcp'], allowed_models:[], disabled_tools:{}},
 	{id:'p_local', name:'Workspace', path:'/Users/x/work', allowed_mcp_ids:['macmcp'], allowed_models:['*'],
-	 context:{macmcp:{write_dirs:['/Users/x/work'], mail_accounts:['Alice']}}, disabled_tools:{}}
+	 context:{macmcp:{file_dirs:['/Users/x/work'], mail_accounts:['Alice']}}, disabled_tools:{}}
 ]`
 
 // ---------------------------------------------------------------------------
@@ -219,9 +219,9 @@ func TestProjectForm_ProjectPathFieldIsReadOnly(t *testing.T) {
 	vm := seedScopeVM(t, scopeProjectsFixture, "p_local")
 	html := evalString(t, vm, `window.renderProjectForm()`)
 	if !strings.Contains(html, `readonly value="/Users/x/work"`) {
-		t.Errorf("the derived write_dirs value is not shown read-only\n%s", html)
+		t.Errorf("the derived file_dirs value is not shown read-only\n%s", html)
 	}
-	if strings.Contains(html, `setProjScopeText('macmcp', 'write_dirs'`) {
+	if strings.Contains(html, `setProjScopeText('macmcp', 'file_dirs'`) {
 		t.Error("a derived field was rendered as an editable input")
 	}
 
@@ -290,7 +290,7 @@ func TestProjectForm_HarvestsThePermissionSet(t *testing.T) {
 			t.Errorf("harvested payload missing %s in %s", want, got)
 		}
 	}
-	if strings.Contains(got, "write_dirs") {
+	if strings.Contains(got, "file_dirs") {
 		t.Errorf("the editor sent a field relay derives and refuses: %s", got)
 	}
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -1033,8 +1033,8 @@ func TestValidateProjectGrants_RefusesFilesystemMcpInEitherSchemaShape(t *testin
 			s := &Settings{Projects: []Project{{
 				ID: "p1", Name: "Remote", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"fsmcp"},
 			}}}
-			err := s.ValidateProjectGrants(&s.Projects[0], map[string]json.RawMessage{
-				"fsmcp": json.RawMessage(schema),
+			err := s.ValidateProjectGrants(&s.Projects[0], McpSurfaces{
+				"fsmcp": {Schema: json.RawMessage(schema)},
 			})
 			if err == nil {
 				t.Fatalf("%s schema: remote project was granted a filesystem-scoped MCP", name)

--- a/timeouts.go
+++ b/timeouts.go
@@ -17,6 +17,14 @@ const (
 	// handshake (spawn, initialize, tools/list, kill).
 	MCPDiscoveryTimeout = 30 * time.Second
 
+	// MCPEnumerateTimeout bounds one context/enumerate request (ADR-011
+	// decision 6). Deliberately far shorter than MCPRequestTimeout: that one
+	// is five minutes because a tool call can be an LLM inference, whereas
+	// this is a control an operator is looking at, and the correct degraded
+	// answer — "could not list, try again", with the text box still there —
+	// is much better than a spinner.
+	MCPEnumerateTimeout = 15 * time.Second
+
 	// MCPStartupTimeout is the maximum time for a single MCP to complete
 	// its startup handshake during StartAll/Reconcile. This bounds the
 	// HTTP transport path which has no independent per-request timer

--- a/tool_pattern_test.go
+++ b/tool_pattern_test.go
@@ -1,0 +1,271 @@
+package main
+
+// F1 and F2: an allowlist entry that matches by shape rather than by name.
+//
+// ADR-011 decision 2b refuses a wildcard in allowed_tools because registering
+// a tool tomorrow must not widen a grant made today. That refusal was a
+// literal compare against "*" while the matcher underneath was path.Match, and
+// a tool name contains no "/" — so "**", "?*", "*_*", "[a-z]*" and "*e*" each
+// match EVERY tool of an MCP and not one of them is the string "*". An
+// adversarial review built a read-only "mail" profile with
+// allowed_tools {"macmcp": ["**"]}, was served 26 tools across 11 of macMCP's
+// domains, and exfiltrated through web_fetch — the outbound channel decision
+// 2b claims to remove.
+//
+// The two halves are tested together on purpose. Refusing at the editor is
+// F1; refusing at the matcher is F2, because any route that skips validation
+// (a hand-edited settings.json, a restored backup, a migration written before
+// the rule) must not be able to widen a grant either. A fix in one place only
+// is a fix that holds until the next way into the file.
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// everyToolPatternTheReviewFound is the reviewer's list verbatim, plus the
+// bare "*" the old rule did catch. Every one of these matched all 47 of
+// macMCP's tools through path.Match.
+var everyToolPatternTheReviewFound = []string{
+	"*",
+	"**",
+	"?*",
+	"*_*",
+	"[a-z]*",
+	"*e*",
+	// Not from the review: the next spellings, which is the point of fixing
+	// the matcher rather than blacklisting the six above.
+	"***",
+	"?",
+	"??????*",
+	"[a-z]*_*",
+	"*[a-z]*",
+	`\*` + "*", // an escaped star followed by a real one: literal "*", matches nothing real
+}
+
+// The editor refuses every one of them, and the refusal names the pattern and
+// the MCP so an operator knows which line to fix.
+func TestAllowedTools_ValidationRefusesEveryOverBroadSpelling(t *testing.T) {
+	for _, pattern := range everyToolPatternTheReviewFound {
+		if pattern == `\**` {
+			continue // literal "*" — narrow, not broad; asserted below
+		}
+		t.Run(pattern, func(t *testing.T) {
+			proj := &Project{ID: "p1", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"},
+				AllowedTools: map[string][]string{"macmcp": {pattern}}}
+			err := validateProjectPermissions(proj, v2Surfaces())
+			if err == nil {
+				t.Fatalf("pattern %q was accepted into an allowlist", pattern)
+			}
+			for _, want := range []string{pattern, "macmcp", "allowed_tools"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("refusal should say %q; got: %v", want, err)
+				}
+			}
+			// The create path is a second route to the same record and must
+			// refuse identically — CreateProjectWithTokenKind runs shape only.
+			if err := validateProjectShape(proj); err == nil {
+				t.Fatalf("validateProjectShape accepted %q", pattern)
+			}
+		})
+	}
+}
+
+// The other half of the rule: what an operator actually writes still works.
+// A refusal that also refused "mail_*" would be a fix that removes the
+// feature.
+func TestAllowedTools_ValidationKeepsNamePatterns(t *testing.T) {
+	for _, pattern := range []string{
+		"mail_*",
+		"mail_search",
+		"capture_screen*",
+		"mail_get_*",
+		"messages_?end",
+		`\**`, // a literal asterisk: a name, not a wildcard
+		"[cm]ail_*",
+	} {
+		t.Run(pattern, func(t *testing.T) {
+			proj := &Project{ID: "p1", Kind: ProjectKindRemote, AllowedMcpIDs: []string{"macmcp"},
+				AllowedTools: map[string][]string{"macmcp": {pattern}}}
+			if err := validateProjectPermissions(proj, v2Surfaces()); err != nil {
+				t.Fatalf("pattern %q was refused: %v", pattern, err)
+			}
+			if err := validateProjectShape(proj); err != nil {
+				t.Fatalf("validateProjectShape refused %q: %v", pattern, err)
+			}
+		})
+	}
+}
+
+// F2. Validation is not the boundary: the matcher refuses an over-broad
+// pattern wherever the record came from, and goes on honouring the real ones
+// beside it.
+func TestAllowedTools_MatcherRefusesEveryOverBroadSpelling(t *testing.T) {
+	surface := macmcpToolSurface()
+	for _, pattern := range everyToolPatternTheReviewFound {
+		if pattern == `\**` {
+			continue
+		}
+		t.Run(pattern, func(t *testing.T) {
+			tok := &StoredToken{ProjectKind: ProjectKindRemote,
+				AllowedTools: map[string][]string{"macmcp": {pattern}},
+				Access:       map[string]string{"macmcp": AccessWrite}}
+			for _, tool := range surface {
+				if tok.ToolAllowed("macmcp", tool.Name) {
+					t.Errorf("pattern %q admitted %q", pattern, tool.Name)
+				}
+			}
+			// Beside a real pattern the real one still decides. This is the
+			// case a "refuse the whole list" fix would get wrong, and the
+			// case a hand-edited file most plausibly holds.
+			tok.AllowedTools["macmcp"] = []string{"mail_*", pattern}
+			if !tok.ToolAllowed("macmcp", "mail_search") {
+				t.Errorf(`"mail_*" stopped admitting mail_search beside %q`, pattern)
+			}
+			for _, forbidden := range []string{"web_fetch", "capture_screenshot", "shortcuts_run", "xmail_send"} {
+				if tok.ToolAllowed("macmcp", forbidden) {
+					t.Errorf("pattern %q admitted %q beside \"mail_*\"", pattern, forbidden)
+				}
+			}
+		})
+	}
+}
+
+// The measurement the reviewer took, through the router this time: a profile
+// whose allowlist is "**" is served nothing at all, and web_fetch — the
+// outbound channel — is refused by name.
+func TestListTools_AnOverBroadAllowlistIsNotTheWholeMcp(t *testing.T) {
+	for _, pattern := range []string{"**", "*_*", "[a-z]*", "*e*"} {
+		t.Run(pattern, func(t *testing.T) {
+			r := newProfileRouter(t, profileOpts{
+				kind:         ProjectKindRemote,
+				allowedTools: map[string][]string{"macmcp": {pattern}},
+			})
+			if got := listedToolNames(t, r); len(got) != 0 {
+				t.Fatalf("allowed_tools [%q] listed %v", pattern, got)
+			}
+			for _, tool := range []string{"web_fetch", "capture_screenshot", "mail_search"} {
+				if _, err := r.CallTool(context.Background(), tool, json.RawMessage(`{}`), testToken); err == nil {
+					t.Errorf("allowed_tools [%q] called %q", pattern, tool)
+				}
+			}
+		})
+	}
+
+	// And the profile the operator meant to write is unaffected: mail_* still
+	// serves the mail tools and still holds nothing else.
+	r := newProfileRouter(t, profileOpts{
+		kind:         ProjectKindRemote,
+		allowedTools: map[string][]string{"macmcp": {"mail_*"}},
+		access:       map[string]string{"macmcp": AccessWrite},
+	})
+	got := listedToolNames(t, r)
+	if !slices.Contains(got, "mail_search") || !slices.Contains(got, "mail_send") {
+		t.Fatalf(`"mail_*" listed %v, want the mail tools`, got)
+	}
+	if slices.Contains(got, "web_fetch") {
+		t.Error(`"mail_*" listed web_fetch`)
+	}
+	if _, err := r.CallTool(context.Background(), "mail_search", json.RawMessage(`{}`), testToken); err != nil {
+		t.Fatalf(`"mail_*" could not call mail_search: %v`, err)
+	}
+}
+
+// The rule itself, stated as the two questions it asks. This is the test that
+// says what "too broad" MEANS, so a future edit to the probe list or the
+// literal scanner has something to be wrong against.
+func TestOverBroadToolPattern_TheRule(t *testing.T) {
+	cases := []struct {
+		pattern string
+		over    bool
+		why     string
+	}{
+		{"*", true, "no literal content"},
+		{"**", true, "no literal content"},
+		{"?*", true, "no literal content"},
+		{"[a-z]*", true, "a class is not a literal"},
+		{"*_*", true, "an underscore is in every identifier"},
+		{"*e*", true, "a letter is in every identifier"},
+		{"mail_*", false, "a real prefix"},
+		{"mail_search", false, "an exact name"},
+		{"*_search", false, "a real suffix"},
+		{"capture_screen*", false, "a real prefix"},
+	}
+	for _, tc := range cases {
+		_, over := overBroadToolPattern(tc.pattern)
+		if over != tc.over {
+			t.Errorf("overBroadToolPattern(%q) = %v, want %v (%s)", tc.pattern, over, tc.over, tc.why)
+		}
+	}
+
+	// The literal scanner underneath, which is where the first question is
+	// answered. A class and a wildcard contribute nothing; an escape does.
+	for _, tc := range []struct{ pattern, literal string }{
+		{"*", ""},
+		{"?*?", ""},
+		{"[a-z][0-9]*", ""},
+		{"[]a]*", ""},
+		{"[^a]*", ""},
+		{"mail_*", "mail_"},
+		{`\*`, "*"},
+		{`\[abc`, "[abc"},
+		{"a[b-c]d", "ad"},
+	} {
+		if got := toolPatternLiteral(tc.pattern); got != tc.literal {
+			t.Errorf("toolPatternLiteral(%q) = %q, want %q", tc.pattern, got, tc.literal)
+		}
+	}
+}
+
+// A context field's applies_to shares the matcher and must NOT share this
+// rule: a field that governs everything is a restriction that applies to
+// everything, which is the fail-closed reading there. Same pattern, opposite
+// meaning, and conflating the two would quietly unscope every tool.
+func TestOverBroadRuleDoesNotReachAppliesTo(t *testing.T) {
+	f := ContextField{Name: "mail_accounts", Scope: ContextScopeRestrict, AppliesTo: []string{"*"}}
+	for _, tool := range []string{"mail_search", "web_fetch", "capture_screenshot"} {
+		if !f.Governs(tool) {
+			t.Errorf(`applies_to ["*"] stopped governing %q`, tool)
+		}
+	}
+}
+
+// allowed_mcp_ids does NOT have allowed_tools' shape, and this test is what
+// says so out loud.
+//
+// The review asked for the same rule there. It does not apply, because the
+// list is not matched with path.Match: every consumer is
+// `isWildcard(ids) || slices.Contains(ids, mcpID)`, an exact string compare
+// with one special case for the single-entry "*". So "**" is not a wildcard
+// there — it is an MCP id nothing is named, and it grants nothing, which is
+// the fail-closed direction and needs no refusal.
+//
+// The reason to pin it is that the property is one edit away from being
+// untrue: swap the Contains for a glob and every spelling F1 is about becomes
+// live one layer up, with no test failing. This one fails.
+func TestAllowedMcpIDs_AreMatchedLiterallyAndNotAsGlobs(t *testing.T) {
+	mcps := []ExternalMcp{{ID: "macmcp"}, {ID: "fsmcp"}}
+	for _, pattern := range []string{"**", "?*", "*_*", "mac*", "[a-z]*"} {
+		s := &Settings{ExternalMcps: mcps}
+		proj := &Project{ID: "p1", Name: "Profile", Kind: ProjectKindRemote,
+			AllowedMcpIDs: []string{pattern}}
+		tok := s.storedTokenForProject(proj, "hash")
+		for _, id := range []string{"macmcp", "fsmcp"} {
+			if tok.Permissions[id] != PermOff {
+				t.Errorf("allowed_mcp_ids [%q] granted %q — the list is being matched as a pattern", pattern, id)
+			}
+		}
+	}
+	// The one special case is still the single "*", which validateProjectShape
+	// refuses for a profile and keeps for a local project.
+	local := &Project{ID: "p2", Name: "Local", Path: "/tmp/x", AllowedMcpIDs: []string{"*"}}
+	if tok := (&Settings{ExternalMcps: mcps}).storedTokenForProject(local, "hash"); len(tok.Permissions) != 0 {
+		t.Errorf(`a local project's ["*"] stopped meaning every MCP: %v`, tok.Permissions)
+	}
+	if err := validateProjectShape(&Project{Kind: ProjectKindRemote, AllowedMcpIDs: []string{"*"}}); err == nil {
+		t.Error(`a profile was allowed allowed_mcp_ids: ["*"]`)
+	}
+}

--- a/trayapp.go
+++ b/trayapp.go
@@ -159,6 +159,7 @@ func runTrayApp() {
 		NotifyReconcile:        bridge.SendReconcile,
 		NotifyReloadMcp:        bridge.SendReloadMcp,
 		Tools:                  extMgr,
+		Enumerate:              extMgr,
 	}
 
 	// Tool-call audit log. A failure here is logged and auditing stays off
@@ -222,7 +223,7 @@ func runTrayApp() {
 			app.platform.DispatchToMain(app.pushFullProjects)
 		}
 	}
-	frontend, err := NewFrontendServer(store, extMgr, extMgr, frontendEndpoint, enhancedRegistry, router, onProjectsChanged)
+	frontend, err := NewFrontendServer(store, extMgr, extMgr, extMgr, frontendEndpoint, enhancedRegistry, router, onProjectsChanged)
 	if err != nil {
 		slog.Error("failed to start frontend server", "error", err)
 		os.Exit(1)

--- a/types.go
+++ b/types.go
@@ -139,16 +139,16 @@ type ExternalMcp struct {
 	Command         string            `json:"command,omitempty"`
 	Args            []string          `json:"args"`
 	Env             map[string]string `json:"env"`
-	DiscoveredTools []ToolInfo        `json:"-"`                   // runtime-only; populated from live MCP connection
-	ContextSchema   json.RawMessage   `json:"-"`                   // runtime-only; discovered during MCP handshake
+	DiscoveredTools []ToolInfo        `json:"-"` // runtime-only; populated from live MCP connection
+	ContextSchema   json.RawMessage   `json:"-"` // runtime-only; discovered during MCP handshake
 	// ContextSchemaVersion is the declared contextSchemaVersion from the same
 	// serverInfo. Absent or < 2 means v1 (ADR-011 decision 3). Runtime-only,
 	// and it travels with ContextSchema everywhere — the version is what says
 	// how the schema may be read.
-	ContextSchemaVersion int `json:"-"`
-	Transport       string            `json:"transport,omitempty"` // "stdio" (default) or "http"
-	URL             string            `json:"url,omitempty"`       // MCP endpoint for HTTP transport
-	OAuthState      *OAuthState       `json:"oauth_state,omitempty"`
+	ContextSchemaVersion int         `json:"-"`
+	Transport            string      `json:"transport,omitempty"` // "stdio" (default) or "http"
+	URL                  string      `json:"url,omitempty"`       // MCP endpoint for HTTP transport
+	OAuthState           *OAuthState `json:"oauth_state,omitempty"`
 
 	// TccServices lists the macOS TCC services this MCP needs (e.g.
 	// ["calendar","contacts","reminders","microphone","appleevents"]).

--- a/types.go
+++ b/types.go
@@ -50,6 +50,21 @@ const (
 	AccessWrite = "write"
 )
 
+// IsRemote reports whether this token authenticates a remote-kind record.
+//
+// It goes through ProjectKind.IsRemote for the reason the Kind field comment
+// gives: the zero value must never be readable as remote, and every place that
+// spelled the test itself — `!= ProjectKindRemote` here, `== ProjectKindRemote`
+// in AccessMode — is a place where a later edit against the wrong constant
+// turns an unset field into a remote grant, or a remote grant into a local one.
+// The decision is made once, on the type.
+func (t *StoredToken) IsRemote() bool {
+	if t == nil {
+		return false
+	}
+	return t.ProjectKind.IsRemote()
+}
+
 // ToolAllowed reports whether this token's allowlist admits a tool of an MCP
 // (ADR-011 decision 2b). The MCP-level grant is checked separately; this is
 // the second of the four allowlists, and none of the four may widen another.
@@ -74,7 +89,7 @@ func (t *StoredToken) ToolAllowed(mcpID, toolName string) bool {
 	}
 	patterns := t.AllowedTools[mcpID]
 	if len(patterns) == 0 {
-		return t.ProjectKind != ProjectKindRemote
+		return !t.IsRemote()
 	}
 	return toolAllowedByPatterns(patterns, toolName)
 }
@@ -110,7 +125,7 @@ func (t *StoredToken) AccessMode(mcpID string) string {
 		}
 		return AccessRead
 	}
-	if t.ProjectKind == ProjectKindRemote {
+	if t.IsRemote() {
 		return AccessRead
 	}
 	return AccessWrite
@@ -433,12 +448,18 @@ func (e *Enrolment) GrantsProject(projectID string) bool {
 	return slices.Contains(e.ProjectIDs, projectID)
 }
 
+// IsRemote reports whether a kind is the remote one. This is the ONE place the
+// comparison is written — see the comment on Project.Kind for why the zero
+// value must always read as local. Everything that holds a kind (a Project, a
+// StoredToken) asks here rather than comparing against a constant itself.
+func (k ProjectKind) IsRemote() bool {
+	return k == ProjectKindRemote
+}
+
 // IsRemote reports whether this project is a remote capability grant rather
-// than a host-directory project. This is the ONLY place that decision should
-// be made — see the comment on Kind for why the zero value must always read
-// as local.
+// than a host-directory project.
 func (p *Project) IsRemote() bool {
-	return p.Kind == ProjectKindRemote
+	return p.Kind.IsRemote()
 }
 
 // normalizeProjectKind collapses anything that isn't ProjectKindRemote to the
@@ -452,7 +473,7 @@ func (p *Project) IsRemote() bool {
 // the overwhelmingly common case. Mirrors IsRemote()'s pattern of testing
 // for remote rather than for local.
 func normalizeProjectKind(kind ProjectKind) ProjectKind {
-	if kind == ProjectKindRemote {
+	if kind.IsRemote() {
 		return ProjectKindRemote
 	}
 	return ""

--- a/types.go
+++ b/types.go
@@ -21,11 +21,99 @@ type StoredToken struct {
 	// ProjectID is the stable id of the project this token authenticates (empty
 	// for service/external tokens). Injected into _meta so an MCP can attribute a
 	// call to its project without trusting LLM-supplied values.
-	ProjectID     string
+	ProjectID string
+	// ProjectKind is the kind of the project this token authenticates. It is
+	// carried because the access-mode default is ASYMMETRIC — see AccessMode —
+	// and checkToolAccess therefore has to know which side of that asymmetry a
+	// token is on. Empty (the zero value) is local, exactly as on Project.
+	ProjectKind   ProjectKind
 	Hash          string
 	Permissions   map[string]Permission
 	DisabledTools map[string][]string
 	Context       map[string]json.RawMessage
+
+	// Access is the per-MCP operation mode (ADR-011 decision 2), and
+	// AllowedTools the per-MCP tool allowlist (decision 2b). Both are carried
+	// onto the token the same way DisabledTools and Context are, so that every
+	// authentication path yields the same scope.
+	Access       map[string]string
+	AllowedTools map[string][]string
+}
+
+// Access modes (ADR-011 decision 2). Relay applies this rule at its own
+// chokepoint and records what it decided; the INPUT — whether a given tool is
+// read-only — is the MCP's own readOnlyHint and is not something relay can
+// check. Write implies read; there is deliberately no third mode. Nobody has named one, and an enum with a speculative member is
+// a migration cost paid in advance.
+const (
+	AccessRead  = "read"
+	AccessWrite = "write"
+)
+
+// ToolAllowed reports whether this token's allowlist admits a tool of an MCP
+// (ADR-011 decision 2b). The MCP-level grant is checked separately; this is
+// the second of the four allowlists, and none of the four may widen another.
+//
+// The default is asymmetric for the same reason AccessMode's is, and in the
+// same direction:
+//
+//   - An ACCESS PROFILE with no list for an MCP holds NO tools of it. That is
+//     ADR-009 decision 4's reasoning one level down: a grant to another machine
+//     must be an enumeration someone typed, and a tool registered later must
+//     not silently join it. macMCP grew from 46 tools to 47 during ADR-010's
+//     own testing.
+//   - A LOCAL project with no list holds all of them, exactly as before, with
+//     disabled_tools still subtracting.
+//
+// An empty list is the same as an absent one, deliberately: for a profile both
+// mean nothing, and there is no reading under which an operator who saved an
+// empty allowlist meant "everything".
+func (t *StoredToken) ToolAllowed(mcpID, toolName string) bool {
+	if t == nil {
+		return false
+	}
+	patterns := t.AllowedTools[mcpID]
+	if len(patterns) == 0 {
+		return t.ProjectKind != ProjectKindRemote
+	}
+	return toolAllowedByPatterns(patterns, toolName)
+}
+
+// AccessMode resolves the operation mode in force for one MCP.
+//
+// THE DEFAULT IS ASYMMETRIC ON PURPOSE, and it is the point of the decision
+// rather than an oversight to be tidied away later:
+//
+//   - An ACCESS PROFILE (a remote-kind record) with no entry defaults to
+//     "read". A grant to a client on another machine that nobody has said
+//     anything about must not be able to send mail, move messages or write
+//     files. This is the same asymmetry ADR-009 and ADR-010 apply everywhere
+//     else on this path — the threat model differs — and it means ADR-011
+//     landing turns the live "Hermes Mail" profile read-only until an operator
+//     says otherwise. That is the safe direction and it is loud in the UI.
+//   - A LOCAL project with no entry defaults to "write". Every local project
+//     that exists today was written before this field did, and silently
+//     revoking every mutating tool from all of them is not a security
+//     improvement, it is an outage. A local project is the operator's own
+//     machine acting as itself.
+//
+// Anything that is not exactly "write" resolves to "read": a hand-edited
+// settings.json carrying "readwrite", "rw", or a typo must narrow rather than
+// widen, and there is no third mode for it to mean.
+func (t *StoredToken) AccessMode(mcpID string) string {
+	if t == nil {
+		return AccessRead
+	}
+	if mode, ok := t.Access[mcpID]; ok {
+		if mode == AccessWrite {
+			return AccessWrite
+		}
+		return AccessRead
+	}
+	if t.ProjectKind == ProjectKindRemote {
+		return AccessRead
+	}
+	return AccessWrite
 }
 
 // ToolInfo describes a discovered tool from an external MCP server.
@@ -53,6 +141,11 @@ type ExternalMcp struct {
 	Env             map[string]string `json:"env"`
 	DiscoveredTools []ToolInfo        `json:"-"`                   // runtime-only; populated from live MCP connection
 	ContextSchema   json.RawMessage   `json:"-"`                   // runtime-only; discovered during MCP handshake
+	// ContextSchemaVersion is the declared contextSchemaVersion from the same
+	// serverInfo. Absent or < 2 means v1 (ADR-011 decision 3). Runtime-only,
+	// and it travels with ContextSchema everywhere — the version is what says
+	// how the schema may be read.
+	ContextSchemaVersion int `json:"-"`
 	Transport       string            `json:"transport,omitempty"` // "stdio" (default) or "http"
 	URL             string            `json:"url,omitempty"`       // MCP endpoint for HTTP transport
 	OAuthState      *OAuthState       `json:"oauth_state,omitempty"`
@@ -213,6 +306,40 @@ type Project struct {
 	// Per-project tool/context scoping (derived from allowed_mcp_ids at auth time).
 	DisabledTools map[string][]string        `json:"disabled_tools,omitempty"`
 	Context       map[string]json.RawMessage `json:"context,omitempty"`
+
+	// AllowedTools is the per-MCP tool allowlist: MCP id -> patterns
+	// (ADR-011 decision 2b). The MCP is the wrong unit of grant — macMCP is
+	// one MCP and thirteen domains — and finding 9 measured what that costs:
+	// a profile called "Hermes Mail" was authorized for capture_screenshot,
+	// capture_audio, shortcuts_run, web_fetch, contacts_* and messages_send,
+	// every one of them through a grant naming one mailbox.
+	//
+	// The access mode does not close that, because contacts_*, calendars_*,
+	// messages_get_chat and web_fetch are all legitimately readOnlyHint: true
+	// and survive a read grant. An allowlist is the only thing that does.
+	//
+	// Patterns are matched by matchToolPattern, the same anchored matcher a
+	// context field's applies_to uses. Absent or empty means NO TOOLS for a
+	// remote-kind record and ALL TOOLS for a local project — the same
+	// asymmetry, and the same reason, as Access.
+	AllowedTools map[string][]string `json:"allowed_tools,omitempty"`
+
+	// Access is the per-MCP operation mode: MCP id -> AccessRead | AccessWrite
+	// (ADR-011 decision 2). It is the layer of authority relay can decide by
+	// itself, at its own chokepoint, from a declaration the MCP already
+	// publishes — unlike Context, which relay injects and cannot verify.
+	//
+	// A missing entry does NOT mean "unset, so allow": see StoredToken.AccessMode
+	// for the asymmetric default and why it is asymmetric. omitempty so every
+	// project already on disk round-trips byte-identical.
+	//
+	// This is what makes ADR-011 finding 9 safe. disabled_tools is a denylist,
+	// so it fails open on upgrade: granting an MCP grants every tool it has
+	// minus whatever was enumerated AT GRANT TIME, and a tool added tomorrow
+	// silently joins every existing grant. A mode derived from the MCP's own
+	// readOnlyHint works on tools that did not exist when the profile was
+	// written.
+	Access map[string]string `json:"access,omitempty"`
 
 	// Per-project Claude permission policy.
 	PermissionPolicy *PermissionPolicy `json:"permission_policy,omitempty"`

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -362,6 +362,39 @@ textarea:focus {
 .proj-template-card { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 8px; }
 .proj-template-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
 .proj-form-actions { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--border); display: flex; gap: 8px; }
+/* Effective authority: what a record can actually DO, per MCP. On the list row
+   and on an enrolment card, because "MCPs: 1" beside a client that can read
+   every mailbox on the machine is the failure ADR-011 exists to fix. */
+.proj-authority { margin-top: 6px; display: flex; flex-direction: column; gap: 3px; }
+.proj-auth-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; font-size: 11px; }
+.proj-auth-mcp { font-family: var(--mono); color: var(--text); }
+.proj-auth-mode { display: inline-block; padding: 0 6px; border-radius: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; font-size: 10px; }
+.proj-auth-mode.read { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
+.proj-auth-mode.write { background: color-mix(in srgb, var(--warn) 22%, transparent); color: var(--warn); }
+.proj-auth-tools { color: var(--text-2); font-family: var(--mono); }
+.proj-auth-scope { color: var(--text-2); }
+.proj-auth-scope.none { color: var(--text-3); font-style: italic; }
+/* A grant that cannot be satisfied is not a detail. It reads as a warning here
+   and again in the banner, because the client-facing half of this is a silent
+   `denied` nobody watching the UI would ever see. */
+.proj-auth-missing { color: var(--warn); font-weight: 600; }
+.proj-auth-none { color: var(--text-3); font-style: italic; font-size: 11px; }
+.proj-scope-gap { border: 1px solid var(--warn); border-radius: var(--radius-sm); background: color-mix(in srgb, var(--warn) 10%, transparent); padding: 10px 12px; margin-bottom: 12px; font-size: 12px; color: var(--text); }
+.proj-scope-gap ul { margin: 6px 0 0 18px; }
+.proj-scope-gap code { font-family: var(--mono); }
+
+/* The per-MCP permission panel: mode, tools, resource scope. */
+.proj-perm-panel { padding: 8px 0 10px 16px; border-left: 2px solid var(--accent); margin: 4px 0 10px 8px; display: flex; flex-direction: column; gap: 10px; }
+.proj-perm-block { }
+.proj-perm-label { font-size: 11px; font-weight: 600; color: var(--text-2); text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 4px; }
+.proj-scope-field { margin-top: 8px; }
+.proj-scope-field > label { display: block; font-size: 12px; color: var(--text); font-family: var(--mono); margin-bottom: 1px; }
+.proj-scope-type { font-family: var(--sans, inherit); font-size: 10px; color: var(--text-3); text-transform: none; letter-spacing: 0; }
+.proj-scope-desc { font-size: 11px; color: var(--text-3); margin-bottom: 3px; }
+.proj-scope-missing { font-size: 11px; color: var(--warn); margin-top: 2px; }
+.proj-scope-field input[readonly] { color: var(--text-2); font-family: var(--mono); }
+.enrol-profile { margin-top: 6px; }
+
 .proj-error { color: var(--danger); font-size: 12px; margin-top: 8px; }
 .proj-ok { color: var(--ok); font-size: 12px; margin-top: 8px; }
 
@@ -446,6 +479,7 @@ window.__RELAY_INIT__ = {
   runningIds: __RUNNING_IDS_JSON__,
   projects: __PROJECTS_JSON__,
   mcpToolCache: __MCP_TOOL_CACHE_JSON__,
+  mcpScopeFields: __MCP_SCOPE_FIELDS_JSON__,
   enrolments: __ENROLMENTS_JSON__,
   remote: __REMOTE_JSON__,
   enrolmentBudgetDefaults: __ENROLMENT_BUDGET_DEFAULTS_JSON__
@@ -659,6 +693,7 @@ window.__RELAY_INIT__ = {
   var RUNNING_IDS_INIT = window.__RELAY_INIT__.runningIds;
   var PROJECTS_INIT = window.__RELAY_INIT__.projects;
   var MCP_TOOL_CACHE_INIT = window.__RELAY_INIT__.mcpToolCache;
+  var MCP_SCOPE_FIELDS_INIT = window.__RELAY_INIT__.mcpScopeFields || {};
   var ENROLMENTS_INIT = window.__RELAY_INIT__.enrolments || [];
   var REMOTE_INIT = window.__RELAY_INIT__.remote || null;
   var ENROLMENT_BUDGET_DEFAULTS_INIT = window.__RELAY_INIT__.enrolmentBudgetDefaults || {};
@@ -723,6 +758,8 @@ window.__RELAY_INIT__ = {
     projects: PROJECTS_INIT,
     mcpToolCache: MCP_TOOL_CACHE_INIT,
     // mcpId -> [{name, description, category}]
+    mcpScopeFields: MCP_SCOPE_FIELDS_INIT,
+    // mcpId -> [ScopeFieldView]; NO KEY = relay has never seen that MCP
     editingProjectId: null,
     // null = list, 'new' = create form, '<id>' = edit
     projectForm: null,
@@ -1307,6 +1344,7 @@ window.__RELAY_INIT__ = {
     }, {});
     if (data.projects) state.projects = data.projects;
     if (data.mcp_tool_cache) state.mcpToolCache = data.mcp_tool_cache;
+    if (data.mcp_scope_fields) state.mcpScopeFields = data.mcp_scope_fields;
     if (data.enrolments) state.enrolments = data.enrolments;
     if (data.remote) {
       state.remote = data.remote;
@@ -1326,22 +1364,131 @@ window.__RELAY_INIT__ = {
     if (state.page === "projects") render("push");
   };
   var PROJ_MCP_WILDCARD = "*";
+  function projNoun(p) {
+    return isRemoteProject(p) ? "access profile" : "project";
+  }
+  function mcpScopeFieldsFor(mcpID) {
+    const m = state.mcpScopeFields || {};
+    return Object.prototype.hasOwnProperty.call(m, mcpID) ? m[mcpID] || [] : null;
+  }
+  function projGrantedMcpIds(p) {
+    const ids = p && p.allowed_mcp_ids || [];
+    if (ids.length === 1 && ids[0] === PROJ_MCP_WILDCARD) {
+      return (state.externalMcps || []).map((m) => m.id);
+    }
+    return ids.slice();
+  }
+  function projAccessMode(p, mcpID) {
+    const explicit = p && p.access ? p.access[mcpID] : void 0;
+    if (explicit !== void 0 && explicit !== null && explicit !== "") {
+      return explicit === "write" ? "write" : "read";
+    }
+    return isRemoteProject(p) ? "read" : "write";
+  }
+  function scopeValueIsSet(v) {
+    if (v === void 0 || v === null) return false;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === "string") return v.trim() !== "";
+    if (typeof v === "object") return Object.keys(v).length > 0;
+    return true;
+  }
+  function projScopeValue(p, mcpID, fieldName) {
+    const perMcp = p && p.context ? p.context[mcpID] : null;
+    return perMcp ? perMcp[fieldName] : void 0;
+  }
+  function scopeValueText(v) {
+    if (Array.isArray(v)) return v.join(", ");
+    if (typeof v === "string") return v;
+    if (v === void 0 || v === null) return "";
+    return JSON.stringify(v);
+  }
+  function projMissingScopeFields(p, mcpID) {
+    const fields = mcpScopeFieldsFor(mcpID);
+    if (!fields) return [];
+    return fields.filter((f) => f.source !== "project_path").filter((f) => !scopeValueIsSet(projScopeValue(p, mcpID, f.name))).map((f) => f.name);
+  }
+  function projScopeGaps(p) {
+    const out = [];
+    for (const mcpID of projGrantedMcpIds(p)) {
+      const missing = projMissingScopeFields(p, mcpID);
+      if (missing.length) out.push({ mcp: mcpID, fields: missing });
+    }
+    return out;
+  }
+  function projAllowedToolPatterns(p, mcpID) {
+    return (p && p.allowed_tools ? p.allowed_tools[mcpID] : null) || [];
+  }
+  function projToolAuthorityText(p, mcpID) {
+    const patterns = projAllowedToolPatterns(p, mcpID);
+    if (isRemoteProject(p)) {
+      return patterns.length ? patterns.join(", ") : "no tools";
+    }
+    if (patterns.length) return patterns.join(", ");
+    const disabled = ((p.disabled_tools || {})[mcpID] || []).length;
+    return disabled ? "all tools except " + disabled : "all tools";
+  }
+  function projAuthorityRows(p) {
+    return projGrantedMcpIds(p).map(function(mcpID) {
+      const fields = mcpScopeFieldsFor(mcpID);
+      const scope = [];
+      const derived = [];
+      for (const f of fields || []) {
+        const v = projScopeValue(p, mcpID, f.name);
+        if (f.source === "project_path") {
+          if (scopeValueIsSet(v)) derived.push(f.name + ": " + scopeValueText(v));
+          continue;
+        }
+        if (scopeValueIsSet(v)) scope.push(f.name + ": " + scopeValueText(v));
+      }
+      return {
+        mcp: mcpID,
+        mode: projAccessMode(p, mcpID),
+        tools: projToolAuthorityText(p, mcpID),
+        scope,
+        derived,
+        missing: projMissingScopeFields(p, mcpID),
+        schemaUnknown: fields === null
+      };
+    });
+  }
+  function renderAuthorityRows(p) {
+    const rows = projAuthorityRows(p);
+    if (!rows.length) {
+      return '<div class="proj-auth-row"><span class="proj-auth-none">no MCPs granted \u2014 this ' + esc(projNoun(p)) + " reaches nothing</span></div>";
+    }
+    let html = "";
+    for (const r of rows) {
+      html += '<div class="proj-auth-row">';
+      html += '<span class="proj-auth-mcp">' + esc(r.mcp) + "</span>";
+      html += '<span class="proj-auth-mode ' + esc(r.mode) + '">' + esc(r.mode) + "</span>";
+      html += '<span class="proj-auth-tools">' + esc(r.tools) + "</span>";
+      if (r.scope.length) html += '<span class="proj-auth-scope">' + esc(r.scope.join(" \xB7 ")) + "</span>";
+      if (r.missing.length) {
+        html += '<span class="proj-auth-missing">needs a scope value for ' + esc(r.missing.join(", ")) + "</span>";
+      } else if (!r.scope.length && !r.schemaUnknown) {
+        html += '<span class="proj-auth-scope none">no resource scope declared by this MCP</span>';
+      }
+      if (r.schemaUnknown) html += '<span class="proj-auth-scope none">not connected \u2014 scope unknown</span>';
+      html += "</div>";
+    }
+    return html;
+  }
   function renderProjects() {
     if (state.editingProjectId) return renderProjectForm();
     let html = '<div class="page-header">';
-    html += "<h2>Projects</h2>";
-    html += '<button class="btn btn-primary" onclick="newProject()">+ New Project</button>';
+    html += "<h2>Projects &amp; Access Profiles</h2>";
+    html += '<button class="btn btn-primary" onclick="newProject()">+ New</button>';
     html += "</div>";
-    html += '<p class="page-intro">Projects are the security boundary: each gets a scoped bearer token, an allowed-MCP list, per-tool selection, and optional auto-generated SKILL.md.</p>';
+    html += '<p class="page-intro">Both kinds are the security boundary and both get a scoped bearer token. A <strong>project</strong> is bound to a host directory and has models, shell templates and skills. An <strong>access profile</strong> is a capability grant to a client on another machine: no directory, no skills, no shell, no models \u2014 just which MCPs, which tools, which operations and which resources.</p>';
     if (state.projectError) {
       html += '<div class="proj-error">' + esc(state.projectError) + "</div>";
     }
+    html += renderScopeGapBanner();
     if (state.projects.length === 0) {
-      html += '<div class="empty-state">No projects yet. Click <strong>+ New Project</strong> to create one.</div>';
+      html += '<div class="empty-state">Nothing here yet. Click <strong>+ New</strong> to create a project or an access profile.</div>';
     } else {
       for (const p of state.projects) {
         const remote = isRemoteProject(p);
-        const allowedCount = p.allowed_mcp_ids && p.allowed_mcp_ids.length > 0 ? p.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD ? "all" : String(p.allowed_mcp_ids.length) : remote ? "no tools granted" : "0";
         const modelsCount = p.allowed_models && p.allowed_models.length > 0 ? p.allowed_models[0] === PROJ_MCP_WILDCARD ? "all" : String(p.allowed_models.length) : "0";
         const skillState = p.generate_skill ? "auto" : "off";
         const policy = p.permission_policy && p.permission_policy.default_mode || "\u2014";
@@ -1350,19 +1497,23 @@ window.__RELAY_INIT__ = {
         html += '<div class="proj-card-header">';
         html += '<div style="display:flex;align-items:center;gap:6px">';
         html += '<span class="proj-card-name">' + esc(p.name) + "</span>";
-        if (remote) html += '<span class="proj-badge-remote">Remote</span>';
+        if (remote) html += '<span class="proj-badge-remote">Access profile</span>';
         html += "</div>";
         html += '<div style="display:flex;gap:4px">';
         html += `<button class="btn btn-sm" onclick="editProject('` + esc(p.id) + `')">Edit</button>`;
-        html += `<button class="btn btn-sm" onclick="regenProjectSkill('` + esc(p.id) + `')" title="Regenerate SKILL.md now">Regen Skill</button>`;
+        if (!remote) {
+          html += `<button class="btn btn-sm" onclick="regenProjectSkill('` + esc(p.id) + `')" title="Regenerate SKILL.md now">Regen Skill</button>`;
+        }
         html += `<button class="btn btn-sm btn-danger" onclick="removeProject('` + esc(p.id) + "', '" + esc(p.name) + `')">Delete</button>`;
         html += "</div></div>";
-        html += '<div class="proj-card-path">' + esc(p.path || "(no path)") + "</div>";
+        html += '<div class="proj-card-path">' + esc(remote ? "no host directory \u2014 an access profile grants capability, not a filesystem" : p.path || "(no path)") + "</div>";
+        html += '<div class="proj-authority">' + renderAuthorityRows(p) + "</div>";
         html += '<div class="proj-card-meta">';
-        html += "<span>MCPs: <strong>" + esc(allowedCount) + "</strong></span>";
-        html += "<span>Models: <strong>" + esc(modelsCount) + "</strong></span>";
+        if (!remote) {
+          html += "<span>Models: <strong>" + esc(modelsCount) + "</strong></span>";
+          html += "<span>Skill: <strong>" + esc(skillState) + "</strong></span>";
+        }
         html += "<span>Policy: <strong>" + esc(policy) + "</strong></span>";
-        html += "<span>Skill: <strong>" + esc(skillState) + "</strong></span>";
         if (p.allow_cwd_auth) html += "<span>Dir auth: <strong>on</strong></span>";
         html += "</div>";
         if (regen) {
@@ -1372,6 +1523,24 @@ window.__RELAY_INIT__ = {
         html += "</div>";
       }
     }
+    return html;
+  }
+  function renderScopeGapBanner() {
+    const rows = [];
+    for (const p of state.projects || []) {
+      for (const gap of projScopeGaps(p)) {
+        rows.push({ name: p.name, noun: projNoun(p), mcp: gap.mcp, fields: gap.fields });
+      }
+    }
+    if (!rows.length) return "";
+    let html = '<div class="proj-scope-gap">';
+    html += "<strong>" + rows.length + (rows.length === 1 ? " grant needs" : " grants need") + " a scope value.</strong> ";
+    html += "Until one is set, every tool the field governs is <em>denied</em> at call time \u2014 the client gets nothing and nothing else says why.";
+    html += "<ul>";
+    for (const r of rows) {
+      html += "<li>" + esc(r.name) + " (" + esc(r.noun) + ") \u2192 <code>" + esc(r.mcp) + "</code>: " + esc(r.fields.join(", ")) + "</li>";
+    }
+    html += "</ul></div>";
     return html;
   }
   function blankProjectForm() {
@@ -1389,8 +1558,25 @@ window.__RELAY_INIT__ = {
       generate_skill: false,
       allow_cwd_auth: false,
       // token-less auth by working directory
-      disabled_tools: {}
+      disabled_tools: {},
       // mcpID -> [toolName, ...]
+      // The ADR-011 permission set. access and allowed_tools are what relay
+      // enforces at its own chokepoint; context is what it injects and
+      // cannot verify. All three are absent by default, which for an access
+      // profile means read, no tools, and no scope — every layer failing
+      // closed until someone widens it deliberately.
+      access: {},
+      // mcpID -> 'read' | 'write'
+      allowed_tools: {},
+      // mcpID -> [pattern, ...]
+      context: {},
+      // mcpID -> { field: value }
+      // Raw text as typed, so a half-finished value survives a re-render and
+      // is parsed exactly once, at harvest. Underscore-prefixed: never sent.
+      _scopeText: {},
+      // mcpID -> { field: text }
+      _toolsText: {}
+      // mcpID -> text
     };
   }
   function projectFormFromExisting(p) {
@@ -1411,6 +1597,11 @@ window.__RELAY_INIT__ = {
       generate_skill: !!p.generate_skill,
       allow_cwd_auth: !!p.allow_cwd_auth,
       disabled_tools: JSON.parse(JSON.stringify(p.disabled_tools || {})),
+      access: JSON.parse(JSON.stringify(p.access || {})),
+      allowed_tools: JSON.parse(JSON.stringify(p.allowed_tools || {})),
+      context: JSON.parse(JSON.stringify(p.context || {})),
+      _scopeText: {},
+      _toolsText: {},
       token: p.token || ""
     };
   }
@@ -1438,7 +1629,11 @@ window.__RELAY_INIT__ = {
     ipc(JSON.stringify({ type: "regen_project_skill", id }));
   }
   function removeProject(id, name) {
-    if (!confirm('Delete project "' + name + '"?\nThis revokes its token immediately and removes its SKILL.md.')) return;
+    const p = (state.projects || []).find((x) => x.id === id);
+    const remote = isRemoteProject(p);
+    const what = remote ? "access profile" : "project";
+    const consequence = remote ? "\nThis revokes its token immediately. Any enrolment granting it is left holding an id that resolves to nothing." : "\nThis revokes its token immediately and removes its SKILL.md.";
+    if (!confirm("Delete " + what + ' "' + name + '"?' + consequence)) return;
     ipc(JSON.stringify({ type: "remove_project", id }));
   }
   function rotateProjectToken(id, name) {
@@ -1528,6 +1723,152 @@ window.__RELAY_INIT__ = {
     }
     f.disabled_tools[mcpID] = Array.from(currentlyDisabled);
   }
+  function projFormAccessMode(f, mcpID) {
+    const explicit = (f.access || {})[mcpID];
+    if (explicit === "read" || explicit === "write") return explicit;
+    return isRemoteForm(f) ? "read" : "write";
+  }
+  function setProjAccess(mcpID, mode) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (!f.access) f.access = {};
+    f.access[mcpID] = mode;
+    render();
+  }
+  function setProjMcpGranted(mcpID, granted) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (granted) {
+      if (f.allowed_mcp_ids.indexOf(mcpID) < 0) f.allowed_mcp_ids.push(mcpID);
+    } else {
+      f.allowed_mcp_ids = f.allowed_mcp_ids.filter((id) => id !== mcpID);
+      delete (f.access || {})[mcpID];
+      delete (f.allowed_tools || {})[mcpID];
+      delete (f.context || {})[mcpID];
+      delete (f._scopeText || {})[mcpID];
+      delete (f._toolsText || {})[mcpID];
+    }
+    render();
+  }
+  function scopeTextFromValue(field, v) {
+    if (v === void 0 || v === null) return "";
+    if (Array.isArray(v)) return v.join("\n");
+    if (typeof v === "string") return v;
+    return JSON.stringify(v);
+  }
+  function scopeValueFromText(field, text) {
+    const raw = String(text === void 0 || text === null ? "" : text);
+    if (field.type === "array") {
+      return raw.split("\n").map((s) => s.trim()).filter(Boolean);
+    }
+    if (field.type === "string") return raw.trim();
+    const trimmed = raw.trim();
+    if (!trimmed) return "";
+    try {
+      return JSON.parse(trimmed);
+    } catch (e) {
+      return trimmed;
+    }
+  }
+  function projScopeText(f, mcpID, field) {
+    const typed = (f._scopeText || {})[mcpID];
+    if (typed && Object.prototype.hasOwnProperty.call(typed, field.name)) return typed[field.name];
+    return scopeTextFromValue(field, ((f.context || {})[mcpID] || {})[field.name]);
+  }
+  function setProjScopeText(mcpID, fieldName, text) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (!f._scopeText) f._scopeText = {};
+    if (!f._scopeText[mcpID]) f._scopeText[mcpID] = {};
+    f._scopeText[mcpID][fieldName] = text;
+  }
+  function projAllowedToolsText(f, mcpID) {
+    const typed = (f._toolsText || {})[mcpID];
+    if (typed !== void 0) return typed;
+    return ((f.allowed_tools || {})[mcpID] || []).join("\n");
+  }
+  function setProjAllowedToolsText(mcpID, text) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (!f._toolsText) f._toolsText = {};
+    f._toolsText[mcpID] = text;
+  }
+  function renderProjMcpPermissions(mcpID, f) {
+    const remote = isRemoteForm(f);
+    const mode = projFormAccessMode(f, mcpID);
+    let html = '<div class="proj-perm-panel">';
+    html += '<div class="proj-perm-block">';
+    html += '<div class="proj-perm-label">Operations</div>';
+    html += '<div class="perm-btns">';
+    html += '<button class="perm-btn ' + (mode === "read" ? "active" : "") + `" onclick="setProjAccess('` + esc(mcpID) + `', 'read')">Read</button>`;
+    html += '<button class="perm-btn ' + (mode === "write" ? "active" : "") + `" onclick="setProjAccess('` + esc(mcpID) + `', 'write')">Write</button>`;
+    html += "</div>";
+    html += '<p class="proj-section-help">' + (mode === "read" ? "Only tools this MCP annotates <code>readOnlyHint: true</code>. A tool that is unannotated, malformed, or added later is refused \u2014 that is what keeps a new mutating tool out of an old grant." : "Every tool this grant admits, mutating included. Write implies read.") + " Unset defaults to <strong>" + (remote ? "read" : "write") + "</strong> for " + (remote ? "an access profile" : "a local project") + ".</p>";
+    html += "</div>";
+    if (remote) {
+      const patterns = projAllowedToolsText(f, mcpID);
+      html += '<div class="proj-perm-block">';
+      html += '<div class="proj-perm-label">Tools</div>';
+      html += '<p class="proj-section-help">One name or pattern per line, e.g. <code>mail_*</code>. Patterns are anchored \u2014 <code>mail_*</code> admits <code>mail_send</code> and not <code>xmail_send</code>. A bare <code>*</code> is refused: registering a new tool would silently widen the grant. <strong>Empty means no tools at all.</strong></p>';
+      html += `<textarea rows="3" placeholder="mail_*" oninput="setProjAllowedToolsText('` + esc(mcpID) + `', this.value)">` + esc(patterns) + "</textarea>";
+      html += "</div>";
+    }
+    const fields = mcpScopeFieldsFor(mcpID);
+    html += '<div class="proj-perm-block">';
+    html += '<div class="proj-perm-label">Resource scope</div>';
+    if (fields === null) {
+      html += '<p class="proj-section-help">Relay has not connected to this MCP, so it cannot say what may be narrowed. Anything this MCP scopes will be enforced at call time regardless \u2014 a grant with no value for a field it declares is <em>denied</em>, not unrestricted.</p>';
+    } else if (!fields.length) {
+      html += '<p class="proj-section-help">This MCP declares nothing narrowable. The grant is bounded by the tools and the mode above and by nothing else.</p>';
+    } else {
+      html += '<p class="proj-section-help">Each field below is declared by the MCP as one that <strong>restricts</strong> access. An empty value is not "no restriction" \u2014 it refuses every tool the field governs. There is no wildcard: to allow everything, list everything.</p>';
+      for (const field of fields) {
+        html += renderScopeFieldInput(mcpID, field, f);
+      }
+    }
+    html += "</div>";
+    html += "</div>";
+    return html;
+  }
+  function renderScopeFieldInput(mcpID, field, f) {
+    const remote = isRemoteForm(f);
+    const typeLabel = field.type === "array" ? "list of " + (field.item_type || "value") + "s, one per line" : field.type || "value";
+    let html = '<div class="proj-scope-field">';
+    html += "<label>" + esc(field.name) + ' <span class="proj-scope-type">' + esc(typeLabel) + "</span></label>";
+    if (field.description) html += '<div class="proj-scope-desc">' + esc(field.description) + "</div>";
+    if (field.source === "project_path") {
+      const derived = ((f.context || {})[mcpID] || {})[field.name];
+      let shown, note;
+      if (remote) {
+        shown = "";
+        note = "An access profile has no host directory, so relay derives nothing here and every tool this field governs" + (field.applies_to && field.applies_to.length ? " (" + field.applies_to.join(", ") + ")" : "") + " is refused. That is the intended outcome, not a gap to fill in.";
+      } else if (scopeValueIsSet(derived)) {
+        shown = scopeTextFromValue(field, derived);
+        note = "Derived by relay from this project's path. Change the path to change it.";
+      } else {
+        shown = f.path || "";
+        note = "Derived by relay from this project's path on save.";
+      }
+      html += '<input type="text" readonly value="' + esc(shown) + '" placeholder="(nothing derived)" />';
+      html += '<div class="proj-scope-desc">' + esc(note) + "</div>";
+      html += "</div>";
+      return html;
+    }
+    const text = projScopeText(f, mcpID, field);
+    if (field.type === "array") {
+      html += `<textarea rows="3" oninput="setProjScopeText('` + esc(mcpID) + "', '" + esc(field.name) + `', this.value)">` + esc(text) + "</textarea>";
+    } else {
+      html += '<input type="text" value="' + esc(text) + `" oninput="setProjScopeText('` + esc(mcpID) + "', '" + esc(field.name) + `', this.value)" />`;
+    }
+    if (!String(text).trim()) {
+      html += '<div class="proj-scope-missing">No value: every tool this field governs is denied at call time.</div>';
+    }
+    if (field.depends_on && field.depends_on.length) {
+      html += '<div class="proj-scope-desc">Values here are read within ' + esc(field.depends_on.join(", ")) + ".</div>";
+    }
+    html += "</div>";
+    return html;
+  }
   function setProjModelsWildcard(checked) {
     const f = state.projectForm;
     if (!f) return;
@@ -1546,45 +1887,59 @@ window.__RELAY_INIT__ = {
     if (!f) return '<div class="empty-state">No form state.</div>';
     const isNew = !f.id;
     const isRemote = isRemoteForm(f);
-    const title = isNew ? "New Project" : "Edit Project";
+    const noun = isRemote ? "Access Profile" : "Project";
+    const title = (isNew ? "New " : "Edit ") + noun;
     let html = "<h2>" + esc(title) + "</h2>";
     if (state.projectFormError) {
       html += '<div class="proj-error">' + esc(state.projectFormError) + "</div>";
+    }
+    const formGaps = projScopeGaps({
+      kind: f.kind,
+      allowed_mcp_ids: f.allowed_mcp_ids,
+      context: harvestProjectPermissions(f).context
+    });
+    if (formGaps.length) {
+      html += '<div class="proj-scope-gap">';
+      html += "<strong>A scope value is missing.</strong> Every tool the field governs is denied at call time until it is set \u2014 the client gets nothing, and nothing else says why.<ul>";
+      for (const g of formGaps) {
+        html += "<li><code>" + esc(g.mcp) + "</code>: " + esc(g.fields.join(", ")) + "</li>";
+      }
+      html += "</ul></div>";
     }
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Kind</div>';
     if (isNew) {
       html += '<div class="perm-btns">';
-      html += '<button class="perm-btn ' + (!isRemote ? "active" : "") + `" onclick="setProjKind('local')">Local</button>`;
-      html += '<button class="perm-btn ' + (isRemote ? "active" : "") + `" onclick="setProjKind('remote')">Remote</button>`;
+      html += '<button class="perm-btn ' + (!isRemote ? "active" : "") + `" onclick="setProjKind('local')">Local project</button>`;
+      html += '<button class="perm-btn ' + (isRemote ? "active" : "") + `" onclick="setProjKind('remote')">Access profile</button>`;
       html += "</div>";
     } else {
-      html += '<div class="proj-kind-label">' + (isRemote ? "Remote \u2014 capability grant to another machine" : "Local \u2014 bound to a host directory") + "</div>";
+      html += '<div class="proj-kind-label">' + (isRemote ? "Access profile \u2014 a capability grant to a client on another machine" : "Local project \u2014 bound to a host directory") + "</div>";
       html += `<p class="proj-section-help">Kind can't be changed here after creation.</p>`;
     }
     html += "</div>";
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Identity</div>';
-    html += "<label>Project name</label>";
-    html += '<input type="text" id="projName" value="' + esc(f.name) + '" placeholder="e.g. Acme Website" />';
+    html += "<label>" + (isRemote ? "Profile name" : "Project name") + "</label>";
+    html += '<input type="text" id="projName" value="' + esc(f.name) + '" placeholder="' + (isRemote ? "e.g. Hermes \u2014 Bob INBOX (read-only)" : "e.g. Acme Website") + '" />';
     if (!isRemote) {
       html += "<label>Project path</label>";
       html += '<input type="text" id="projPath" value="' + esc(f.path) + '" placeholder="/Users/you/projects/acme" />';
       html += '<p class="proj-section-help">Absolute path. Filesystem MCPs are auto-scoped to this directory.</p>';
     } else {
-      html += `<p class="proj-section-help">Remote projects are capability grants to an agent on another machine \u2014 they have no host directory, so path, directory auth, and skill generation don't apply.</p>`;
+      html += '<p class="proj-section-help">An access profile is a capability grant to an agent on another machine. It has no host directory, so path, directory auth, skills, shell templates and models do not apply \u2014 what it carries is which MCPs, which tools, which operations and which resources.</p>';
     }
     html += "</div>";
     const wild = !isRemote && isProjMcpWildcard(f);
     html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Allowed MCPs &amp; Tools</div>';
+    html += '<div class="proj-section-title">MCPs, Tools, Operations &amp; Resources</div>';
     if (!isRemote) {
       html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
       html += "<span>Allow all registered MCPs (wildcard <code>*</code>)</span>";
       html += '<label class="switch"><input type="checkbox" ' + (wild ? "checked" : "") + ' onchange="setProjMcpWildcard(this.checked)" /><span class="slider"></span></label>';
       html += "</div>";
     } else {
-      html += `<p class="proj-section-help">Remote projects can't use the wildcard \u2014 list MCPs explicitly. Zero granted is a valid starting point; widen it deliberately later.</p>`;
+      html += `<p class="proj-section-help">An access profile can't use the wildcard \u2014 list MCPs explicitly, because registering a new MCP on the host would otherwise silently widen what this client reaches. Zero granted is a valid starting point; widen it deliberately later.</p>`;
     }
     if (!wild) {
       const registered = state.externalMcps.slice();
@@ -1595,16 +1950,25 @@ window.__RELAY_INIT__ = {
       }
       for (const mcp of registered) {
         const st = projMcpState(f, mcp.id);
+        const granted = f.allowed_mcp_ids.indexOf(mcp.id) >= 0;
         html += '<div class="proj-mcp-row">';
         html += '<span class="proj-mcp-name">' + esc(mcp.display_name || mcp.id) + ' <span style="color:var(--text-3);font-size:11px">(' + esc(mcp.id) + ")</span></span>";
         html += '<div class="perm-btns">';
-        html += '<button class="perm-btn ' + (st === "all" ? "active" : "") + `" onclick="setProjMcpState('` + esc(mcp.id) + `', 'all')">All tools</button>`;
-        html += '<button class="perm-btn ' + (st === "selected" ? "active" : "") + `" onclick="setProjMcpState('` + esc(mcp.id) + `', 'selected')">Selected</button>`;
-        html += '<button class="perm-btn ' + (st === "none" ? "active" : "") + `" onclick="setProjMcpState('` + esc(mcp.id) + `', 'none')">No tools</button>`;
+        if (isRemote) {
+          html += '<button class="perm-btn ' + (granted ? "active" : "") + `" onclick="setProjMcpGranted('` + esc(mcp.id) + `', true)">Granted</button>`;
+          html += '<button class="perm-btn ' + (!granted ? "active" : "") + `" onclick="setProjMcpGranted('` + esc(mcp.id) + `', false)">Not granted</button>`;
+        } else {
+          html += '<button class="perm-btn ' + (st === "all" ? "active" : "") + `" onclick="setProjMcpState('` + esc(mcp.id) + `', 'all')">All tools</button>`;
+          html += '<button class="perm-btn ' + (st === "selected" ? "active" : "") + `" onclick="setProjMcpState('` + esc(mcp.id) + `', 'selected')">Selected</button>`;
+          html += '<button class="perm-btn ' + (st === "none" ? "active" : "") + `" onclick="setProjMcpState('` + esc(mcp.id) + `', 'none')">No tools</button>`;
+        }
         html += "</div>";
         html += "</div>";
-        if (st === "selected") {
+        if (!isRemote && st === "selected") {
           html += renderProjToolPicker(mcp.id, f);
+        }
+        if (granted) {
+          html += renderProjMcpPermissions(mcp.id, f);
         }
       }
       for (const id of dangling) {
@@ -1613,12 +1977,20 @@ window.__RELAY_INIT__ = {
         html += `<button class="perm-btn" onclick="setProjMcpState('` + esc(id) + `', 'none')">Remove</button>`;
         html += "</div>";
       }
+    } else {
+      for (const mcp of state.externalMcps) {
+        html += '<div class="proj-mcp-row">';
+        html += '<span class="proj-mcp-name">' + esc(mcp.display_name || mcp.id) + ' <span style="color:var(--text-3);font-size:11px">(' + esc(mcp.id) + ")</span></span>";
+        html += '<span class="proj-mcp-name" style="color:var(--text-3)">granted by the wildcard</span>';
+        html += "</div>";
+        html += renderProjMcpPermissions(mcp.id, f);
+      }
     }
     html += "</div>";
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Allowed Models</div>';
     if (isRemote) {
-      html += '<p class="proj-section-help">Not applicable to remote projects \u2014 the model allowlist stays empty.</p>';
+      html += '<p class="proj-section-help">Not applicable to an access profile \u2014 the model allowlist stays empty.</p>';
     } else {
       const modelsWild = isProjModelsWildcard(f);
       html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
@@ -1632,25 +2004,27 @@ window.__RELAY_INIT__ = {
       }
     }
     html += "</div>";
-    html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Chat Templates</div>';
-    html += `<p class="proj-section-help">Project-scoped chat presets stored with the project. Create and edit them in Eve's project dialog, which offers live model selection.</p>`;
-    if (f.chat_templates.length === 0) {
-      html += '<div class="proj-tool-empty">No templates yet.</div>';
-    }
-    for (const t of f.chat_templates) {
-      html += '<div class="proj-template-card">';
-      html += '<div class="proj-template-header">';
-      html += "<span>" + esc(t.name || "(unnamed)") + "</span>";
-      html += '<span class="desc">' + esc(t.model || "") + (t.mode === "voice" ? " \xB7 voice" : "") + "</span>";
+    if (!isRemote || f.chat_templates.length > 0) {
+      html += '<div class="proj-section">';
+      html += '<div class="proj-section-title">Chat Templates</div>';
+      html += '<p class="proj-section-help">' + (isRemote ? "An access profile has no chat sessions, so these are inert. They are shown because they are stored on the record." : "Project-scoped chat presets stored with the project. Create and edit them in Eve's project dialog, which offers live model selection.") + "</p>";
+      if (f.chat_templates.length === 0) {
+        html += '<div class="proj-tool-empty">No templates yet.</div>';
+      }
+      for (const t of f.chat_templates) {
+        html += '<div class="proj-template-card">';
+        html += '<div class="proj-template-header">';
+        html += "<span>" + esc(t.name || "(unnamed)") + "</span>";
+        html += '<span class="desc">' + esc(t.model || "") + (t.mode === "voice" ? " \xB7 voice" : "") + "</span>";
+        html += "</div>";
+        html += "</div>";
+      }
       html += "</div>";
-      html += "</div>";
     }
-    html += "</div>";
     const pol = f.permission_policy;
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Permission Policy</div>';
-    html += `<p class="proj-section-help">Claude CLI permission gates. Empty mode inherits Claude's default. Patterns follow Claude's tool grammar (e.g. <code>Bash(ls *)</code>).</p>`;
+    html += '<p class="proj-section-help">' + (isRemote ? "Claude CLI permission gates. An access profile launches no Claude session, so this is inert for one \u2014 what bounds a remote client is the mode, tools and scope above." : "Claude CLI permission gates. Empty mode inherits Claude's default. Patterns follow Claude's tool grammar (e.g. <code>Bash(ls *)</code>).") + "</p>";
     html += "<label>Default mode</label>";
     html += '<select id="projPolicyMode" onchange="state.projectForm.permission_policy.default_mode = this.value">';
     for (const m of ["", "default", "acceptEdits", "plan", "bypassPermissions"]) {
@@ -1788,11 +2162,47 @@ window.__RELAY_INIT__ = {
       allow_cwd_auth: isRemote ? false : f.allow_cwd_auth,
       disabled_tools: f.disabled_tools
     };
+    const perms = harvestProjectPermissions(f);
+    payload.access = perms.access;
+    payload.allowed_tools = perms.allowed_tools;
+    payload.context = perms.context;
     if (!isRemote) {
       const path = (document.getElementById("projPath") || {}).value || f.path;
       payload.path = path.trim();
     }
     return payload;
+  }
+  function harvestProjectPermissions(f) {
+    const remote = isRemoteForm(f);
+    const wild = f.allowed_mcp_ids.length === 1 && f.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD;
+    const granted = wild ? (state.externalMcps || []).map((m) => m.id) : f.allowed_mcp_ids.slice();
+    const access = {};
+    const allowedTools = {};
+    const context = {};
+    for (const mcpID of granted) {
+      const mode = (f.access || {})[mcpID];
+      if (mode === "read" || mode === "write") access[mcpID] = mode;
+      if (remote) {
+        const text = projAllowedToolsText(f, mcpID);
+        const patterns = String(text).split("\n").map((t) => t.trim()).filter(Boolean);
+        if (patterns.length) allowedTools[mcpID] = patterns;
+      } else if (((f.allowed_tools || {})[mcpID] || []).length) {
+        allowedTools[mcpID] = (f.allowed_tools[mcpID] || []).slice();
+      }
+      const existing = Object.assign({}, (f.context || {})[mcpID] || {});
+      const fields = mcpScopeFieldsFor(mcpID);
+      for (const field of fields || []) {
+        if (field.source === "project_path") {
+          delete existing[field.name];
+          continue;
+        }
+        const value = scopeValueFromText(field, projScopeText(f, mcpID, field));
+        if (scopeValueIsSet(value)) existing[field.name] = value;
+        else delete existing[field.name];
+      }
+      if (Object.keys(existing).length) context[mcpID] = existing;
+    }
+    return { access, allowed_tools: allowedTools, context };
   }
   function saveProjectForm() {
     const f = state.projectForm;
@@ -1878,12 +2288,12 @@ window.__RELAY_INIT__ = {
   function enrolGrantNames(e) {
     return (e && e.project_ids || []).map(function(id) {
       const p = (state.projects || []).find((x) => x.id === id);
-      return { id, name: p ? p.name : null };
+      return { id, name: p ? p.name : null, profile: p || null };
     });
   }
   function enrolGrantSummary(e) {
-    const names = enrolGrantNames(e).map((g) => g.name || g.id + " (unknown project)");
-    if (!names.length) return "no projects \u2014 this enrolment grants nothing today";
+    const names = enrolGrantNames(e).map((g) => g.name || g.id + " (unknown access profile)");
+    if (!names.length) return "no access profiles \u2014 this enrolment grants nothing today";
     return names.join(", ");
   }
   function enrolBytes(n) {
@@ -1900,7 +2310,7 @@ window.__RELAY_INIT__ = {
     if (state.enrolForm) return renderEnrolmentForm();
     let html = '<div class="page-header"><h2>Remote Clients</h2>';
     html += '<button class="btn btn-primary" onclick="newEnrolment()">+ New Enrolment</button></div>';
-    html += '<p class="page-intro">An enrolment binds one client certificate to the remote projects it may use. The certificate <em>is</em> the identity \u2014 there is no bearer token on this path, so a copy of <code>settings.json</code> grants no remote access at all. Enrolments are keyed by certificate, not by machine: several agents on one VM each hold their own, granted and revoked independently.</p>';
+    html += '<p class="page-intro">An enrolment binds one client certificate to the access profiles it may use. The certificate <em>is</em> the identity \u2014 there is no bearer token on this path, so a copy of <code>settings.json</code> grants no remote access at all. Enrolments are keyed by certificate, not by machine: several agents on one VM each hold their own, granted and revoked independently.</p>';
     if (state.enrolBundle) html += renderEnrolBundleBanner(state.enrolBundle);
     if (state.enrolRevoked) {
       html += '<div class="audit-note">Revoked <strong>' + esc(state.enrolRevoked.client_id) + "</strong>. Its calls remain in the Tool Calls log under fingerprint <code>" + esc(state.enrolRevoked.fingerprint) + "</code> \u2014 now the only thing that names them.</div>";
@@ -1916,19 +2326,20 @@ window.__RELAY_INIT__ = {
       html += '<span class="enrol-card-name">' + esc(e.client_id) + "</span>";
       html += `<button class="btn btn-sm btn-danger" onclick="revokeEnrolment('` + esc(e.client_id) + `')">Revoke</button>`;
       html += "</div>";
-      html += '<div class="enrol-grants">';
       const grants = enrolGrantNames(e);
       if (!grants.length) {
-        html += '<span class="enrol-grant none">no projects granted</span>';
+        html += '<div class="enrol-grants"><span class="enrol-grant none">no access profiles granted</span></div>';
       }
       for (const g of grants) {
-        if (g.name) {
-          html += '<span class="enrol-grant" title="' + esc(g.id) + '">' + esc(g.name) + "</span>";
-        } else {
-          html += '<span class="enrol-grant dangling" title="No project carries this id">' + esc(g.id) + " \u2014 unknown project</span>";
+        if (!g.name) {
+          html += '<div class="enrol-grants"><span class="enrol-grant dangling" title="No access profile carries this id">' + esc(g.id) + " \u2014 unknown access profile</span></div>";
+          continue;
         }
+        html += '<div class="enrol-profile">';
+        html += '<div class="enrol-grants"><span class="enrol-grant" title="' + esc(g.id) + '">' + esc(g.name) + "</span></div>";
+        html += '<div class="proj-authority">' + renderAuthorityRows(g.profile) + "</div>";
+        html += "</div>";
       }
-      html += "</div>";
       html += '<div class="enrol-meta">';
       html += "<span>Budget: <strong>" + esc(enrolBudgetText(e.budget)) + "</strong></span>";
       html += "<span>Enrolled: <strong>" + esc(e.created_at || "\u2014") + "</strong></span>";
@@ -1964,11 +2375,11 @@ window.__RELAY_INIT__ = {
     html += '<input type="text" id="enrolClientId" value="' + esc(f.client_id) + '" placeholder="hermes-mail" />';
     html += "</div>";
     html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Granted Projects</div>';
-    html += `<p class="proj-section-help">Only <strong>remote</strong> projects can be granted. A remote client granted a local project would inherit that project's host-directory scope, so the grant is refused outright \u2014 this list offers nothing that would be refused.</p>`;
+    html += '<div class="proj-section-title">Granted Access Profiles</div>';
+    html += `<p class="proj-section-help">Only <strong>access profiles</strong> can be granted. A remote client granted a local project would inherit that project's host-directory scope, so the grant is refused outright \u2014 this list offers nothing that would be refused.</p>`;
     const grantable = remoteGrantableProjects();
     if (!grantable.length) {
-      html += '<div class="proj-tool-empty">No remote projects exist yet. Create one in the <strong>Projects</strong> tab (Kind \u2192 Remote) first.</div>';
+      html += '<div class="proj-tool-empty">No access profiles exist yet. Create one in the <strong>Projects</strong> tab (Kind \u2192 Access profile) first.</div>';
     }
     for (const p of grantable) {
       const checked = f.project_ids.indexOf(p.id) >= 0;
@@ -1978,7 +2389,7 @@ window.__RELAY_INIT__ = {
       html += "</label>";
     }
     if (grantable.length && f.project_ids.length === 0) {
-      html += '<p class="proj-section-help">No grant selected: this client will be enrolled but can reach no project until one is added.</p>';
+      html += '<p class="proj-section-help">No grant selected: this client will be enrolled but can reach no access profile until one is added.</p>';
     }
     html += "</div>";
     html += '<div class="proj-section">';
@@ -3258,6 +3669,32 @@ window.__RELAY_INIT__ = {
     saveEnrolment,
     saveRemoteConfig,
     toggleEnrolGrant,
+    harvestProjectPermissions,
+    mcpScopeFieldsFor,
+    projAccessMode,
+    projAllowedToolPatterns,
+    projAllowedToolsText,
+    projAuthorityRows,
+    projFormAccessMode,
+    projGrantedMcpIds,
+    projMissingScopeFields,
+    projNoun,
+    projScopeGaps,
+    projScopeText,
+    projScopeValue,
+    projToolAuthorityText,
+    renderAuthorityRows,
+    renderProjMcpPermissions,
+    renderScopeFieldInput,
+    renderScopeGapBanner,
+    scopeTextFromValue,
+    scopeValueFromText,
+    scopeValueIsSet,
+    scopeValueText,
+    setProjAccess,
+    setProjAllowedToolsText,
+    setProjMcpGranted,
+    setProjScopeText,
     addExternalMcp,
     addExternalMcpFromJson,
     addExternalMcpHttp,

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -393,6 +393,23 @@ textarea:focus {
 .proj-scope-desc { font-size: 11px; color: var(--text-3); margin-bottom: 3px; }
 .proj-scope-missing { font-size: 11px; color: var(--warn); margin-top: 2px; }
 .proj-scope-field input[readonly] { color: var(--text-2); font-family: var(--mono); }
+
+/* The enumeration picker (ADR-011 decision 6). The summary is outside the
+   disclosure on purpose: what is stored is what confines the client, so it is
+   never behind a control someone has to open to see. */
+.proj-scope-summary { font-size: 12px; font-family: var(--mono); color: var(--text); margin: 2px 0 4px; word-break: break-word; }
+.proj-scope-summary .proj-scope-none { font-family: var(--sans, inherit); color: var(--text-3); font-style: italic; }
+.proj-scope-choices { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 6px 8px; margin-top: 6px; max-height: 260px; overflow-y: auto; }
+.proj-scope-choice { display: flex; align-items: baseline; gap: 6px; font-size: 12px; padding: 2px 0; }
+.proj-scope-choice label { font-family: var(--mono); color: var(--text); }
+.proj-scope-choice .desc { font-family: var(--sans, inherit); font-size: 11px; color: var(--text-3); }
+/* A stored value the MCP no longer offers stays visible and stays SELECTED.
+   An account renamed on the host must not quietly widen or narrow a profile by
+   vanishing from a form, so it is flagged rather than dropped. */
+.proj-scope-choice.unrecognised label { color: var(--warn); }
+.proj-scope-unrecognised { font-size: 11px; color: var(--warn); margin: 2px 0; }
+.proj-scope-failed { font-size: 11px; color: var(--danger); margin: 4px 0 2px; }
+.proj-scope-pending { font-size: 11px; color: var(--text-3); margin: 4px 0 2px; }
 .enrol-profile { margin-top: 6px; }
 
 .proj-error { color: var(--danger); font-size: 12px; margin-top: 8px; }
@@ -773,6 +790,21 @@ window.__RELAY_INIT__ = {
     // id -> { ok, message, t } (last regen result)
     projectError: null,
     rotatingProjectId: null,
+    // The enumeration picker (ADR-011 decision 6). Enumeration is a LIVE call
+    // into another process, so none of this is populated by a paint: a list is
+    // fetched when an operator opens the control and cached for the life of
+    // the form, keyed on (mcp, field, dependency values) — a mailbox list read
+    // within Bob is not an answer about Alice.
+    scopeEnum: {},
+    // key -> ContextEnumResult (see scopeEnumKey)
+    scopeEnumReq: {},
+    // "mcp\0field" -> the key of the in-flight request
+    scopeEnumOpen: {},
+    // "mcp\0field" -> bool (the operator opened it)
+    scopeEnumUnsupported: {},
+    // mcpId -> true once it answered -32601, permanently
+    _scopeBind: [],
+    // per-render bindings from a checkbox to its value
     // Remote Clients tab. Enrolments and the remote block are seeded by the
     // initial payload like projects are — the list is one row per enrolled
     // certificate, and a credential you cannot see is one you will not revoke,
@@ -1855,10 +1887,13 @@ window.__RELAY_INIT__ = {
       return html;
     }
     const text = projScopeText(f, mcpID, field);
-    if (field.type === "array") {
-      html += `<textarea rows="3" oninput="setProjScopeText('` + esc(mcpID) + "', '" + esc(field.name) + `', this.value)">` + esc(text) + "</textarea>";
+    if (field.enumerable && !state.scopeEnumUnsupported[mcpID]) {
+      html += renderScopeFieldPicker(mcpID, field, f, text);
     } else {
-      html += '<input type="text" value="' + esc(text) + `" oninput="setProjScopeText('` + esc(mcpID) + "', '" + esc(field.name) + `', this.value)" />`;
+      html += renderScopeFieldTextInput(mcpID, field, text);
+      if (field.enumerable) {
+        html += '<div class="proj-scope-desc">' + esc(mcpID) + " cannot list this field's values, so it is typed by hand. Spelling counts: a value that matches nothing refuses every tool the field governs, silently.</div>";
+      }
     }
     if (!String(text).trim()) {
       html += '<div class="proj-scope-missing">No value: every tool this field governs is denied at call time.</div>';
@@ -1868,6 +1903,183 @@ window.__RELAY_INIT__ = {
     }
     html += "</div>";
     return html;
+  }
+  function renderScopeFieldTextInput(mcpID, field, text) {
+    if (field.type === "array") {
+      return `<textarea rows="3" oninput="setProjScopeText('` + esc(mcpID) + "', '" + esc(field.name) + `', this.value)">` + esc(text) + "</textarea>";
+    }
+    return '<input type="text" value="' + esc(text) + `" oninput="setProjScopeText('` + esc(mcpID) + "', '" + esc(field.name) + `', this.value)" />`;
+  }
+  function scopeEnumValueKey(v) {
+    return typeof v === "string" ? v : JSON.stringify(v);
+  }
+  function scopeDependencyValues(f, mcpID, field) {
+    const out = {};
+    const fields = mcpScopeFieldsFor(mcpID) || [];
+    for (const dep of field.depends_on || []) {
+      const depField = fields.find((x) => x.name === dep);
+      if (!depField) continue;
+      const v = scopeValueFromText(depField, projScopeText(f, mcpID, depField));
+      if (scopeValueIsSet(v)) out[dep] = v;
+    }
+    return out;
+  }
+  function scopeEnumKey(mcpID, fieldName, deps) {
+    return mcpID + "\0" + fieldName + "\0" + JSON.stringify(deps || {});
+  }
+  function scopeOpenKey(mcpID, fieldName) {
+    return mcpID + "\0" + fieldName;
+  }
+  function scopeFieldIsOpen(mcpID, fieldName) {
+    return !!state.scopeEnumOpen[scopeOpenKey(mcpID, fieldName)];
+  }
+  function requestScopeEnum(mcpID, field, force) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (state.scopeEnumUnsupported[mcpID]) return;
+    const deps = scopeDependencyValues(f, mcpID, field);
+    const key = scopeEnumKey(mcpID, field.name, deps);
+    const openKey = scopeOpenKey(mcpID, field.name);
+    if (!force) {
+      if (Object.prototype.hasOwnProperty.call(state.scopeEnum, key)) return;
+      if (state.scopeEnumReq[openKey] === key) return;
+    }
+    delete state.scopeEnum[key];
+    state.scopeEnumReq[openKey] = key;
+    ipc(JSON.stringify({ type: "enumerate_scope_field", mcp_id: mcpID, field: field.name, values: deps }));
+  }
+  function scopeFieldByName(mcpID, fieldName) {
+    return (mcpScopeFieldsFor(mcpID) || []).find((x) => x.name === fieldName) || null;
+  }
+  function toggleScopeFieldPicker(mcpID, fieldName) {
+    const field = scopeFieldByName(mcpID, fieldName);
+    if (!field) return;
+    captureProjectFormInputs();
+    const openKey = scopeOpenKey(mcpID, fieldName);
+    state.scopeEnumOpen[openKey] = !state.scopeEnumOpen[openKey];
+    if (state.scopeEnumOpen[openKey]) requestScopeEnum(mcpID, field);
+    render();
+  }
+  function retryScopeEnum(mcpID, fieldName) {
+    const field = scopeFieldByName(mcpID, fieldName);
+    if (!field) return;
+    captureProjectFormInputs();
+    requestScopeEnum(mcpID, field, true);
+    render();
+  }
+  function refreshDependentScopeFields(mcpID, changedField) {
+    for (const field of mcpScopeFieldsFor(mcpID) || []) {
+      if (!field.enumerable) continue;
+      if (!(field.depends_on || []).includes(changedField)) continue;
+      if (!scopeFieldIsOpen(mcpID, field.name)) continue;
+      requestScopeEnum(mcpID, field);
+    }
+  }
+  function scopeSelectedValues(field, text) {
+    const v = scopeValueFromText(field, text);
+    if (Array.isArray(v)) return v;
+    return scopeValueIsSet(v) ? [v] : [];
+  }
+  function unrecognisedScopeValues(selected, offered) {
+    const known = new Set((offered || []).map((o) => scopeEnumValueKey(o.value)));
+    return selected.filter((v) => !known.has(scopeEnumValueKey(v)));
+  }
+  function renderScopeFieldPicker(mcpID, field, f, text) {
+    const selected = scopeSelectedValues(field, text);
+    const open = scopeFieldIsOpen(mcpID, field.name);
+    const deps = scopeDependencyValues(f, mcpID, field);
+    const key = scopeEnumKey(mcpID, field.name, deps);
+    const res = state.scopeEnum[key];
+    const pending = !res && state.scopeEnumReq[scopeOpenKey(mcpID, field.name)] === key;
+    const args = "'" + esc(mcpID) + "', '" + esc(field.name) + "'";
+    let html = '<div class="proj-scope-summary">' + (selected.length ? esc(selected.map(scopeEnumValueKey).join(", ")) : '<span class="proj-scope-none">nothing selected \u2014 every tool this field governs is refused</span>') + "</div>";
+    const unknown = res && res.status === "ok" ? unrecognisedScopeValues(selected, res.values) : [];
+    if (unknown.length) {
+      html += '<div class="proj-scope-unrecognised">' + esc(mcpID) + " does not offer " + esc(unknown.map(scopeEnumValueKey).join(", ")) + ". Kept and still in force \u2014 it may have been renamed on the host, or this MCP may be reading a different one. Untick it to remove it.</div>";
+    }
+    html += '<button class="btn btn-sm" onclick="toggleScopeFieldPicker(' + args + ')">' + (open ? "Done" : "Choose values\u2026") + "</button>";
+    if (!open) return html;
+    if (pending) return html + '<div class="proj-scope-pending">Listing values from ' + esc(mcpID) + "\u2026</div>";
+    if (!res) {
+      return html + '<div class="proj-scope-pending">The values this list is read within have changed.</div><button class="btn btn-sm" onclick="retryScopeEnum(' + args + ')">List values</button>';
+    }
+    if (res.status === "ok") {
+      return html + renderScopeChoices(mcpID, field, selected, res.values, unknown, deps);
+    }
+    if (res.status === "invalid_field" || res.status === "not_enumerable") {
+      html += '<div class="proj-scope-failed">Relay asked ' + esc(mcpID) + " for values it will not enumerate, which is a bug in relay rather than in this profile" + (res.error ? ": " + esc(res.error) : ".") + " Type the values instead \u2014 they are stored and enforced exactly the same way.</div>";
+    } else if (res.status === "unsupported") {
+      html += '<div class="proj-scope-desc">' + esc(mcpID) + " cannot list this field's values.</div>";
+    } else {
+      html += '<div class="proj-scope-failed">Could not list values from ' + esc(mcpID) + " just now" + (res.error ? ": " + esc(res.error) : ".") + " This is not an empty list \u2014 nothing was read. Retry, or type the values.</div>";
+      html += '<button class="btn btn-sm" onclick="retryScopeEnum(' + args + ')">Try again</button>';
+    }
+    return html + renderScopeFieldTextInput(mcpID, field, text);
+  }
+  function renderScopeChoices(mcpID, field, selected, offered, unknown, deps) {
+    const multi = field.type === "array";
+    const rows = [];
+    const byKey = {};
+    const push = (value, label, isUnknown) => {
+      const k = scopeEnumValueKey(value);
+      if (byKey[k]) {
+        if (label && byKey[k].labels.indexOf(label) < 0) byKey[k].labels.push(label);
+        return;
+      }
+      byKey[k] = { value, labels: [label], unknown: isUnknown };
+      rows.push(byKey[k]);
+    };
+    for (const v of unknown) push(v, scopeEnumValueKey(v), true);
+    for (const o of offered || []) push(o.value, o.label || scopeEnumValueKey(o.value), false);
+    for (const row of rows) row.label = row.labels.join(" \xB7 ");
+    if (!rows.length) {
+      return '<div class="proj-scope-desc">' + esc(mcpID) + " offers no values for this field" + (Object.keys(deps).length ? " within the values chosen above" : "") + ". That is its answer, not a failure \u2014 there is nothing here to grant.</div>";
+    }
+    const selectedKeys = new Set(selected.map(scopeEnumValueKey));
+    let html = '<div class="proj-scope-choices">';
+    for (const row of rows) {
+      const idx = state._scopeBind.length;
+      state._scopeBind.push({ mcpID, field: field.name, value: row.value });
+      const checked = selectedKeys.has(scopeEnumValueKey(row.value)) ? " checked" : "";
+      html += '<div class="proj-scope-choice' + (row.unknown ? " unrecognised" : "") + '">';
+      html += '<input type="' + (multi ? "checkbox" : "radio") + '" name="scope-' + esc(mcpID) + "-" + esc(field.name) + '"' + checked + ' onchange="toggleProjScopeValueAt(' + idx + ', this.checked)" />';
+      html += "<label>" + esc(row.label) + "</label>";
+      if (row.unknown) html += '<span class="desc">not offered by this MCP</span>';
+      html += "</div>";
+    }
+    html += "</div>";
+    return html;
+  }
+  function toggleProjScopeValueAt(index, checked) {
+    const bind = state._scopeBind[index];
+    if (!bind) return;
+    const f = state.projectForm;
+    if (!f) return;
+    const field = scopeFieldByName(bind.mcpID, bind.field);
+    if (!field) return;
+    captureProjectFormInputs();
+    const current = scopeSelectedValues(field, projScopeText(f, bind.mcpID, field));
+    const key = scopeEnumValueKey(bind.value);
+    let next;
+    if (field.type === "array") {
+      next = current.filter((v) => scopeEnumValueKey(v) !== key);
+      if (checked) next.push(bind.value);
+    } else {
+      next = checked ? [bind.value] : [];
+    }
+    setProjScopeText(bind.mcpID, bind.field, scopeTextFromValue(field, field.type === "array" ? next : next[0] !== void 0 ? next[0] : ""));
+    refreshDependentScopeFields(bind.mcpID, bind.field);
+    render();
+  }
+  function captureProjectFormInputs() {
+    const f = state.projectForm;
+    if (!f) return;
+    const val = (id) => {
+      const el = document.getElementById(id);
+      return el && typeof el.value === "string" ? el.value : "";
+    };
+    f.name = val("projName") || f.name;
+    if (!isRemoteForm(f)) f.path = val("projPath") || f.path;
   }
   function setProjModelsWildcard(checked) {
     const f = state.projectForm;
@@ -1885,6 +2097,7 @@ window.__RELAY_INIT__ = {
   function renderProjectForm() {
     const f = state.projectForm;
     if (!f) return '<div class="empty-state">No form state.</div>';
+    state._scopeBind = [];
     const isNew = !f.id;
     const isRemote = isRemoteForm(f);
     const noun = isRemote ? "Access Profile" : "Project";
@@ -2007,7 +2220,7 @@ window.__RELAY_INIT__ = {
     if (!isRemote || f.chat_templates.length > 0) {
       html += '<div class="proj-section">';
       html += '<div class="proj-section-title">Chat Templates</div>';
-      html += '<p class="proj-section-help">' + (isRemote ? "An access profile has no chat sessions, so these are inert. They are shown because they are stored on the record." : "Project-scoped chat presets stored with the project. Create and edit them in Eve's project dialog, which offers live model selection.") + "</p>";
+      html += '<p class="proj-section-help">' + (isRemote ? "An access profile has no chat sessions, so relay refuses chat templates on one. These are stored from before that rule; <strong>saving this profile removes them.</strong>" : "Project-scoped chat presets stored with the project. Create and edit them in Eve's project dialog, which offers live model selection.") + "</p>";
       if (f.chat_templates.length === 0) {
         html += '<div class="proj-tool-empty">No templates yet.</div>';
       }
@@ -2022,21 +2235,30 @@ window.__RELAY_INIT__ = {
       html += "</div>";
     }
     const pol = f.permission_policy;
-    html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Permission Policy</div>';
-    html += '<p class="proj-section-help">' + (isRemote ? "Claude CLI permission gates. An access profile launches no Claude session, so this is inert for one \u2014 what bounds a remote client is the mode, tools and scope above." : "Claude CLI permission gates. Empty mode inherits Claude's default. Patterns follow Claude's tool grammar (e.g. <code>Bash(ls *)</code>).") + "</p>";
-    html += "<label>Default mode</label>";
-    html += '<select id="projPolicyMode" onchange="state.projectForm.permission_policy.default_mode = this.value">';
-    for (const m of ["", "default", "acceptEdits", "plan", "bypassPermissions"]) {
-      const sel = pol.default_mode === m ? "selected" : "";
-      html += '<option value="' + esc(m) + '" ' + sel + ">" + (m || "(inherit)") + "</option>";
+    if (isRemote) {
+      if (!isPolicyEmpty(pol)) {
+        html += '<div class="proj-section">';
+        html += '<div class="proj-section-title">Permission Policy</div>';
+        html += '<p class="proj-section-help">Claude CLI permission gates, stored from before relay refused them on an access profile. A profile launches no Claude session, so they gate nothing; what bounds a remote client is the operations, tools and resources above. <strong>Saving this profile removes them.</strong></p>';
+        html += "</div>";
+      }
+    } else {
+      html += '<div class="proj-section">';
+      html += '<div class="proj-section-title">Permission Policy</div>';
+      html += `<p class="proj-section-help">Claude CLI permission gates. Empty mode inherits Claude's default. Patterns follow Claude's tool grammar (e.g. <code>Bash(ls *)</code>).</p>`;
+      html += "<label>Default mode</label>";
+      html += '<select id="projPolicyMode" onchange="state.projectForm.permission_policy.default_mode = this.value">';
+      for (const m of ["", "default", "acceptEdits", "plan", "bypassPermissions"]) {
+        const sel = pol.default_mode === m ? "selected" : "";
+        html += '<option value="' + esc(m) + '" ' + sel + ">" + (m || "(inherit)") + "</option>";
+      }
+      html += "</select>";
+      html += "<label>Allowed tools (one per line)</label>";
+      html += '<textarea id="projAllowedTools" rows="3" placeholder="Read&#10;Grep&#10;Bash(ls *)">' + esc(pol.allowed_tools.join("\n")) + "</textarea>";
+      html += "<label>Denied tools (one per line)</label>";
+      html += '<textarea id="projDeniedTools" rows="3" placeholder="Bash(rm *)&#10;Write">' + esc(pol.denied_tools.join("\n")) + "</textarea>";
+      html += "</div>";
     }
-    html += "</select>";
-    html += "<label>Allowed tools (one per line)</label>";
-    html += '<textarea id="projAllowedTools" rows="3" placeholder="Read&#10;Grep&#10;Bash(ls *)">' + esc(pol.allowed_tools.join("\n")) + "</textarea>";
-    html += "<label>Denied tools (one per line)</label>";
-    html += '<textarea id="projDeniedTools" rows="3" placeholder="Bash(rm *)&#10;Write">' + esc(pol.denied_tools.join("\n")) + "</textarea>";
-    html += "</div>";
     if (!isRemote) {
       html += '<div class="proj-section">';
       html += '<div class="proj-section-title">Skill (CLAUDE.md / SKILL.md)</div>';
@@ -2131,6 +2353,10 @@ window.__RELAY_INIT__ = {
     f.disabled_tools[mcpID] = (f.disabled_tools[mcpID] || []).filter((n) => n !== name);
     render();
   }
+  function isPolicyEmpty(pol) {
+    if (!pol) return true;
+    return !pol.default_mode && (pol.allowed_tools || []).length === 0 && (pol.denied_tools || []).length === 0;
+  }
   function harvestProjectForm() {
     const f = state.projectForm;
     if (!f) return null;
@@ -2143,13 +2369,16 @@ window.__RELAY_INIT__ = {
       const csv = (document.getElementById("projModels") || {}).value || "";
       allowedModels = csv.split(",").map((s) => s.trim()).filter(Boolean);
     }
-    const allowedToolsTA = document.getElementById("projAllowedTools");
-    const deniedToolsTA = document.getElementById("projDeniedTools");
-    const policy = {
-      default_mode: f.permission_policy.default_mode,
-      allowed_tools: allowedToolsTA ? allowedToolsTA.value.split("\n").map((s) => s.trim()).filter(Boolean) : f.permission_policy.allowed_tools,
-      denied_tools: deniedToolsTA ? deniedToolsTA.value.split("\n").map((s) => s.trim()).filter(Boolean) : f.permission_policy.denied_tools
-    };
+    let policy = { default_mode: "", allowed_tools: [], denied_tools: [] };
+    if (!isRemote) {
+      const allowedToolsTA = document.getElementById("projAllowedTools");
+      const deniedToolsTA = document.getElementById("projDeniedTools");
+      policy = {
+        default_mode: f.permission_policy.default_mode,
+        allowed_tools: allowedToolsTA ? allowedToolsTA.value.split("\n").map((s) => s.trim()).filter(Boolean) : f.permission_policy.allowed_tools,
+        denied_tools: deniedToolsTA ? deniedToolsTA.value.split("\n").map((s) => s.trim()).filter(Boolean) : f.permission_policy.denied_tools
+      };
+    }
     const payload = {
       name: name.trim(),
       kind: isRemote ? "remote" : "local",
@@ -2162,10 +2391,13 @@ window.__RELAY_INIT__ = {
       allow_cwd_auth: isRemote ? false : f.allow_cwd_auth,
       disabled_tools: f.disabled_tools
     };
+    if (isRemote && f.chat_templates.length > 0) payload.chat_templates = [];
     const perms = harvestProjectPermissions(f);
-    payload.access = perms.access;
-    payload.allowed_tools = perms.allowed_tools;
-    payload.context = perms.context;
+    if (perms.complete) {
+      payload.access = perms.access;
+      payload.allowed_tools = perms.allowed_tools;
+      payload.context = perms.context;
+    }
     if (!isRemote) {
       const path = (document.getElementById("projPath") || {}).value || f.path;
       payload.path = path.trim();
@@ -2175,7 +2407,9 @@ window.__RELAY_INIT__ = {
   function harvestProjectPermissions(f) {
     const remote = isRemoteForm(f);
     const wild = f.allowed_mcp_ids.length === 1 && f.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD;
-    const granted = wild ? (state.externalMcps || []).map((m) => m.id) : f.allowed_mcp_ids.slice();
+    const registered = (state.externalMcps || []).map((m) => m.id);
+    const complete = !wild || registered.length > 0;
+    const granted = wild ? registered : f.allowed_mcp_ids.slice();
     const access = {};
     const allowedTools = {};
     const context = {};
@@ -2202,7 +2436,7 @@ window.__RELAY_INIT__ = {
       }
       if (Object.keys(existing).length) context[mcpID] = existing;
     }
-    return { access, allowed_tools: allowedTools, context };
+    return { access, allowed_tools: allowedTools, context, complete };
   }
   function saveProjectForm() {
     const f = state.projectForm;
@@ -2275,6 +2509,18 @@ window.__RELAY_INIT__ = {
     if (state.page === "projects" && state.editingProjectId) {
       render("push");
     }
+  };
+  window.onScopeFieldEnumerated = function(res) {
+    if (!res || !res.mcp_id || !res.field) return;
+    const openKey = scopeOpenKey(res.mcp_id, res.field);
+    const key = state.scopeEnumReq[openKey];
+    if (!key) return;
+    delete state.scopeEnumReq[openKey];
+    state.scopeEnum[key] = res;
+    if (res.status === "unsupported") state.scopeEnumUnsupported[res.mcp_id] = true;
+    if (state.page !== "projects" || !state.editingProjectId) return;
+    captureProjectFormInputs();
+    render();
   };
   window.onProjectError = function(msg) {
     state.projectError = msg;
@@ -3686,6 +3932,9 @@ window.__RELAY_INIT__ = {
     renderAuthorityRows,
     renderProjMcpPermissions,
     renderScopeFieldInput,
+    renderScopeFieldPicker,
+    renderScopeFieldTextInput,
+    renderScopeChoices,
     renderScopeGapBanner,
     scopeTextFromValue,
     scopeValueFromText,
@@ -3695,6 +3944,21 @@ window.__RELAY_INIT__ = {
     setProjAllowedToolsText,
     setProjMcpGranted,
     setProjScopeText,
+    captureProjectFormInputs,
+    isPolicyEmpty,
+    refreshDependentScopeFields,
+    requestScopeEnum,
+    retryScopeEnum,
+    scopeDependencyValues,
+    scopeEnumKey,
+    scopeEnumValueKey,
+    scopeFieldByName,
+    scopeFieldIsOpen,
+    scopeOpenKey,
+    scopeSelectedValues,
+    toggleProjScopeValueAt,
+    toggleScopeFieldPicker,
+    unrecognisedScopeValues,
     addExternalMcp,
     addExternalMcpFromJson,
     addExternalMcpHttp,

--- a/web/dist/settings.html
+++ b/web/dist/settings.html
@@ -1841,7 +1841,7 @@ window.__RELAY_INIT__ = {
       const patterns = projAllowedToolsText(f, mcpID);
       html += '<div class="proj-perm-block">';
       html += '<div class="proj-perm-label">Tools</div>';
-      html += '<p class="proj-section-help">One name or pattern per line, e.g. <code>mail_*</code>. Patterns are anchored \u2014 <code>mail_*</code> admits <code>mail_send</code> and not <code>xmail_send</code>. A bare <code>*</code> is refused: registering a new tool would silently widen the grant. <strong>Empty means no tools at all.</strong></p>';
+      html += '<p class="proj-section-help">One name or pattern per line, e.g. <code>mail_*</code>. Patterns are anchored \u2014 <code>mail_*</code> admits <code>mail_send</code> and not <code>xmail_send</code>. A pattern that matches by <em>shape</em> rather than by name is refused, whatever it is spelled as: <code>*</code>, <code>**</code>, <code>?*</code>, <code>[a-z]*</code>, <code>*_*</code> all match every tool the MCP has, so a tool registered tomorrow would join this grant with nobody reviewing it. There is no way to say &quot;everything&quot; here, deliberately. <strong>Empty means no tools at all.</strong></p>';
       html += `<textarea rows="3" placeholder="mail_*" oninput="setProjAllowedToolsText('` + esc(mcpID) + `', this.value)">` + esc(patterns) + "</textarea>";
       html += "</div>";
     }

--- a/web/shell.html
+++ b/web/shell.html
@@ -362,6 +362,39 @@ textarea:focus {
 .proj-template-card { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 8px; }
 .proj-template-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
 .proj-form-actions { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--border); display: flex; gap: 8px; }
+/* Effective authority: what a record can actually DO, per MCP. On the list row
+   and on an enrolment card, because "MCPs: 1" beside a client that can read
+   every mailbox on the machine is the failure ADR-011 exists to fix. */
+.proj-authority { margin-top: 6px; display: flex; flex-direction: column; gap: 3px; }
+.proj-auth-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; font-size: 11px; }
+.proj-auth-mcp { font-family: var(--mono); color: var(--text); }
+.proj-auth-mode { display: inline-block; padding: 0 6px; border-radius: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; font-size: 10px; }
+.proj-auth-mode.read { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
+.proj-auth-mode.write { background: color-mix(in srgb, var(--warn) 22%, transparent); color: var(--warn); }
+.proj-auth-tools { color: var(--text-2); font-family: var(--mono); }
+.proj-auth-scope { color: var(--text-2); }
+.proj-auth-scope.none { color: var(--text-3); font-style: italic; }
+/* A grant that cannot be satisfied is not a detail. It reads as a warning here
+   and again in the banner, because the client-facing half of this is a silent
+   `denied` nobody watching the UI would ever see. */
+.proj-auth-missing { color: var(--warn); font-weight: 600; }
+.proj-auth-none { color: var(--text-3); font-style: italic; font-size: 11px; }
+.proj-scope-gap { border: 1px solid var(--warn); border-radius: var(--radius-sm); background: color-mix(in srgb, var(--warn) 10%, transparent); padding: 10px 12px; margin-bottom: 12px; font-size: 12px; color: var(--text); }
+.proj-scope-gap ul { margin: 6px 0 0 18px; }
+.proj-scope-gap code { font-family: var(--mono); }
+
+/* The per-MCP permission panel: mode, tools, resource scope. */
+.proj-perm-panel { padding: 8px 0 10px 16px; border-left: 2px solid var(--accent); margin: 4px 0 10px 8px; display: flex; flex-direction: column; gap: 10px; }
+.proj-perm-block { }
+.proj-perm-label { font-size: 11px; font-weight: 600; color: var(--text-2); text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 4px; }
+.proj-scope-field { margin-top: 8px; }
+.proj-scope-field > label { display: block; font-size: 12px; color: var(--text); font-family: var(--mono); margin-bottom: 1px; }
+.proj-scope-type { font-family: var(--sans, inherit); font-size: 10px; color: var(--text-3); text-transform: none; letter-spacing: 0; }
+.proj-scope-desc { font-size: 11px; color: var(--text-3); margin-bottom: 3px; }
+.proj-scope-missing { font-size: 11px; color: var(--warn); margin-top: 2px; }
+.proj-scope-field input[readonly] { color: var(--text-2); font-family: var(--mono); }
+.enrol-profile { margin-top: 6px; }
+
 .proj-error { color: var(--danger); font-size: 12px; margin-top: 8px; }
 .proj-ok { color: var(--ok); font-size: 12px; margin-top: 8px; }
 
@@ -446,6 +479,7 @@ window.__RELAY_INIT__ = {
   runningIds: __RUNNING_IDS_JSON__,
   projects: __PROJECTS_JSON__,
   mcpToolCache: __MCP_TOOL_CACHE_JSON__,
+  mcpScopeFields: __MCP_SCOPE_FIELDS_JSON__,
   enrolments: __ENROLMENTS_JSON__,
   remote: __REMOTE_JSON__,
   enrolmentBudgetDefaults: __ENROLMENT_BUDGET_DEFAULTS_JSON__

--- a/web/shell.html
+++ b/web/shell.html
@@ -393,6 +393,23 @@ textarea:focus {
 .proj-scope-desc { font-size: 11px; color: var(--text-3); margin-bottom: 3px; }
 .proj-scope-missing { font-size: 11px; color: var(--warn); margin-top: 2px; }
 .proj-scope-field input[readonly] { color: var(--text-2); font-family: var(--mono); }
+
+/* The enumeration picker (ADR-011 decision 6). The summary is outside the
+   disclosure on purpose: what is stored is what confines the client, so it is
+   never behind a control someone has to open to see. */
+.proj-scope-summary { font-size: 12px; font-family: var(--mono); color: var(--text); margin: 2px 0 4px; word-break: break-word; }
+.proj-scope-summary .proj-scope-none { font-family: var(--sans, inherit); color: var(--text-3); font-style: italic; }
+.proj-scope-choices { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 6px 8px; margin-top: 6px; max-height: 260px; overflow-y: auto; }
+.proj-scope-choice { display: flex; align-items: baseline; gap: 6px; font-size: 12px; padding: 2px 0; }
+.proj-scope-choice label { font-family: var(--mono); color: var(--text); }
+.proj-scope-choice .desc { font-family: var(--sans, inherit); font-size: 11px; color: var(--text-3); }
+/* A stored value the MCP no longer offers stays visible and stays SELECTED.
+   An account renamed on the host must not quietly widen or narrow a profile by
+   vanishing from a form, so it is flagged rather than dropped. */
+.proj-scope-choice.unrecognised label { color: var(--warn); }
+.proj-scope-unrecognised { font-size: 11px; color: var(--warn); margin: 2px 0; }
+.proj-scope-failed { font-size: 11px; color: var(--danger); margin: 4px 0 2px; }
+.proj-scope-pending { font-size: 11px; color: var(--text-3); margin: 4px 0 2px; }
 .enrol-profile { margin-top: 6px; }
 
 .proj-error { color: var(--danger); font-size: 12px; margin-top: 8px; }

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -1443,7 +1443,7 @@ function renderProjMcpPermissions(mcpID, f) {
         const patterns = projAllowedToolsText(f, mcpID);
         html += '<div class="proj-perm-block">';
         html += '<div class="proj-perm-label">Tools</div>';
-        html += '<p class="proj-section-help">One name or pattern per line, e.g. <code>mail_*</code>. Patterns are anchored — <code>mail_*</code> admits <code>mail_send</code> and not <code>xmail_send</code>. A bare <code>*</code> is refused: registering a new tool would silently widen the grant. <strong>Empty means no tools at all.</strong></p>';
+        html += '<p class="proj-section-help">One name or pattern per line, e.g. <code>mail_*</code>. Patterns are anchored — <code>mail_*</code> admits <code>mail_send</code> and not <code>xmail_send</code>. A pattern that matches by <em>shape</em> rather than by name is refused, whatever it is spelled as: <code>*</code>, <code>**</code>, <code>?*</code>, <code>[a-z]*</code>, <code>*_*</code> all match every tool the MCP has, so a tool registered tomorrow would join this grant with nobody reviewing it. There is no way to say &quot;everything&quot; here, deliberately. <strong>Empty means no tools at all.</strong></p>';
         html += '<textarea rows="3" placeholder="mail_*" oninput="setProjAllowedToolsText(\'' + esc(mcpID) + '\', this.value)">' + esc(patterns) + '</textarea>';
         html += '</div>';
     }

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -11,6 +11,12 @@ const SERVICES_INIT = window.__RELAY_INIT__.services;
 const RUNNING_IDS_INIT = window.__RELAY_INIT__.runningIds;
 const PROJECTS_INIT = window.__RELAY_INIT__.projects;
 const MCP_TOOL_CACHE_INIT = window.__RELAY_INIT__.mcpToolCache;
+// What each MCP declares as narrowable: its scope: "restrict" fields, already
+// projected by Go (ScopeFieldView) so the rule that an absent `source` means
+// "operator" lives in exactly one place. Seeded rather than fetched because
+// the LIST needs it — a row has to be able to say "needs a scope value"
+// without anyone opening the editor first.
+const MCP_SCOPE_FIELDS_INIT = window.__RELAY_INIT__.mcpScopeFields || {};
 const ENROLMENTS_INIT = window.__RELAY_INIT__.enrolments || [];
 const REMOTE_INIT = window.__RELAY_INIT__.remote || null;
 // The conservative per-enrolment budget defaults, shipped from Go so the
@@ -65,6 +71,7 @@ let state = {
     // Projects tab.
     projects: PROJECTS_INIT,
     mcpToolCache: MCP_TOOL_CACHE_INIT,     // mcpId -> [{name, description, category}]
+    mcpScopeFields: MCP_SCOPE_FIELDS_INIT, // mcpId -> [ScopeFieldView]; NO KEY = relay has never seen that MCP
     editingProjectId: null,                 // null = list, 'new' = create form, '<id>' = edit
     projectForm: null,                      // in-flight form values (kept out of state.projects until Save)
     projectFormError: null,
@@ -751,6 +758,7 @@ window.onSettingsReloaded = function(data) {
     state.runningServices = data.running_ids.reduce(function(m, id) { m[id] = true; return m; }, {});
     if (data.projects) state.projects = data.projects;
     if (data.mcp_tool_cache) state.mcpToolCache = data.mcp_tool_cache;
+    if (data.mcp_scope_fields) state.mcpScopeFields = data.mcp_scope_fields;
     if (data.enrolments) state.enrolments = data.enrolments;
     if (data.remote) {
         state.remote = data.remote;
@@ -791,27 +799,199 @@ window.onProjectsReloaded = function(projects) {
 
 const PROJ_MCP_WILDCARD = '*';
 
+// ---------------------------------------------------------------------------
+// Effective authority (ADR-011 decisions 1 and 2)
+//
+// Everything below answers one question in one place: given a record and an
+// MCP it grants, what can the client actually do? A row that says "MCPs: 1"
+// while the client can read every mailbox on the machine is the problem this
+// ADR exists to fix, so the same helpers feed the Projects list, the project
+// editor, and the Remote Clients tab — a summary that disagreed with the
+// editor beside it would be worse than no summary.
+//
+// The mode rule is StoredToken.AccessMode's, restated: an explicit entry that
+// is not exactly "write" reads as read, and an ABSENT entry defaults read for
+// an access profile and write for a local project. The asymmetry is
+// deliberate (ADR-011 decision 2) and it is why this is a function rather than
+// a lookup with a default argument — a caller that forgot which default
+// applied would draw the wrong one.
+// ---------------------------------------------------------------------------
+
+// A remote-kind record is an ACCESS PROFILE everywhere an operator reads it
+// (ADR-011 decision 1). It has no directory, no skills, no shell and no
+// models, and calling it a project invites the reader to expect all four. The
+// stored kind is unchanged; this is presentation only.
+function projNoun(p) { return isRemoteProject(p) ? 'access profile' : 'project'; }
+
+// mcpScopeFieldsFor returns what an MCP declares as narrowable, or null when
+// relay has never connected to it. Null is not an empty list: "this MCP scopes
+// nothing" and "relay cannot tell you what this MCP scopes" are different
+// answers, and only the first one means an editor may safely offer no fields.
+function mcpScopeFieldsFor(mcpID) {
+    const m = state.mcpScopeFields || {};
+    return Object.prototype.hasOwnProperty.call(m, mcpID) ? (m[mcpID] || []) : null;
+}
+
+// projGrantedMcpIds expands the wildcard the way SyncProjectToken does — to
+// every MCP relay currently knows about — because that is what the grant
+// actually reaches. A summary that printed "*" would be hiding the number the
+// operator needs.
+function projGrantedMcpIds(p) {
+    const ids = (p && p.allowed_mcp_ids) || [];
+    if (ids.length === 1 && ids[0] === PROJ_MCP_WILDCARD) {
+        return (state.externalMcps || []).map(m => m.id);
+    }
+    return ids.slice();
+}
+
+function projAccessMode(p, mcpID) {
+    const explicit = (p && p.access) ? p.access[mcpID] : undefined;
+    if (explicit !== undefined && explicit !== null && explicit !== '') {
+        return explicit === 'write' ? 'write' : 'read';
+    }
+    return isRemoteProject(p) ? 'read' : 'write';
+}
+
+// scopeValueIsSet mirrors hasScopeValue on the Go side: absent, null, empty
+// string, empty list and empty object are all ABSENT, because a restrict field
+// with no value refuses every call it governs. "No restriction" is not
+// expressible as emptiness anywhere in this model.
+function scopeValueIsSet(v) {
+    if (v === undefined || v === null) return false;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === 'string') return v.trim() !== '';
+    if (typeof v === 'object') return Object.keys(v).length > 0;
+    return true;
+}
+
+function projScopeValue(p, mcpID, fieldName) {
+    const perMcp = (p && p.context) ? p.context[mcpID] : null;
+    return perMcp ? perMcp[fieldName] : undefined;
+}
+
+// scopeValueText renders a stored value for a human. Arrays are the shape
+// every scope field met so far declares; anything else prints as its JSON,
+// which is honest about a shape this UI does not model.
+function scopeValueText(v) {
+    if (Array.isArray(v)) return v.join(', ');
+    if (typeof v === 'string') return v;
+    if (v === undefined || v === null) return '';
+    return JSON.stringify(v);
+}
+
+// projMissingScopeFields names the OPERATOR-set restrict fields this record
+// grants an MCP for but supplies no value for. Those are the ones an operator
+// can fix; a project_path field on an access profile is reported separately,
+// because there is nothing to type — the tools it governs are simply gone.
+function projMissingScopeFields(p, mcpID) {
+    const fields = mcpScopeFieldsFor(mcpID);
+    if (!fields) return [];
+    return fields
+        .filter(f => f.source !== 'project_path')
+        .filter(f => !scopeValueIsSet(projScopeValue(p, mcpID, f.name)))
+        .map(f => f.name);
+}
+
+// projScopeGaps is the list-level form: every (record, MCP) pair still missing
+// a value someone has to type. This is the operator-facing half of ADR-011's
+// loud-and-closed behaviour — the client-facing half is a `denied` at call
+// time, which is silent from the operator's side and baffling from the
+// agent's.
+function projScopeGaps(p) {
+    const out = [];
+    for (const mcpID of projGrantedMcpIds(p)) {
+        const missing = projMissingScopeFields(p, mcpID);
+        if (missing.length) out.push({ mcp: mcpID, fields: missing });
+    }
+    return out;
+}
+
+function projAllowedToolPatterns(p, mcpID) {
+    return ((p && p.allowed_tools) ? p.allowed_tools[mcpID] : null) || [];
+}
+
+// projToolAuthorityText says which tools the grant admits. The two kinds are
+// genuinely different mechanisms and the text says so rather than smoothing it
+// over: an access profile holds only what allowed_tools enumerates (absent
+// means NOTHING), a local project holds everything minus its denylist.
+function projToolAuthorityText(p, mcpID) {
+    const patterns = projAllowedToolPatterns(p, mcpID);
+    if (isRemoteProject(p)) {
+        return patterns.length ? patterns.join(', ') : 'no tools';
+    }
+    if (patterns.length) return patterns.join(', ');
+    const disabled = ((p.disabled_tools || {})[mcpID] || []).length;
+    return disabled ? ('all tools except ' + disabled) : 'all tools';
+}
+
+// projAuthorityRows is the one shape every authority summary renders from.
+function projAuthorityRows(p) {
+    return projGrantedMcpIds(p).map(function(mcpID) {
+        const fields = mcpScopeFieldsFor(mcpID);
+        const scope = [];
+        const derived = [];
+        for (const f of (fields || [])) {
+            const v = projScopeValue(p, mcpID, f.name);
+            if (f.source === 'project_path') {
+                if (scopeValueIsSet(v)) derived.push(f.name + ': ' + scopeValueText(v));
+                continue;
+            }
+            if (scopeValueIsSet(v)) scope.push(f.name + ': ' + scopeValueText(v));
+        }
+        return {
+            mcp: mcpID,
+            mode: projAccessMode(p, mcpID),
+            tools: projToolAuthorityText(p, mcpID),
+            scope: scope,
+            derived: derived,
+            missing: projMissingScopeFields(p, mcpID),
+            schemaUnknown: fields === null,
+        };
+    });
+}
+
+function renderAuthorityRows(p) {
+    const rows = projAuthorityRows(p);
+    if (!rows.length) {
+        return '<div class="proj-auth-row"><span class="proj-auth-none">no MCPs granted — this ' + esc(projNoun(p)) + ' reaches nothing</span></div>';
+    }
+    let html = '';
+    for (const r of rows) {
+        html += '<div class="proj-auth-row">';
+        html += '<span class="proj-auth-mcp">' + esc(r.mcp) + '</span>';
+        html += '<span class="proj-auth-mode ' + esc(r.mode) + '">' + esc(r.mode) + '</span>';
+        html += '<span class="proj-auth-tools">' + esc(r.tools) + '</span>';
+        if (r.scope.length) html += '<span class="proj-auth-scope">' + esc(r.scope.join(' · ')) + '</span>';
+        if (r.missing.length) {
+            html += '<span class="proj-auth-missing">needs a scope value for ' + esc(r.missing.join(', ')) + '</span>';
+        } else if (!r.scope.length && !r.schemaUnknown) {
+            html += '<span class="proj-auth-scope none">no resource scope declared by this MCP</span>';
+        }
+        if (r.schemaUnknown) html += '<span class="proj-auth-scope none">not connected — scope unknown</span>';
+        html += '</div>';
+    }
+    return html;
+}
+
 function renderProjects() {
     if (state.editingProjectId) return renderProjectForm();
 
     let html = '<div class="page-header">';
-    html += '<h2>Projects</h2>';
-    html += '<button class="btn btn-primary" onclick="newProject()">+ New Project</button>';
+    html += '<h2>Projects &amp; Access Profiles</h2>';
+    html += '<button class="btn btn-primary" onclick="newProject()">+ New</button>';
     html += '</div>';
-    html += '<p class="page-intro">Projects are the security boundary: each gets a scoped bearer token, an allowed-MCP list, per-tool selection, and optional auto-generated SKILL.md.</p>';
+    html += '<p class="page-intro">Both kinds are the security boundary and both get a scoped bearer token. A <strong>project</strong> is bound to a host directory and has models, shell templates and skills. An <strong>access profile</strong> is a capability grant to a client on another machine: no directory, no skills, no shell, no models — just which MCPs, which tools, which operations and which resources.</p>';
 
     if (state.projectError) {
         html += '<div class="proj-error">' + esc(state.projectError) + '</div>';
     }
+    html += renderScopeGapBanner();
 
     if (state.projects.length === 0) {
-        html += '<div class="empty-state">No projects yet. Click <strong>+ New Project</strong> to create one.</div>';
+        html += '<div class="empty-state">Nothing here yet. Click <strong>+ New</strong> to create a project or an access profile.</div>';
     } else {
         for (const p of state.projects) {
             const remote = isRemoteProject(p);
-            const allowedCount = p.allowed_mcp_ids && p.allowed_mcp_ids.length > 0
-                ? (p.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD ? 'all' : String(p.allowed_mcp_ids.length))
-                : (remote ? 'no tools granted' : '0');
             const modelsCount = p.allowed_models && p.allowed_models.length > 0
                 ? (p.allowed_models[0] === PROJ_MCP_WILDCARD ? 'all' : String(p.allowed_models.length))
                 : '0';
@@ -822,19 +1002,32 @@ function renderProjects() {
             html += '<div class="proj-card-header">';
             html += '<div style="display:flex;align-items:center;gap:6px">';
             html += '<span class="proj-card-name">' + esc(p.name) + '</span>';
-            if (remote) html += '<span class="proj-badge-remote">Remote</span>';
+            if (remote) html += '<span class="proj-badge-remote">Access profile</span>';
             html += '</div>';
             html += '<div style="display:flex;gap:4px">';
             html += '<button class="btn btn-sm" onclick="editProject(\'' + esc(p.id) + '\')">Edit</button>';
-            html += '<button class="btn btn-sm" onclick="regenProjectSkill(\'' + esc(p.id) + '\')" title="Regenerate SKILL.md now">Regen Skill</button>';
+            // Regen Skill is absent for a profile rather than disabled:
+            // validateProjectShape refuses generate_skill on a remote record,
+            // and the regen handler refuses a record with no path, so the
+            // button could never do anything. ADR-009 decision 2's argument
+            // applies to the control as much as to the flag — refusing at the
+            // door is more honest than something that quietly no-ops.
+            if (!remote) {
+                html += '<button class="btn btn-sm" onclick="regenProjectSkill(\'' + esc(p.id) + '\')" title="Regenerate SKILL.md now">Regen Skill</button>';
+            }
             html += '<button class="btn btn-sm btn-danger" onclick="removeProject(\'' + esc(p.id) + '\', \'' + esc(p.name) + '\')">Delete</button>';
             html += '</div></div>';
-            html += '<div class="proj-card-path">' + esc(p.path || '(no path)') + '</div>';
+            html += '<div class="proj-card-path">' + esc(remote ? 'no host directory — an access profile grants capability, not a filesystem' : (p.path || '(no path)')) + '</div>';
+            // What this record can actually DO, per MCP: mode, tools, scope.
+            // Counts alone were the ADR's own example of the failure — "MCPs: 1"
+            // beside a client that can read every mailbox on the machine.
+            html += '<div class="proj-authority">' + renderAuthorityRows(p) + '</div>';
             html += '<div class="proj-card-meta">';
-            html += '<span>MCPs: <strong>' + esc(allowedCount) + '</strong></span>';
-            html += '<span>Models: <strong>' + esc(modelsCount) + '</strong></span>';
+            if (!remote) {
+                html += '<span>Models: <strong>' + esc(modelsCount) + '</strong></span>';
+                html += '<span>Skill: <strong>' + esc(skillState) + '</strong></span>';
+            }
             html += '<span>Policy: <strong>' + esc(policy) + '</strong></span>';
-            html += '<span>Skill: <strong>' + esc(skillState) + '</strong></span>';
             // Only shown when on: directory auth is the exception, and a row of
             // "off" labels would bury the projects where it's actually enabled.
             if (p.allow_cwd_auth) html += '<span>Dir auth: <strong>on</strong></span>';
@@ -847,6 +1040,29 @@ function renderProjects() {
         }
     }
 
+    return html;
+}
+
+// renderScopeGapBanner is ADR-011's "N profiles need a scope value for
+// `macmcp`" — the operator-facing half of loud-and-closed. Without it the only
+// signal is a `denied` in the audit log for a call the operator never saw,
+// against a grant the UI otherwise renders as complete.
+function renderScopeGapBanner() {
+    const rows = [];
+    for (const p of (state.projects || [])) {
+        for (const gap of projScopeGaps(p)) {
+            rows.push({ name: p.name, noun: projNoun(p), mcp: gap.mcp, fields: gap.fields });
+        }
+    }
+    if (!rows.length) return '';
+    let html = '<div class="proj-scope-gap">';
+    html += '<strong>' + rows.length + (rows.length === 1 ? ' grant needs' : ' grants need') + ' a scope value.</strong> ';
+    html += 'Until one is set, every tool the field governs is <em>denied</em> at call time — the client gets nothing and nothing else says why.';
+    html += '<ul>';
+    for (const r of rows) {
+        html += '<li>' + esc(r.name) + ' (' + esc(r.noun) + ') → <code>' + esc(r.mcp) + '</code>: ' + esc(r.fields.join(', ')) + '</li>';
+    }
+    html += '</ul></div>';
     return html;
 }
 
@@ -863,6 +1079,18 @@ function blankProjectForm() {
         generate_skill: false,
         allow_cwd_auth: false,                   // token-less auth by working directory
         disabled_tools: {},                      // mcpID -> [toolName, ...]
+        // The ADR-011 permission set. access and allowed_tools are what relay
+        // enforces at its own chokepoint; context is what it injects and
+        // cannot verify. All three are absent by default, which for an access
+        // profile means read, no tools, and no scope — every layer failing
+        // closed until someone widens it deliberately.
+        access: {},                              // mcpID -> 'read' | 'write'
+        allowed_tools: {},                       // mcpID -> [pattern, ...]
+        context: {},                             // mcpID -> { field: value }
+        // Raw text as typed, so a half-finished value survives a re-render and
+        // is parsed exactly once, at harvest. Underscore-prefixed: never sent.
+        _scopeText: {},                          // mcpID -> { field: text }
+        _toolsText: {},                          // mcpID -> text
     };
 }
 
@@ -885,6 +1113,11 @@ function projectFormFromExisting(p) {
         generate_skill: !!p.generate_skill,
         allow_cwd_auth: !!p.allow_cwd_auth,
         disabled_tools: JSON.parse(JSON.stringify(p.disabled_tools || {})),
+        access: JSON.parse(JSON.stringify(p.access || {})),
+        allowed_tools: JSON.parse(JSON.stringify(p.allowed_tools || {})),
+        context: JSON.parse(JSON.stringify(p.context || {})),
+        _scopeText: {},
+        _toolsText: {},
         token: p.token || '',
     };
 }
@@ -917,7 +1150,15 @@ function regenProjectSkill(id) {
 }
 
 function removeProject(id, name) {
-    if (!confirm('Delete project "' + name + '"?\nThis revokes its token immediately and removes its SKILL.md.')) return;
+    const p = (state.projects || []).find(x => x.id === id);
+    const remote = isRemoteProject(p);
+    const what = remote ? 'access profile' : 'project';
+    // A profile has no skills to remove, and saying it does would be the
+    // clearest possible signal that the two kinds are being confused.
+    const consequence = remote
+        ? '\nThis revokes its token immediately. Any enrolment granting it is left holding an id that resolves to nothing.'
+        : '\nThis revokes its token immediately and removes its SKILL.md.';
+    if (!confirm('Delete ' + what + ' "' + name + '"?' + consequence)) return;
     ipc(JSON.stringify({ type: 'remove_project', id }));
 }
 
@@ -940,9 +1181,10 @@ function copyProjectToken(text) {
 
 // ---- Kind helpers ----
 //
-// A remote project (types.go ProjectKind) is a capability grant to an agent
-// on another machine, not a host directory: it carries no path, can't use
-// allow_cwd_auth or generate_skill (both are directory-flavored), can't use
+// A remote-kind record is an ACCESS PROFILE (ADR-011 decision 1): a capability
+// grant to an agent on another machine, not a host directory. It carries no
+// path, can't use allow_cwd_auth or generate_skill (both are
+// directory-flavored), can't use
 // the "*" MCP wildcard (a remote grant must be an explicit enumeration —
 // see validateProjectShape in project_apply.go), and always sends an empty
 // allowed_models. Kind is chosen at create time only; the edit form shows it
@@ -1053,6 +1295,222 @@ function toggleProjTool(mcpID, toolName, isChecked) {
     f.disabled_tools[mcpID] = Array.from(currentlyDisabled);
 }
 
+// ---------------------------------------------------------------------------
+// The per-MCP permission panel (ADR-011 decisions 2, 2b, 4, 6)
+//
+// One panel per granted MCP, and it is the whole authority in one place: which
+// operations (the mode), which tools (the allowlist, profiles only), and which
+// resources (one input per scope: "restrict" field the MCP declares).
+//
+// Scope values are TEXT ENTRY for now. `context/enumerate` (decision 6) is a
+// later change that replaces them with pickers over real values, and the swap
+// is meant to be local: renderScopeFieldInput is the only function that decides
+// what a field's control looks like, and scopeValueFromText / scopeTextFromValue
+// are the only two that convert between what is typed and what is stored.
+// ---------------------------------------------------------------------------
+
+// projFormAccessMode is projAccessMode against the in-flight form, which
+// carries `kind` as a string rather than as the stored ProjectKind.
+function projFormAccessMode(f, mcpID) {
+    const explicit = (f.access || {})[mcpID];
+    if (explicit === 'read' || explicit === 'write') return explicit;
+    return isRemoteForm(f) ? 'read' : 'write';
+}
+
+function setProjAccess(mcpID, mode) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (!f.access) f.access = {};
+    f.access[mcpID] = mode;
+    render();
+}
+
+// setProjMcpGranted is the access-profile form's grant control. A profile has
+// no tri-state, because the third state is a DENYLIST and a denylist cannot
+// bound a client — validateProjectShape refuses disabled_tools on a remote
+// record outright (ADR-011 decision 2b). What replaces it is the allowed-tools
+// box in the panel below.
+function setProjMcpGranted(mcpID, granted) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (granted) {
+        if (f.allowed_mcp_ids.indexOf(mcpID) < 0) f.allowed_mcp_ids.push(mcpID);
+    } else {
+        f.allowed_mcp_ids = f.allowed_mcp_ids.filter(id => id !== mcpID);
+        // Drop the permission set with the grant. Relay's mutators prune these
+        // on every resync anyway; leaving them here would show a mode and a
+        // scope for an MCP the record no longer reaches, which reads as an
+        // authority it does not have.
+        delete (f.access || {})[mcpID];
+        delete (f.allowed_tools || {})[mcpID];
+        delete (f.context || {})[mcpID];
+        delete (f._scopeText || {})[mcpID];
+        delete (f._toolsText || {})[mcpID];
+    }
+    render();
+}
+
+// ---- Scope value <-> text --------------------------------------------------
+//
+// The one pair of functions that knows how a typed value becomes a stored one.
+// A picker replaces the CONTROL, not this conversion.
+
+function scopeTextFromValue(field, v) {
+    if (v === undefined || v === null) return '';
+    if (Array.isArray(v)) return v.join('\n');
+    if (typeof v === 'string') return v;
+    return JSON.stringify(v);
+}
+
+function scopeValueFromText(field, text) {
+    const raw = String(text === undefined || text === null ? '' : text);
+    if (field.type === 'array') {
+        return raw.split('\n').map(s => s.trim()).filter(Boolean);
+    }
+    if (field.type === 'string') return raw.trim();
+    // A type outside the declared subset. Send what parses as JSON, otherwise
+    // the trimmed string — and let the server refuse it, which it will do
+    // against the MCP's own declaration rather than against a guess made here.
+    const trimmed = raw.trim();
+    if (!trimmed) return '';
+    try { return JSON.parse(trimmed); } catch (e) { return trimmed; }
+}
+
+function projScopeText(f, mcpID, field) {
+    const typed = (f._scopeText || {})[mcpID];
+    if (typed && Object.prototype.hasOwnProperty.call(typed, field.name)) return typed[field.name];
+    return scopeTextFromValue(field, ((f.context || {})[mcpID] || {})[field.name]);
+}
+
+function setProjScopeText(mcpID, fieldName, text) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (!f._scopeText) f._scopeText = {};
+    if (!f._scopeText[mcpID]) f._scopeText[mcpID] = {};
+    f._scopeText[mcpID][fieldName] = text;
+    // No render(): this fires on every keystroke and a repaint would eat the
+    // caret. The list-level "needs a scope value" banner catches up on save.
+}
+
+function projAllowedToolsText(f, mcpID) {
+    const typed = (f._toolsText || {})[mcpID];
+    if (typed !== undefined) return typed;
+    return ((f.allowed_tools || {})[mcpID] || []).join('\n');
+}
+
+function setProjAllowedToolsText(mcpID, text) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (!f._toolsText) f._toolsText = {};
+    f._toolsText[mcpID] = text;
+}
+
+// ---- The panel -------------------------------------------------------------
+
+function renderProjMcpPermissions(mcpID, f) {
+    const remote = isRemoteForm(f);
+    const mode = projFormAccessMode(f, mcpID);
+    let html = '<div class="proj-perm-panel">';
+
+    // Which operations.
+    html += '<div class="proj-perm-block">';
+    html += '<div class="proj-perm-label">Operations</div>';
+    html += '<div class="perm-btns">';
+    html += '<button class="perm-btn ' + (mode === 'read' ? 'active' : '') + '" onclick="setProjAccess(\'' + esc(mcpID) + '\', \'read\')">Read</button>';
+    html += '<button class="perm-btn ' + (mode === 'write' ? 'active' : '') + '" onclick="setProjAccess(\'' + esc(mcpID) + '\', \'write\')">Write</button>';
+    html += '</div>';
+    html += '<p class="proj-section-help">' + (mode === 'read'
+        ? 'Only tools this MCP annotates <code>readOnlyHint: true</code>. A tool that is unannotated, malformed, or added later is refused — that is what keeps a new mutating tool out of an old grant.'
+        : 'Every tool this grant admits, mutating included. Write implies read.')
+        + ' Unset defaults to <strong>' + (remote ? 'read' : 'write') + '</strong> for ' + (remote ? 'an access profile' : 'a local project') + '.</p>';
+    html += '</div>';
+
+    // Which tools — profiles only. A local project subtracts with the tool
+    // picker above; a profile enumerates, because a denylist grants every tool
+    // the MCP gains tomorrow.
+    if (remote) {
+        const patterns = projAllowedToolsText(f, mcpID);
+        html += '<div class="proj-perm-block">';
+        html += '<div class="proj-perm-label">Tools</div>';
+        html += '<p class="proj-section-help">One name or pattern per line, e.g. <code>mail_*</code>. Patterns are anchored — <code>mail_*</code> admits <code>mail_send</code> and not <code>xmail_send</code>. A bare <code>*</code> is refused: registering a new tool would silently widen the grant. <strong>Empty means no tools at all.</strong></p>';
+        html += '<textarea rows="3" placeholder="mail_*" oninput="setProjAllowedToolsText(\'' + esc(mcpID) + '\', this.value)">' + esc(patterns) + '</textarea>';
+        html += '</div>';
+    }
+
+    // Which resources.
+    const fields = mcpScopeFieldsFor(mcpID);
+    html += '<div class="proj-perm-block">';
+    html += '<div class="proj-perm-label">Resource scope</div>';
+    if (fields === null) {
+        html += '<p class="proj-section-help">Relay has not connected to this MCP, so it cannot say what may be narrowed. Anything this MCP scopes will be enforced at call time regardless — a grant with no value for a field it declares is <em>denied</em>, not unrestricted.</p>';
+    } else if (!fields.length) {
+        html += '<p class="proj-section-help">This MCP declares nothing narrowable. The grant is bounded by the tools and the mode above and by nothing else.</p>';
+    } else {
+        html += '<p class="proj-section-help">Each field below is declared by the MCP as one that <strong>restricts</strong> access. An empty value is not "no restriction" — it refuses every tool the field governs. There is no wildcard: to allow everything, list everything.</p>';
+        for (const field of fields) {
+            html += renderScopeFieldInput(mcpID, field, f);
+        }
+    }
+    html += '</div>';
+
+    html += '</div>';
+    return html;
+}
+
+// renderScopeFieldInput is the one place a scope field's CONTROL is chosen, so
+// swapping text entry for a `context/enumerate` picker (ADR-011 decision 6) is
+// a change to this function and nothing else.
+function renderScopeFieldInput(mcpID, field, f) {
+    const remote = isRemoteForm(f);
+    const typeLabel = field.type === 'array'
+        ? ('list of ' + (field.item_type || 'value') + 's, one per line')
+        : (field.type || 'value');
+    let html = '<div class="proj-scope-field">';
+    html += '<label>' + esc(field.name) + ' <span class="proj-scope-type">' + esc(typeLabel) + '</span></label>';
+    if (field.description) html += '<div class="proj-scope-desc">' + esc(field.description) + '</div>';
+
+    if (field.source === 'project_path') {
+        // Read-only, and it shows the DERIVED value rather than hiding the
+        // field: an operator has to be able to see that the bound exists
+        // without being able to type in it. Relay refuses an operator-supplied
+        // value for one of these outright — it would be overwritten by the
+        // next resync anyway.
+        const derived = ((f.context || {})[mcpID] || {})[field.name];
+        let shown, note;
+        if (remote) {
+            shown = '';
+            note = 'An access profile has no host directory, so relay derives nothing here and every tool this field governs'
+                + (field.applies_to && field.applies_to.length ? ' (' + field.applies_to.join(', ') + ')' : '')
+                + ' is refused. That is the intended outcome, not a gap to fill in.';
+        } else if (scopeValueIsSet(derived)) {
+            shown = scopeTextFromValue(field, derived);
+            note = 'Derived by relay from this project\'s path. Change the path to change it.';
+        } else {
+            shown = f.path || '';
+            note = 'Derived by relay from this project\'s path on save.';
+        }
+        html += '<input type="text" readonly value="' + esc(shown) + '" placeholder="(nothing derived)" />';
+        html += '<div class="proj-scope-desc">' + esc(note) + '</div>';
+        html += '</div>';
+        return html;
+    }
+
+    const text = projScopeText(f, mcpID, field);
+    if (field.type === 'array') {
+        html += '<textarea rows="3" oninput="setProjScopeText(\'' + esc(mcpID) + '\', \'' + esc(field.name) + '\', this.value)">' + esc(text) + '</textarea>';
+    } else {
+        html += '<input type="text" value="' + esc(text) + '" oninput="setProjScopeText(\'' + esc(mcpID) + '\', \'' + esc(field.name) + '\', this.value)" />';
+    }
+    if (!String(text).trim()) {
+        html += '<div class="proj-scope-missing">No value: every tool this field governs is denied at call time.</div>';
+    }
+    if (field.depends_on && field.depends_on.length) {
+        html += '<div class="proj-scope-desc">Values here are read within ' + esc(field.depends_on.join(', ')) + '.</div>';
+    }
+    html += '</div>';
+    return html;
+}
+
 function setProjModelsWildcard(checked) {
     const f = state.projectForm;
     if (!f) return;
@@ -1075,11 +1533,28 @@ function renderProjectForm() {
     if (!f) return '<div class="empty-state">No form state.</div>';
     const isNew = !f.id;
     const isRemote = isRemoteForm(f);
-    const title = isNew ? 'New Project' : 'Edit Project';
+    const noun = isRemote ? 'Access Profile' : 'Project';
+    const title = (isNew ? 'New ' : 'Edit ') + noun;
 
     let html = '<h2>' + esc(title) + '</h2>';
     if (state.projectFormError) {
         html += '<div class="proj-error">' + esc(state.projectFormError) + '</div>';
+    }
+    // The same gap the list names, named again here — this is the editor the
+    // operator would have to open to fix it, so it is the one place the
+    // sentence has to appear.
+    const formGaps = projScopeGaps({
+        kind: f.kind,
+        allowed_mcp_ids: f.allowed_mcp_ids,
+        context: harvestProjectPermissions(f).context,
+    });
+    if (formGaps.length) {
+        html += '<div class="proj-scope-gap">';
+        html += '<strong>A scope value is missing.</strong> Every tool the field governs is denied at call time until it is set — the client gets nothing, and nothing else says why.<ul>';
+        for (const g of formGaps) {
+            html += '<li><code>' + esc(g.mcp) + '</code>: ' + esc(g.fields.join(', ')) + '</li>';
+        }
+        html += '</ul></div>';
     }
 
     // ---- Kind ----
@@ -1091,11 +1566,11 @@ function renderProjectForm() {
     html += '<div class="proj-section-title">Kind</div>';
     if (isNew) {
         html += '<div class="perm-btns">';
-        html += '<button class="perm-btn ' + (!isRemote ? 'active' : '') + '" onclick="setProjKind(\'local\')">Local</button>';
-        html += '<button class="perm-btn ' + (isRemote ? 'active' : '') + '" onclick="setProjKind(\'remote\')">Remote</button>';
+        html += '<button class="perm-btn ' + (!isRemote ? 'active' : '') + '" onclick="setProjKind(\'local\')">Local project</button>';
+        html += '<button class="perm-btn ' + (isRemote ? 'active' : '') + '" onclick="setProjKind(\'remote\')">Access profile</button>';
         html += '</div>';
     } else {
-        html += '<div class="proj-kind-label">' + (isRemote ? 'Remote — capability grant to another machine' : 'Local — bound to a host directory') + '</div>';
+        html += '<div class="proj-kind-label">' + (isRemote ? 'Access profile — a capability grant to a client on another machine' : 'Local project — bound to a host directory') + '</div>';
         html += '<p class="proj-section-help">Kind can\'t be changed here after creation.</p>';
     }
     html += '</div>';
@@ -1103,28 +1578,28 @@ function renderProjectForm() {
     // ---- Identity ----
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Identity</div>';
-    html += '<label>Project name</label>';
-    html += '<input type="text" id="projName" value="' + esc(f.name) + '" placeholder="e.g. Acme Website" />';
+    html += '<label>' + (isRemote ? 'Profile name' : 'Project name') + '</label>';
+    html += '<input type="text" id="projName" value="' + esc(f.name) + '" placeholder="' + (isRemote ? 'e.g. Hermes — Bob INBOX (read-only)' : 'e.g. Acme Website') + '" />';
     if (!isRemote) {
         html += '<label>Project path</label>';
         html += '<input type="text" id="projPath" value="' + esc(f.path) + '" placeholder="/Users/you/projects/acme" />';
         html += '<p class="proj-section-help">Absolute path. Filesystem MCPs are auto-scoped to this directory.</p>';
     } else {
-        html += '<p class="proj-section-help">Remote projects are capability grants to an agent on another machine — they have no host directory, so path, directory auth, and skill generation don\'t apply.</p>';
+        html += '<p class="proj-section-help">An access profile is a capability grant to an agent on another machine. It has no host directory, so path, directory auth, skills, shell templates and models do not apply — what it carries is which MCPs, which tools, which operations and which resources.</p>';
     }
     html += '</div>';
 
     // ---- Allowed MCPs + tri-state picker ----
     const wild = !isRemote && isProjMcpWildcard(f);
     html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Allowed MCPs &amp; Tools</div>';
+    html += '<div class="proj-section-title">MCPs, Tools, Operations &amp; Resources</div>';
     if (!isRemote) {
         html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
         html += '<span>Allow all registered MCPs (wildcard <code>*</code>)</span>';
         html += '<label class="switch"><input type="checkbox" ' + (wild ? 'checked' : '') + ' onchange="setProjMcpWildcard(this.checked)" /><span class="slider"></span></label>';
         html += '</div>';
     } else {
-        html += '<p class="proj-section-help">Remote projects can\'t use the wildcard — list MCPs explicitly. Zero granted is a valid starting point; widen it deliberately later.</p>';
+        html += '<p class="proj-section-help">An access profile can\'t use the wildcard — list MCPs explicitly, because registering a new MCP on the host would otherwise silently widen what this client reaches. Zero granted is a valid starting point; widen it deliberately later.</p>';
     }
 
     if (!wild) {
@@ -1137,16 +1612,32 @@ function renderProjectForm() {
         }
         for (const mcp of registered) {
             const st = projMcpState(f, mcp.id);
+            const granted = f.allowed_mcp_ids.indexOf(mcp.id) >= 0;
             html += '<div class="proj-mcp-row">';
             html += '<span class="proj-mcp-name">' + esc(mcp.display_name || mcp.id) + ' <span style="color:var(--text-3);font-size:11px">(' + esc(mcp.id) + ')</span></span>';
             html += '<div class="perm-btns">';
-            html += '<button class="perm-btn ' + (st === 'all' ? 'active' : '') + '" onclick="setProjMcpState(\'' + esc(mcp.id) + '\', \'all\')">All tools</button>';
-            html += '<button class="perm-btn ' + (st === 'selected' ? 'active' : '') + '" onclick="setProjMcpState(\'' + esc(mcp.id) + '\', \'selected\')">Selected</button>';
-            html += '<button class="perm-btn ' + (st === 'none' ? 'active' : '') + '" onclick="setProjMcpState(\'' + esc(mcp.id) + '\', \'none\')">No tools</button>';
+            if (isRemote) {
+                // Two states, not three. The third one is a denylist, and a
+                // denylist grants every tool the MCP gains after the grant was
+                // written — the fail-open shape a grant to another machine must
+                // not have. What bounds a profile is the allowlist in the panel.
+                html += '<button class="perm-btn ' + (granted ? 'active' : '') + '" onclick="setProjMcpGranted(\'' + esc(mcp.id) + '\', true)">Granted</button>';
+                html += '<button class="perm-btn ' + (!granted ? 'active' : '') + '" onclick="setProjMcpGranted(\'' + esc(mcp.id) + '\', false)">Not granted</button>';
+            } else {
+                html += '<button class="perm-btn ' + (st === 'all' ? 'active' : '') + '" onclick="setProjMcpState(\'' + esc(mcp.id) + '\', \'all\')">All tools</button>';
+                html += '<button class="perm-btn ' + (st === 'selected' ? 'active' : '') + '" onclick="setProjMcpState(\'' + esc(mcp.id) + '\', \'selected\')">Selected</button>';
+                html += '<button class="perm-btn ' + (st === 'none' ? 'active' : '') + '" onclick="setProjMcpState(\'' + esc(mcp.id) + '\', \'none\')">No tools</button>';
+            }
             html += '</div>';
             html += '</div>';
-            if (st === 'selected') {
+            if (!isRemote && st === 'selected') {
                 html += renderProjToolPicker(mcp.id, f);
+            }
+            // Mode, tool allowlist and resource scope for every MCP this
+            // record actually grants — the three layers relay checks beneath
+            // the MCP itself.
+            if (granted) {
+                html += renderProjMcpPermissions(mcp.id, f);
             }
         }
         for (const id of dangling) {
@@ -1155,6 +1646,20 @@ function renderProjectForm() {
             html += '<button class="perm-btn" onclick="setProjMcpState(\'' + esc(id) + '\', \'none\')">Remove</button>';
             html += '</div>';
         }
+    } else {
+        // A wildcard grant still reaches every registered MCP, and a scope
+        // requirement is not waived by how the grant was spelled — ADR-011
+        // decision 4 applies to local projects too, which is why the live
+        // wildcard "Relay" project loses macMCP's mail tools until someone
+        // sets a value. The panel has to be reachable here or the editor
+        // would name a problem it offers no way to fix.
+        for (const mcp of state.externalMcps) {
+            html += '<div class="proj-mcp-row">';
+            html += '<span class="proj-mcp-name">' + esc(mcp.display_name || mcp.id) + ' <span style="color:var(--text-3);font-size:11px">(' + esc(mcp.id) + ')</span></span>';
+            html += '<span class="proj-mcp-name" style="color:var(--text-3)">granted by the wildcard</span>';
+            html += '</div>';
+            html += renderProjMcpPermissions(mcp.id, f);
+        }
     }
     html += '</div>';
 
@@ -1162,7 +1667,7 @@ function renderProjectForm() {
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Allowed Models</div>';
     if (isRemote) {
-        html += '<p class="proj-section-help">Not applicable to remote projects — the model allowlist stays empty.</p>';
+        html += '<p class="proj-section-help">Not applicable to an access profile — the model allowlist stays empty.</p>';
     } else {
         const modelsWild = isProjModelsWildcard(f);
         html += '<div class="toggle-row" style="padding:4px 0;margin:0">';
@@ -1178,9 +1683,16 @@ function renderProjectForm() {
     html += '</div>';
 
     // ---- Chat templates (read-only; relay stores them, Eve edits them) ----
+    // Absent for an access profile with none: a profile has no sessions to
+    // launch one from, so an empty section here is a heading that suggests a
+    // capability the record does not have. One that somehow carries templates
+    // still shows them — hiding stored data is worse than an odd heading.
+    if (!isRemote || f.chat_templates.length > 0) {
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Chat Templates</div>';
-    html += '<p class="proj-section-help">Project-scoped chat presets stored with the project. Create and edit them in Eve\'s project dialog, which offers live model selection.</p>';
+    html += '<p class="proj-section-help">' + (isRemote
+        ? 'An access profile has no chat sessions, so these are inert. They are shown because they are stored on the record.'
+        : 'Project-scoped chat presets stored with the project. Create and edit them in Eve\'s project dialog, which offers live model selection.') + '</p>';
     if (f.chat_templates.length === 0) {
         html += '<div class="proj-tool-empty">No templates yet.</div>';
     }
@@ -1193,12 +1705,15 @@ function renderProjectForm() {
         html += '</div>';
     }
     html += '</div>';
+    }
 
     // ---- Permission policy ----
     const pol = f.permission_policy;
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Permission Policy</div>';
-    html += '<p class="proj-section-help">Claude CLI permission gates. Empty mode inherits Claude\'s default. Patterns follow Claude\'s tool grammar (e.g. <code>Bash(ls *)</code>).</p>';
+    html += '<p class="proj-section-help">' + (isRemote
+        ? 'Claude CLI permission gates. An access profile launches no Claude session, so this is inert for one — what bounds a remote client is the mode, tools and scope above.'
+        : 'Claude CLI permission gates. Empty mode inherits Claude\'s default. Patterns follow Claude\'s tool grammar (e.g. <code>Bash(ls *)</code>).') + '</p>';
     html += '<label>Default mode</label>';
     html += '<select id="projPolicyMode" onchange="state.projectForm.permission_policy.default_mode = this.value">';
     for (const m of ['', 'default', 'acceptEdits', 'plan', 'bypassPermissions']) {
@@ -1361,11 +1876,66 @@ function harvestProjectForm() {
         allow_cwd_auth: isRemote ? false : f.allow_cwd_auth,
         disabled_tools: f.disabled_tools,
     };
+    // The ADR-011 permission set. Sent on every save, including when it is
+    // empty: these are pointer fields on the update DTO, so omitting one means
+    // "leave it alone" — which would make clearing a scope value from this
+    // editor impossible.
+    const perms = harvestProjectPermissions(f);
+    payload.access = perms.access;
+    payload.allowed_tools = perms.allowed_tools;
+    payload.context = perms.context;
     if (!isRemote) {
         const path = (document.getElementById('projPath') || {}).value || f.path;
         payload.path = path.trim();
     }
     return payload;
+}
+
+// harvestProjectPermissions turns the panel's typed text into the three maps
+// relay stores. Every value is validated on the server, whichever surface
+// produced it — this side is a convenience, never the check.
+//
+// Two things it deliberately does NOT do. It does not drop a context key it
+// cannot render: a field the MCP no longer declares, or one belonging to an
+// MCP relay has not connected to, is passed through untouched, because opening
+// the editor must not silently delete a value nobody looked at. And it does
+// not send a source: "project_path" field — relay derives those, refuses an
+// operator-supplied one, and would overwrite it on the next resync anyway.
+function harvestProjectPermissions(f) {
+    const remote = isRemoteForm(f);
+    const wild = f.allowed_mcp_ids.length === 1 && f.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD;
+    const granted = wild ? (state.externalMcps || []).map(m => m.id) : f.allowed_mcp_ids.slice();
+
+    const access = {};
+    const allowedTools = {};
+    const context = {};
+
+    for (const mcpID of granted) {
+        const mode = (f.access || {})[mcpID];
+        if (mode === 'read' || mode === 'write') access[mcpID] = mode;
+
+        if (remote) {
+            const text = projAllowedToolsText(f, mcpID);
+            const patterns = String(text).split('\n').map(t => t.trim()).filter(Boolean);
+            if (patterns.length) allowedTools[mcpID] = patterns;
+        } else if (((f.allowed_tools || {})[mcpID] || []).length) {
+            // A local project's tool narrowing is the picker above
+            // (disabled_tools); an allowlist here can only have arrived from
+            // eve or the API, so it is carried through rather than erased.
+            allowedTools[mcpID] = (f.allowed_tools[mcpID] || []).slice();
+        }
+
+        const existing = Object.assign({}, (f.context || {})[mcpID] || {});
+        const fields = mcpScopeFieldsFor(mcpID);
+        for (const field of (fields || [])) {
+            if (field.source === 'project_path') { delete existing[field.name]; continue; }
+            const value = scopeValueFromText(field, projScopeText(f, mcpID, field));
+            if (scopeValueIsSet(value)) existing[field.name] = value;
+            else delete existing[field.name];
+        }
+        if (Object.keys(existing).length) context[mcpID] = existing;
+    }
+    return { access: access, allowed_tools: allowedTools, context: context };
 }
 
 function saveProjectForm() {
@@ -1469,11 +2039,14 @@ window.onProjectError = function(msg) {
 // and that sentence is this tab's whole specification. Two consequences shape
 // everything below:
 //
-//   * Grants render as project NAMES. An operator deciding whether to revoke
-//     needs to know what they are cutting, not which opaque id it was stored
-//     under. A grant naming a project that no longer exists still renders — as
-//     the raw id, marked — because hiding it would hide the fact that the
-//     enrolment is holding something relay cannot resolve.
+//   * Grants render as access-profile NAMES, with the profile's EFFECTIVE
+//     AUTHORITY beside each one — MCPs, mode, tools, scope (ADR-011 decision
+//     1). Two records is the model, and the cost of two records is paid here:
+//     "what can this client do" has to be answerable without mentally joining
+//     an enrolment to a profile in another tab. A grant naming a profile that
+//     no longer exists still renders — as the raw id, marked — because hiding
+//     it would hide the fact that the enrolment is holding something relay
+//     cannot resolve.
 //   * The certificate fingerprint renders IN FULL. After an enrolment is
 //     deleted the fingerprint is the only thing that identifies that client's
 //     calls in the audit log, which is why the Tool Calls tab prints it
@@ -1497,9 +2070,10 @@ window.onProjectError = function(msg) {
 // actually likely to change here.
 const REMOTE_NOTE = 'Enabling, disabling and moving the listener take effect within a few seconds — no restart needed. Re-enabling auditing after turning it off is the exception: that still needs Relay to relaunch.';
 
-// remoteGrantableProjects is the only set the create form offers.
-// ValidateEnrolmentGrants refuses a grant naming a local project outright, so
-// presenting one would be offering a choice relay is about to reject. This is
+// remoteGrantableProjects is the only set the create form offers: the access
+// profiles. ValidateEnrolmentGrants refuses a grant naming a local project
+// outright, so presenting one would be offering a choice relay is about to
+// reject. This is
 // a courtesy, not the enforcement — the server validates regardless, inside
 // the same store.With that claims the client id.
 function remoteGrantableProjects() {
@@ -1512,7 +2086,7 @@ function remoteGrantableProjects() {
 function enrolGrantNames(e) {
     return ((e && e.project_ids) || []).map(function(id) {
         const p = (state.projects || []).find(x => x.id === id);
-        return { id: id, name: p ? p.name : null };
+        return { id: id, name: p ? p.name : null, profile: p || null };
     });
 }
 
@@ -1520,8 +2094,8 @@ function enrolGrantNames(e) {
 // The confirmation names what is being cut; "are you sure?" over an opaque id
 // is not a decision anyone can make.
 function enrolGrantSummary(e) {
-    const names = enrolGrantNames(e).map(g => g.name || (g.id + ' (unknown project)'));
-    if (!names.length) return 'no projects — this enrolment grants nothing today';
+    const names = enrolGrantNames(e).map(g => g.name || (g.id + ' (unknown access profile)'));
+    if (!names.length) return 'no access profiles — this enrolment grants nothing today';
     return names.join(', ');
 }
 
@@ -1545,7 +2119,7 @@ function renderEnrolments() {
 
     let html = '<div class="page-header"><h2>Remote Clients</h2>';
     html += '<button class="btn btn-primary" onclick="newEnrolment()">+ New Enrolment</button></div>';
-    html += '<p class="page-intro">An enrolment binds one client certificate to the remote projects it may use. The certificate <em>is</em> the identity — there is no bearer token on this path, so a copy of <code>settings.json</code> grants no remote access at all. Enrolments are keyed by certificate, not by machine: several agents on one VM each hold their own, granted and revoked independently.</p>';
+    html += '<p class="page-intro">An enrolment binds one client certificate to the access profiles it may use. The certificate <em>is</em> the identity — there is no bearer token on this path, so a copy of <code>settings.json</code> grants no remote access at all. Enrolments are keyed by certificate, not by machine: several agents on one VM each hold their own, granted and revoked independently.</p>';
 
     if (state.enrolBundle) html += renderEnrolBundleBanner(state.enrolBundle);
     if (state.enrolRevoked) {
@@ -1566,19 +2140,23 @@ function renderEnrolments() {
 
         // Grants, by name. A card that showed ids would make the revoke
         // decision unanswerable without a second tab open beside it.
-        html += '<div class="enrol-grants">';
         const grants = enrolGrantNames(e);
         if (!grants.length) {
-            html += '<span class="enrol-grant none">no projects granted</span>';
+            html += '<div class="enrol-grants"><span class="enrol-grant none">no access profiles granted</span></div>';
         }
         for (const g of grants) {
-            if (g.name) {
-                html += '<span class="enrol-grant" title="' + esc(g.id) + '">' + esc(g.name) + '</span>';
-            } else {
-                html += '<span class="enrol-grant dangling" title="No project carries this id">' + esc(g.id) + ' — unknown project</span>';
+            if (!g.name) {
+                html += '<div class="enrol-grants"><span class="enrol-grant dangling" title="No access profile carries this id">' + esc(g.id) + ' — unknown access profile</span></div>';
+                continue;
             }
+            // The profile's name, and then what it actually permits. A card
+            // that stopped at the name answers "which grant" and leaves "what
+            // can this client do" to a second tab.
+            html += '<div class="enrol-profile">';
+            html += '<div class="enrol-grants"><span class="enrol-grant" title="' + esc(g.id) + '">' + esc(g.name) + '</span></div>';
+            html += '<div class="proj-authority">' + renderAuthorityRows(g.profile) + '</div>';
+            html += '</div>';
         }
-        html += '</div>';
 
         html += '<div class="enrol-meta">';
         html += '<span>Budget: <strong>' + esc(enrolBudgetText(e.budget)) + '</strong></span>';
@@ -1627,11 +2205,11 @@ function renderEnrolmentForm() {
 
     // ---- Grants ----
     html += '<div class="proj-section">';
-    html += '<div class="proj-section-title">Granted Projects</div>';
-    html += '<p class="proj-section-help">Only <strong>remote</strong> projects can be granted. A remote client granted a local project would inherit that project\'s host-directory scope, so the grant is refused outright — this list offers nothing that would be refused.</p>';
+    html += '<div class="proj-section-title">Granted Access Profiles</div>';
+    html += '<p class="proj-section-help">Only <strong>access profiles</strong> can be granted. A remote client granted a local project would inherit that project\'s host-directory scope, so the grant is refused outright — this list offers nothing that would be refused.</p>';
     const grantable = remoteGrantableProjects();
     if (!grantable.length) {
-        html += '<div class="proj-tool-empty">No remote projects exist yet. Create one in the <strong>Projects</strong> tab (Kind → Remote) first.</div>';
+        html += '<div class="proj-tool-empty">No access profiles exist yet. Create one in the <strong>Projects</strong> tab (Kind → Access profile) first.</div>';
     }
     for (const p of grantable) {
         const checked = f.project_ids.indexOf(p.id) >= 0;
@@ -1645,7 +2223,7 @@ function renderEnrolmentForm() {
         // legal and is the expected "enrol now, widen deliberately later"
         // resting state. Say so rather than emitting a certificate that
         // silently reaches nothing.
-        html += '<p class="proj-section-help">No grant selected: this client will be enrolled but can reach no project until one is added.</p>';
+        html += '<p class="proj-section-help">No grant selected: this client will be enrolled but can reach no access profile until one is added.</p>';
     }
     html += '</div>';
 
@@ -3198,5 +3776,6 @@ render();
 Object.assign(window, {
     auditCaller, auditDetail, auditFmtTime, auditMatches, auditPretty, auditSelect, auditVisible, exportAudit, queryAudit, renderAudit, renderAuditDetail, renderAuditRow, restoreAuditFocus, revealAuditLog, setAuditFilter, toggleAuditFollow, toggleAuditRow,
     cancelEnrolment, dismissEnrolBundle, enrolBudgetText, enrolBytes, enrolGrantNames, enrolGrantSummary, newEnrolment, remoteDraft, remoteDraftSet, remoteGrantableProjects, remoteListenIsLoopback, removeRemoteConfig, renderEnrolBundleBanner, renderEnrolmentForm, renderEnrolments, renderRemoteListener, revokeEnrolment, saveEnrolment, saveRemoteConfig, toggleEnrolGrant,
+    harvestProjectPermissions, mcpScopeFieldsFor, projAccessMode, projAllowedToolPatterns, projAllowedToolsText, projAuthorityRows, projFormAccessMode, projGrantedMcpIds, projMissingScopeFields, projNoun, projScopeGaps, projScopeText, projScopeValue, projToolAuthorityText, renderAuthorityRows, renderProjMcpPermissions, renderScopeFieldInput, renderScopeGapBanner, scopeTextFromValue, scopeValueFromText, scopeValueIsSet, scopeValueText, setProjAccess, setProjAllowedToolsText, setProjMcpGranted, setProjScopeText,
     addExternalMcp, addExternalMcpFromJson, addExternalMcpHttp, addService, authenticateMcp, blankProjectForm, cancelMcpEdit, cancelProjectEdit, cancelServiceEdit, cfgArrayAdd, cfgArrayRemove, cfgBind, cfgChevron, cfgDirty, cfgEdit, cfgEditJson, cfgExpandKey, cfgFieldAt, cfgFirstMissingRequired, cfgGetDraft, cfgHasBadJson, cfgIsExpanded, cfgKvAdd, cfgKvRemove, cfgKvRename, cfgKvSetVal, cfgKvState, cfgMapAdd, cfgMapRemove, cfgMapRename, cfgNodeLabel, cfgRefreshChrome, cfgRerender, cfgSetExpanded, cfgToggleExpand, copyProjectToken, dispatchConfigOp, dispatchServiceAction, editProject, editService, harvestProjectForm, ipc, isAnyActionPending, isProjMcpWildcard, isProjModelsWildcard, isRemoteForm, isRemoteProject, newMcp, newProject, newService, projMcpState, projectFormFromExisting, pruneStaleDisabledTool, regenProjectSkill, removeExternalMcp, removeProject, removeService, render, renderActionButton, renderArrayBlock, renderConfigArray, renderConfigItem, renderConfigKeyValue, renderConfigLeaf, renderConfigMap, renderConfigNode, renderConfigObject, renderConfigSection, renderMcpForm, renderMcpPush, renderMcpServers, renderObjectFields, renderProjToolPicker, renderProjectForm, renderProjects, renderServiceForm, renderServiceInspector, renderServicePanel, renderServiceStatus, renderServices, renderStatusPayload, resetMcpPermissions, revertConfig, rotateProjectToken, saveConfig, saveProjectForm, saveServiceEdit, serviceBadgeHTML, setMcpAddMode, setMcpTransport, setProjKind, setProjMcpState, setProjMcpWildcard, setProjModelsWildcard, setsEqual, showPage, svcFormValues, toggleConfigSection, toggleProjTool, toggleProjectTokenVisible, toggleServiceRunning, updateServiceAutostart, updateServiceStatusDOM});
 window.state = state;

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -81,6 +81,17 @@ let state = {
     projectError: null,
     rotatingProjectId: null,
 
+    // The enumeration picker (ADR-011 decision 6). Enumeration is a LIVE call
+    // into another process, so none of this is populated by a paint: a list is
+    // fetched when an operator opens the control and cached for the life of
+    // the form, keyed on (mcp, field, dependency values) — a mailbox list read
+    // within Bob is not an answer about Alice.
+    scopeEnum: {},            // key -> ContextEnumResult (see scopeEnumKey)
+    scopeEnumReq: {},         // "mcp\0field" -> the key of the in-flight request
+    scopeEnumOpen: {},        // "mcp\0field" -> bool (the operator opened it)
+    scopeEnumUnsupported: {}, // mcpId -> true once it answered -32601, permanently
+    _scopeBind: [],           // per-render bindings from a checkbox to its value
+
     // Remote Clients tab. Enrolments and the remote block are seeded by the
     // initial payload like projects are — the list is one row per enrolled
     // certificate, and a credential you cannot see is one you will not revoke,
@@ -1496,10 +1507,16 @@ function renderScopeFieldInput(mcpID, field, f) {
     }
 
     const text = projScopeText(f, mcpID, field);
-    if (field.type === 'array') {
-        html += '<textarea rows="3" oninput="setProjScopeText(\'' + esc(mcpID) + '\', \'' + esc(field.name) + '\', this.value)">' + esc(text) + '</textarea>';
+    // A picker over real values wherever the MCP says it can list them, and the
+    // text box everywhere else — including for an MCP that answered "I do not
+    // implement that", which is a permanent, silent degrade for that MCP.
+    if (field.enumerable && !state.scopeEnumUnsupported[mcpID]) {
+        html += renderScopeFieldPicker(mcpID, field, f, text);
     } else {
-        html += '<input type="text" value="' + esc(text) + '" oninput="setProjScopeText(\'' + esc(mcpID) + '\', \'' + esc(field.name) + '\', this.value)" />';
+        html += renderScopeFieldTextInput(mcpID, field, text);
+        if (field.enumerable) {
+            html += '<div class="proj-scope-desc">' + esc(mcpID) + ' cannot list this field\'s values, so it is typed by hand. Spelling counts: a value that matches nothing refuses every tool the field governs, silently.</div>';
+        }
     }
     if (!String(text).trim()) {
         html += '<div class="proj-scope-missing">No value: every tool this field governs is denied at call time.</div>';
@@ -1509,6 +1526,305 @@ function renderScopeFieldInput(mcpID, field, f) {
     }
     html += '</div>';
     return html;
+}
+
+// renderScopeFieldTextInput is the free-text control, which is both the
+// non-enumerable case and the fallback for every way enumeration can fail. It
+// is deliberately the SAME storage as the picker — see setProjScopeText — so
+// the two controls are interchangeable and a value typed here survives the
+// picker appearing later, and vice versa.
+function renderScopeFieldTextInput(mcpID, field, text) {
+    if (field.type === 'array') {
+        return '<textarea rows="3" oninput="setProjScopeText(\'' + esc(mcpID) + '\', \'' + esc(field.name) + '\', this.value)">' + esc(text) + '</textarea>';
+    }
+    return '<input type="text" value="' + esc(text) + '" oninput="setProjScopeText(\'' + esc(mcpID) + '\', \'' + esc(field.name) + '\', this.value)" />';
+}
+
+// ---------------------------------------------------------------------------
+// The enumeration picker (ADR-011 decision 6)
+//
+// The picker is a CONTROL OVER THE SAME VALUE the text box edits. It reads
+// scopeValueFromText and writes back through setProjScopeText, so harvest,
+// clearing, validation and the "needs a scope value" banner all keep working
+// unchanged, and an operator can move between the two without either one
+// losing what the other set.
+//
+// That is also what makes the most important behaviour here free: a stored
+// value the MCP no longer offers is IN the value already, so it is rendered as
+// a selected, flagged entry rather than silently dropped. An account renamed
+// on the host must not quietly widen or narrow a profile by disappearing from
+// a form.
+// ---------------------------------------------------------------------------
+
+// scopeEnumValueKey is the identity of one offered value. Strings are the
+// declared subset's shape; anything else is compared by its JSON, which is
+// honest about a shape this UI does not model.
+function scopeEnumValueKey(v) {
+    return typeof v === 'string' ? v : JSON.stringify(v);
+}
+
+// scopeDependencyValues mirrors dependencyValues on the Go side: the fields
+// THIS one declares in depends_on, and only those with a value.
+//
+// Dropping an empty one is the load-bearing half. The picker's normal opening
+// state is mail_mailboxes with mail_accounts still unchosen, and a request
+// carrying {"mail_accounts": []} invites a server to read it as "match
+// nothing" — an empty picker at exactly the moment an operator opens one, and
+// indistinguishable from a host with no mailboxes. Relay drops it again on the
+// way out; this side is what keeps the CACHE KEY the same for "unchosen"
+// however the emptiness is spelled.
+function scopeDependencyValues(f, mcpID, field) {
+    const out = {};
+    const fields = mcpScopeFieldsFor(mcpID) || [];
+    for (const dep of (field.depends_on || [])) {
+        const depField = fields.find(x => x.name === dep);
+        if (!depField) continue;
+        const v = scopeValueFromText(depField, projScopeText(f, mcpID, depField));
+        if (scopeValueIsSet(v)) out[dep] = v;
+    }
+    return out;
+}
+
+// scopeEnumKey identifies one answer: an MCP, a field, and the dependency
+// values it was read within. The dependencies are in the key because changing
+// the account choice must invalidate the mailbox list rather than leave a
+// stale one on screen under a new account's name.
+function scopeEnumKey(mcpID, fieldName, deps) {
+    return mcpID + ' ' + fieldName + ' ' + JSON.stringify(deps || {});
+}
+
+function scopeOpenKey(mcpID, fieldName) { return mcpID + ' ' + fieldName; }
+
+function scopeFieldIsOpen(mcpID, fieldName) {
+    return !!state.scopeEnumOpen[scopeOpenKey(mcpID, fieldName)];
+}
+
+// requestScopeEnum fires at most one live call per (mcp, field, dependency
+// values) for the life of the form. It is never called from a paint or a
+// keystroke — only from opening the control, from a retry, and from a change
+// to a field something else depends on.
+function requestScopeEnum(mcpID, field, force) {
+    const f = state.projectForm;
+    if (!f) return;
+    if (state.scopeEnumUnsupported[mcpID]) return;
+    const deps = scopeDependencyValues(f, mcpID, field);
+    const key = scopeEnumKey(mcpID, field.name, deps);
+    const openKey = scopeOpenKey(mcpID, field.name);
+    if (!force) {
+        if (Object.prototype.hasOwnProperty.call(state.scopeEnum, key)) return; // cached
+        if (state.scopeEnumReq[openKey] === key) return;                        // in flight
+    }
+    delete state.scopeEnum[key];
+    state.scopeEnumReq[openKey] = key;
+    ipc(JSON.stringify({ type: 'enumerate_scope_field', mcp_id: mcpID, field: field.name, values: deps }));
+}
+
+function scopeFieldByName(mcpID, fieldName) {
+    return (mcpScopeFieldsFor(mcpID) || []).find(x => x.name === fieldName) || null;
+}
+
+function toggleScopeFieldPicker(mcpID, fieldName) {
+    const field = scopeFieldByName(mcpID, fieldName);
+    if (!field) return;
+    captureProjectFormInputs();
+    const openKey = scopeOpenKey(mcpID, fieldName);
+    state.scopeEnumOpen[openKey] = !state.scopeEnumOpen[openKey];
+    if (state.scopeEnumOpen[openKey]) requestScopeEnum(mcpID, field);
+    render();
+}
+
+function retryScopeEnum(mcpID, fieldName) {
+    const field = scopeFieldByName(mcpID, fieldName);
+    if (!field) return;
+    captureProjectFormInputs();
+    requestScopeEnum(mcpID, field, true);
+    render();
+}
+
+// refreshDependentScopeFields re-asks for every OPEN field that declares the
+// changed one in depends_on. This is what makes dependency order real rather
+// than decorative: choosing an account changes which mailboxes exist, and a
+// list that did not move would be a picker offering another account's values.
+function refreshDependentScopeFields(mcpID, changedField) {
+    for (const field of (mcpScopeFieldsFor(mcpID) || [])) {
+        if (!field.enumerable) continue;
+        if (!(field.depends_on || []).includes(changedField)) continue;
+        if (!scopeFieldIsOpen(mcpID, field.name)) continue;
+        requestScopeEnum(mcpID, field);
+    }
+}
+
+// scopeSelectedValues is what the field currently holds, as a list, whichever
+// control produced it.
+function scopeSelectedValues(field, text) {
+    const v = scopeValueFromText(field, text);
+    if (Array.isArray(v)) return v;
+    return scopeValueIsSet(v) ? [v] : [];
+}
+
+// unrecognisedScopeValues names the stored values the MCP did not offer. It
+// answers only when there IS an answer to compare against — an empty list from
+// a failed call would flag every stored value as unrecognised, which is the
+// same lie as rendering the failure as "there are none".
+function unrecognisedScopeValues(selected, offered) {
+    const known = new Set((offered || []).map(o => scopeEnumValueKey(o.value)));
+    return selected.filter(v => !known.has(scopeEnumValueKey(v)));
+}
+
+function renderScopeFieldPicker(mcpID, field, f, text) {
+    const selected = scopeSelectedValues(field, text);
+    const open = scopeFieldIsOpen(mcpID, field.name);
+    const deps = scopeDependencyValues(f, mcpID, field);
+    const key = scopeEnumKey(mcpID, field.name, deps);
+    const res = state.scopeEnum[key];
+    const pending = !res && state.scopeEnumReq[scopeOpenKey(mcpID, field.name)] === key;
+    const args = '\'' + esc(mcpID) + '\', \'' + esc(field.name) + '\'';
+
+    // Always visible, open or closed: what is stored is what confines the
+    // client, so it never sits behind a control someone has to open.
+    let html = '<div class="proj-scope-summary">' + (selected.length
+        ? esc(selected.map(scopeEnumValueKey).join(', '))
+        : '<span class="proj-scope-none">nothing selected — every tool this field governs is refused</span>') + '</div>';
+
+    const unknown = (res && res.status === 'ok') ? unrecognisedScopeValues(selected, res.values) : [];
+    if (unknown.length) {
+        html += '<div class="proj-scope-unrecognised">' + esc(mcpID) + ' does not offer ' + esc(unknown.map(scopeEnumValueKey).join(', '))
+            + '. Kept and still in force — it may have been renamed on the host, or this MCP may be reading a different one. Untick it to remove it.</div>';
+    }
+
+    html += '<button class="btn btn-sm" onclick="toggleScopeFieldPicker(' + args + ')">'
+        + (open ? 'Done' : 'Choose values…') + '</button>';
+    if (!open) return html;
+
+    if (pending) return html + '<div class="proj-scope-pending">Listing values from ' + esc(mcpID) + '…</div>';
+    if (!res) {
+        // Open, with no answer for THESE dependency values: something the list
+        // is read within was edited by hand since it was last asked. Offered as
+        // a button rather than fetched from here, because a paint must never
+        // start a live call — a re-render loop would be one call per frame.
+        return html + '<div class="proj-scope-pending">The values this list is read within have changed.</div>'
+            + '<button class="btn btn-sm" onclick="retryScopeEnum(' + args + ')">List values</button>';
+    }
+
+    if (res.status === 'ok') {
+        return html + renderScopeChoices(mcpID, field, selected, res.values, unknown, deps);
+    }
+
+    // Every remaining status keeps the text box, so an operator is never
+    // blocked by an MCP that will not answer — and none of them renders as an
+    // empty list of values, which would read as "there are none".
+    if (res.status === 'invalid_field' || res.status === 'not_enumerable') {
+        html += '<div class="proj-scope-failed">Relay asked ' + esc(mcpID) + ' for values it will not enumerate, which is a bug in relay rather than in this profile'
+            + (res.error ? ': ' + esc(res.error) : '.') + ' Type the values instead — they are stored and enforced exactly the same way.</div>';
+    } else if (res.status === 'unsupported') {
+        html += '<div class="proj-scope-desc">' + esc(mcpID) + ' cannot list this field\'s values.</div>';
+    } else {
+        html += '<div class="proj-scope-failed">Could not list values from ' + esc(mcpID) + ' just now'
+            + (res.error ? ': ' + esc(res.error) : '.')
+            + ' This is not an empty list — nothing was read. Retry, or type the values.</div>';
+        html += '<button class="btn btn-sm" onclick="retryScopeEnum(' + args + ')">Try again</button>';
+    }
+    return html + renderScopeFieldTextInput(mcpID, field, text);
+}
+
+// renderScopeChoices draws one row per offered value, plus one per stored
+// value the MCP did not offer — checked, flagged, and removable only by an
+// explicit untick.
+//
+// Values reach their handler through an index into a per-render binding array
+// rather than through the onclick attribute. Mailbox names carry quotes,
+// apostrophes and emoji, and building a JS string literal out of one in an
+// HTML attribute is how a mailbox called `a'); doSomething('` becomes a bug.
+function renderScopeChoices(mcpID, field, selected, offered, unknown, deps) {
+    const multi = field.type === 'array';
+    const rows = [];
+    const byKey = {};
+    const push = (value, label, isUnknown) => {
+        const k = scopeEnumValueKey(value);
+        // One value is one choice, however many times it was offered. A
+        // cross-product scope makes duplicates normal — every account has an
+        // INBOX, and the mailbox value is account-independent — and two boxes
+        // holding the same value would tick and untick together, which reads
+        // as a bug. The labels are joined instead, because each said something
+        // true about where the value came from.
+        if (byKey[k]) {
+            if (label && byKey[k].labels.indexOf(label) < 0) byKey[k].labels.push(label);
+            return;
+        }
+        byKey[k] = { value: value, labels: [label], unknown: isUnknown };
+        rows.push(byKey[k]);
+    };
+    for (const v of unknown) push(v, scopeEnumValueKey(v), true);
+    for (const o of (offered || [])) push(o.value, o.label || scopeEnumValueKey(o.value), false);
+    for (const row of rows) row.label = row.labels.join(' · ');
+
+    if (!rows.length) {
+        return '<div class="proj-scope-desc">' + esc(mcpID) + ' offers no values for this field'
+            + (Object.keys(deps).length ? ' within the values chosen above' : '')
+            + '. That is its answer, not a failure — there is nothing here to grant.</div>';
+    }
+
+    const selectedKeys = new Set(selected.map(scopeEnumValueKey));
+    let html = '<div class="proj-scope-choices">';
+    for (const row of rows) {
+        const idx = state._scopeBind.length;
+        state._scopeBind.push({ mcpID: mcpID, field: field.name, value: row.value });
+        const checked = selectedKeys.has(scopeEnumValueKey(row.value)) ? ' checked' : '';
+        html += '<div class="proj-scope-choice' + (row.unknown ? ' unrecognised' : '') + '">';
+        html += '<input type="' + (multi ? 'checkbox' : 'radio') + '" name="scope-' + esc(mcpID) + '-' + esc(field.name) + '"'
+            + checked + ' onchange="toggleProjScopeValueAt(' + idx + ', this.checked)" />';
+        html += '<label>' + esc(row.label) + '</label>';
+        if (row.unknown) html += '<span class="desc">not offered by this MCP</span>';
+        html += '</div>';
+    }
+    html += '</div>';
+    return html;
+}
+
+// toggleProjScopeValueAt writes the choice back through the SAME text the box
+// edits, so nothing else in the editor has to know a picker exists.
+function toggleProjScopeValueAt(index, checked) {
+    const bind = state._scopeBind[index];
+    if (!bind) return;
+    const f = state.projectForm;
+    if (!f) return;
+    const field = scopeFieldByName(bind.mcpID, bind.field);
+    if (!field) return;
+    captureProjectFormInputs();
+
+    const current = scopeSelectedValues(field, projScopeText(f, bind.mcpID, field));
+    const key = scopeEnumValueKey(bind.value);
+    let next;
+    if (field.type === 'array') {
+        next = current.filter(v => scopeEnumValueKey(v) !== key);
+        if (checked) next.push(bind.value);
+    } else {
+        next = checked ? [bind.value] : [];
+    }
+    setProjScopeText(bind.mcpID, bind.field, scopeTextFromValue(field, field.type === 'array' ? next : (next[0] !== undefined ? next[0] : '')));
+    // Anything read WITHIN this field is now reading within something else.
+    refreshDependentScopeFields(bind.mcpID, bind.field);
+    render();
+}
+
+// captureProjectFormInputs writes back the values that live only in the DOM.
+//
+// It exists because the picker repaints the form from an ASYNCHRONOUS event —
+// an enumeration answer arriving — and a repaint rebuilds every input from
+// state.projectForm. The name and path are read from the DOM at harvest and
+// nowhere else, so without this a list arriving while someone was typing a
+// name would erase what they had typed. Empty is treated as "leave it", the
+// same guard harvestProjectForm already uses, so a field the browser has not
+// rendered cannot blank a stored value.
+function captureProjectFormInputs() {
+    const f = state.projectForm;
+    if (!f) return;
+    const val = id => {
+        const el = document.getElementById(id);
+        return el && typeof el.value === 'string' ? el.value : '';
+    };
+    f.name = val('projName') || f.name;
+    if (!isRemoteForm(f)) f.path = val('projPath') || f.path;
 }
 
 function setProjModelsWildcard(checked) {
@@ -1531,6 +1847,10 @@ function isProjModelsWildcard(f) {
 function renderProjectForm() {
     const f = state.projectForm;
     if (!f) return '<div class="empty-state">No form state.</div>';
+    // Rebuilt every render: a scope choice reaches its handler as an index
+    // into this, never as a value interpolated into an onclick attribute.
+    // Mailbox names carry quotes, apostrophes and emoji.
+    state._scopeBind = [];
     const isNew = !f.id;
     const isRemote = isRemoteForm(f);
     const noun = isRemote ? 'Access Profile' : 'Project';
@@ -1683,15 +2003,16 @@ function renderProjectForm() {
     html += '</div>';
 
     // ---- Chat templates (read-only; relay stores them, Eve edits them) ----
-    // Absent for an access profile with none: a profile has no sessions to
-    // launch one from, so an empty section here is a heading that suggests a
-    // capability the record does not have. One that somehow carries templates
-    // still shows them — hiding stored data is worse than an odd heading.
+    // Absent for an access profile, because the model now REFUSES one on a
+    // remote record rather than storing an inert copy (validateProjectShape).
+    // A record that still carries templates from an earlier life is the one
+    // exception: it is shown, and told what saving will do, because hiding
+    // stored data an operator is about to lose is worse than an odd heading.
     if (!isRemote || f.chat_templates.length > 0) {
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Chat Templates</div>';
     html += '<p class="proj-section-help">' + (isRemote
-        ? 'An access profile has no chat sessions, so these are inert. They are shown because they are stored on the record.'
+        ? 'An access profile has no chat sessions, so relay refuses chat templates on one. These are stored from before that rule; <strong>saving this profile removes them.</strong>'
         : 'Project-scoped chat presets stored with the project. Create and edit them in Eve\'s project dialog, which offers live model selection.') + '</p>';
     if (f.chat_templates.length === 0) {
         html += '<div class="proj-tool-empty">No templates yet.</div>';
@@ -1708,12 +2029,22 @@ function renderProjectForm() {
     }
 
     // ---- Permission policy ----
+    // Absent for an access profile, for the same reason the skill toggle and
+    // directory auth are: the model refuses it now, so a control here would be
+    // one whose only outcome is a refusal on Save. A profile that still
+    // carries a policy is told, because saving clears it.
     const pol = f.permission_policy;
+    if (isRemote) {
+        if (!isPolicyEmpty(pol)) {
+            html += '<div class="proj-section">';
+            html += '<div class="proj-section-title">Permission Policy</div>';
+            html += '<p class="proj-section-help">Claude CLI permission gates, stored from before relay refused them on an access profile. A profile launches no Claude session, so they gate nothing; what bounds a remote client is the operations, tools and resources above. <strong>Saving this profile removes them.</strong></p>';
+            html += '</div>';
+        }
+    } else {
     html += '<div class="proj-section">';
     html += '<div class="proj-section-title">Permission Policy</div>';
-    html += '<p class="proj-section-help">' + (isRemote
-        ? 'Claude CLI permission gates. An access profile launches no Claude session, so this is inert for one — what bounds a remote client is the mode, tools and scope above.'
-        : 'Claude CLI permission gates. Empty mode inherits Claude\'s default. Patterns follow Claude\'s tool grammar (e.g. <code>Bash(ls *)</code>).') + '</p>';
+    html += '<p class="proj-section-help">Claude CLI permission gates. Empty mode inherits Claude\'s default. Patterns follow Claude\'s tool grammar (e.g. <code>Bash(ls *)</code>).</p>';
     html += '<label>Default mode</label>';
     html += '<select id="projPolicyMode" onchange="state.projectForm.permission_policy.default_mode = this.value">';
     for (const m of ['', 'default', 'acceptEdits', 'plan', 'bypassPermissions']) {
@@ -1726,6 +2057,7 @@ function renderProjectForm() {
     html += '<label>Denied tools (one per line)</label>';
     html += '<textarea id="projDeniedTools" rows="3" placeholder="Bash(rm *)&#10;Write">' + esc(pol.denied_tools.join('\n')) + '</textarea>';
     html += '</div>';
+    }
 
     // ---- Skill ----
     // Skills are written under <path>/.claude/skills — no path, no skill, so
@@ -1839,6 +2171,14 @@ function pruneStaleDisabledTool(mcpID, name, kept) {
     render();
 }
 
+// isPolicyEmpty mirrors permissionPolicyIsEmpty on the Go side. Both surfaces
+// have to agree that an emptied policy is not a policy, or the editor would
+// send something the model refuses on a record it just cleared.
+function isPolicyEmpty(pol) {
+    if (!pol) return true;
+    return !pol.default_mode && (pol.allowed_tools || []).length === 0 && (pol.denied_tools || []).length === 0;
+}
+
 function harvestProjectForm() {
     const f = state.projectForm;
     if (!f) return null;
@@ -1854,16 +2194,25 @@ function harvestProjectForm() {
         const csv = (document.getElementById('projModels') || {}).value || '';
         allowedModels = csv.split(',').map(s => s.trim()).filter(Boolean);
     }
-    const allowedToolsTA = document.getElementById('projAllowedTools');
-    const deniedToolsTA = document.getElementById('projDeniedTools');
-    const policy = {
-        default_mode: f.permission_policy.default_mode,
-        allowed_tools: allowedToolsTA ? allowedToolsTA.value.split('\n').map(s => s.trim()).filter(Boolean) : f.permission_policy.allowed_tools,
-        denied_tools: deniedToolsTA ? deniedToolsTA.value.split('\n').map(s => s.trim()).filter(Boolean) : f.permission_policy.denied_tools,
-    };
+    // An access profile sends an EMPTY policy rather than the one it may still
+    // carry: relay refuses a policy on a remote record, and this is the form
+    // that has to be able to clear one. An empty policy is read as "clear it"
+    // on both sides (permissionPolicyIsEmpty / isPolicyEmpty).
+    let policy = { default_mode: '', allowed_tools: [], denied_tools: [] };
+    if (!isRemote) {
+        const allowedToolsTA = document.getElementById('projAllowedTools');
+        const deniedToolsTA = document.getElementById('projDeniedTools');
+        policy = {
+            default_mode: f.permission_policy.default_mode,
+            allowed_tools: allowedToolsTA ? allowedToolsTA.value.split('\n').map(s => s.trim()).filter(Boolean) : f.permission_policy.allowed_tools,
+            denied_tools: deniedToolsTA ? deniedToolsTA.value.split('\n').map(s => s.trim()).filter(Boolean) : f.permission_policy.denied_tools,
+        };
+    }
     // chat_templates is intentionally absent: the form is read-only for
     // templates (Eve owns editing), and omitting the field makes
-    // update_project leave the stored list untouched.
+    // update_project leave the stored list untouched. The one exception is a
+    // profile that still carries some — relay refuses those now, so the field
+    // has to be SENT as empty or the record could never be saved again.
     const payload = {
         name: name.trim(),
         kind: isRemote ? 'remote' : 'local',
@@ -1876,14 +2225,25 @@ function harvestProjectForm() {
         allow_cwd_auth: isRemote ? false : f.allow_cwd_auth,
         disabled_tools: f.disabled_tools,
     };
+    if (isRemote && f.chat_templates.length > 0) payload.chat_templates = [];
     // The ADR-011 permission set. Sent on every save, including when it is
     // empty: these are pointer fields on the update DTO, so omitting one means
     // "leave it alone" — which would make clearing a scope value from this
     // editor impossible.
+    //
+    // Unless the three maps could not be BUILT, which is a different thing
+    // from being empty. Under a wildcard grant their keys come from relay's
+    // MCP list, of which this side holds only a copy; if that copy is missing
+    // the harvest produces {} for all three — indistinguishable, on the wire,
+    // from an operator clearing every mode, every tool allowlist and every
+    // scope value. Omitting them lets the update path's nil-means-no-change
+    // convention do the right thing, which is nothing.
     const perms = harvestProjectPermissions(f);
-    payload.access = perms.access;
-    payload.allowed_tools = perms.allowed_tools;
-    payload.context = perms.context;
+    if (perms.complete) {
+        payload.access = perms.access;
+        payload.allowed_tools = perms.allowed_tools;
+        payload.context = perms.context;
+    }
     if (!isRemote) {
         const path = (document.getElementById('projPath') || {}).value || f.path;
         payload.path = path.trim();
@@ -1904,7 +2264,19 @@ function harvestProjectForm() {
 function harvestProjectPermissions(f) {
     const remote = isRemoteForm(f);
     const wild = f.allowed_mcp_ids.length === 1 && f.allowed_mcp_ids[0] === PROJ_MCP_WILDCARD;
-    const granted = wild ? (state.externalMcps || []).map(m => m.id) : f.allowed_mcp_ids.slice();
+    const registered = (state.externalMcps || []).map(m => m.id);
+    // A wildcard grant's MCP set is not in the form. It is whatever relay
+    // currently knows, and this side holds a COPY of that — one that is empty
+    // before the first payload arrives, and empty again if one arrives
+    // malformed. Expanding it then yields no keys at all, and the three maps
+    // built from them come out {} whatever the record actually holds.
+    //
+    // `complete` is what the caller keys on. It is not a validity flag: a
+    // non-wildcard grant naming no MCPs is complete and legitimately produces
+    // three empty maps, because the operator said so in the form. What is
+    // incomplete is a wildcard with nothing to expand it against.
+    const complete = !wild || registered.length > 0;
+    const granted = wild ? registered : f.allowed_mcp_ids.slice();
 
     const access = {};
     const allowedTools = {};
@@ -1935,7 +2307,7 @@ function harvestProjectPermissions(f) {
         }
         if (Object.keys(existing).length) context[mcpID] = existing;
     }
-    return { access: access, allowed_tools: allowedTools, context: context };
+    return { access: access, allowed_tools: allowedTools, context: context, complete: complete };
 }
 
 function saveProjectForm() {
@@ -2023,6 +2395,33 @@ window.onMcpToolsListed = function(mcpID, tools) {
     if (state.page === 'projects' && state.editingProjectId) {
         render('push');
     }
+};
+
+// onScopeFieldEnumerated receives one ContextEnumResult, verbatim, including
+// its status — which is the whole point. "There are none" is `status: "ok"`
+// with an empty list; "nobody could look" is any other status with no list at
+// all, and the two must never render the same way.
+window.onScopeFieldEnumerated = function(res) {
+    if (!res || !res.mcp_id || !res.field) return;
+    const openKey = scopeOpenKey(res.mcp_id, res.field);
+    const key = state.scopeEnumReq[openKey];
+    // No request outstanding for this field: a late answer to a question the
+    // dependencies have since changed. Dropping it is right — the key it would
+    // be filed under is not the key anything is looking up.
+    if (!key) return;
+    delete state.scopeEnumReq[openKey];
+    state.scopeEnum[key] = res;
+    // -32601 is final and it is about the MCP, not about this field: it never
+    // implements enumeration, so every field of it degrades to text entry and
+    // nothing asks again.
+    if (res.status === 'unsupported') state.scopeEnumUnsupported[res.mcp_id] = true;
+    if (state.page !== 'projects' || !state.editingProjectId) return;
+    // A full repaint, not render('push'): this answer is the direct result of
+    // the operator opening a control and it must appear. captureProjectFormInputs
+    // is what makes that safe — the repaint would otherwise rebuild the name
+    // and path inputs from state and erase anything typed while waiting.
+    captureProjectFormInputs();
+    render();
 };
 
 window.onProjectError = function(msg) {
@@ -3776,6 +4175,7 @@ render();
 Object.assign(window, {
     auditCaller, auditDetail, auditFmtTime, auditMatches, auditPretty, auditSelect, auditVisible, exportAudit, queryAudit, renderAudit, renderAuditDetail, renderAuditRow, restoreAuditFocus, revealAuditLog, setAuditFilter, toggleAuditFollow, toggleAuditRow,
     cancelEnrolment, dismissEnrolBundle, enrolBudgetText, enrolBytes, enrolGrantNames, enrolGrantSummary, newEnrolment, remoteDraft, remoteDraftSet, remoteGrantableProjects, remoteListenIsLoopback, removeRemoteConfig, renderEnrolBundleBanner, renderEnrolmentForm, renderEnrolments, renderRemoteListener, revokeEnrolment, saveEnrolment, saveRemoteConfig, toggleEnrolGrant,
-    harvestProjectPermissions, mcpScopeFieldsFor, projAccessMode, projAllowedToolPatterns, projAllowedToolsText, projAuthorityRows, projFormAccessMode, projGrantedMcpIds, projMissingScopeFields, projNoun, projScopeGaps, projScopeText, projScopeValue, projToolAuthorityText, renderAuthorityRows, renderProjMcpPermissions, renderScopeFieldInput, renderScopeGapBanner, scopeTextFromValue, scopeValueFromText, scopeValueIsSet, scopeValueText, setProjAccess, setProjAllowedToolsText, setProjMcpGranted, setProjScopeText,
+    harvestProjectPermissions, mcpScopeFieldsFor, projAccessMode, projAllowedToolPatterns, projAllowedToolsText, projAuthorityRows, projFormAccessMode, projGrantedMcpIds, projMissingScopeFields, projNoun, projScopeGaps, projScopeText, projScopeValue, projToolAuthorityText, renderAuthorityRows, renderProjMcpPermissions, renderScopeFieldInput, renderScopeFieldPicker, renderScopeFieldTextInput, renderScopeChoices, renderScopeGapBanner, scopeTextFromValue, scopeValueFromText, scopeValueIsSet, scopeValueText, setProjAccess, setProjAllowedToolsText, setProjMcpGranted, setProjScopeText,
+    captureProjectFormInputs, isPolicyEmpty, refreshDependentScopeFields, requestScopeEnum, retryScopeEnum, scopeDependencyValues, scopeEnumKey, scopeEnumValueKey, scopeFieldByName, scopeFieldIsOpen, scopeOpenKey, scopeSelectedValues, toggleProjScopeValueAt, toggleScopeFieldPicker, unrecognisedScopeValues,
     addExternalMcp, addExternalMcpFromJson, addExternalMcpHttp, addService, authenticateMcp, blankProjectForm, cancelMcpEdit, cancelProjectEdit, cancelServiceEdit, cfgArrayAdd, cfgArrayRemove, cfgBind, cfgChevron, cfgDirty, cfgEdit, cfgEditJson, cfgExpandKey, cfgFieldAt, cfgFirstMissingRequired, cfgGetDraft, cfgHasBadJson, cfgIsExpanded, cfgKvAdd, cfgKvRemove, cfgKvRename, cfgKvSetVal, cfgKvState, cfgMapAdd, cfgMapRemove, cfgMapRename, cfgNodeLabel, cfgRefreshChrome, cfgRerender, cfgSetExpanded, cfgToggleExpand, copyProjectToken, dispatchConfigOp, dispatchServiceAction, editProject, editService, harvestProjectForm, ipc, isAnyActionPending, isProjMcpWildcard, isProjModelsWildcard, isRemoteForm, isRemoteProject, newMcp, newProject, newService, projMcpState, projectFormFromExisting, pruneStaleDisabledTool, regenProjectSkill, removeExternalMcp, removeProject, removeService, render, renderActionButton, renderArrayBlock, renderConfigArray, renderConfigItem, renderConfigKeyValue, renderConfigLeaf, renderConfigMap, renderConfigNode, renderConfigObject, renderConfigSection, renderMcpForm, renderMcpPush, renderMcpServers, renderObjectFields, renderProjToolPicker, renderProjectForm, renderProjects, renderServiceForm, renderServiceInspector, renderServicePanel, renderServiceStatus, renderServices, renderStatusPayload, resetMcpPermissions, revertConfig, rotateProjectToken, saveConfig, saveProjectForm, saveServiceEdit, serviceBadgeHTML, setMcpAddMode, setMcpTransport, setProjKind, setProjMcpState, setProjMcpWildcard, setProjModelsWildcard, setsEqual, showPage, svcFormValues, toggleConfigSection, toggleProjTool, toggleProjectTokenVisible, toggleServiceRunning, updateServiceAutostart, updateServiceStatusDOM});
 window.state = state;


### PR DESCRIPTION
Closes #16. Relay's half of **ADR-011** — the design document is in this PR (`docs/decisions/011-resource-scope.md`) and records the reasoning, the rejected alternatives, and every decision that changed while it was being built.

Pairs with **macMCP#62** — both must land together. Neither can lie about the other: relay only offers scope for fields an MCP *declares*, and macMCP declares none until it enforces them.

## What this closes, measured rather than reasoned

The live `hermes-vm-2` enrolment — a grant named **"Hermes Mail"** — reached **all 47 macMCP tools**. I called these through it and **relay authorized every one**: `capture_screenshot` (reached `/usr/sbin/screencapture`, failed only on a missing TCC grant), `capture_audio`, `shortcuts_run`, `web_fetch`, `contacts_list_groups`, `shortcuts_list`. The ones that returned nothing did so because the host has no shortcuts and no contacts — not because anything refused them.

So a profile created to read one mailbox held screen capture, microphone capture, arbitrary automation, an outbound network channel, the address book, the calendar, and `messages_send`. It also read both fixture accounts and every folder, and wrote a file into `$HOME`.

## The model: four layers, each an allowlist, each failing closed

| layer | field | who decides | what relay can stand behind |
|---|---|---|---|
| which MCP | `allowed_mcp_ids` | relay | the whole thing |
| which tools | `allowed_tools` **(new)** | relay | the whole thing |
| which operations | `access: read\|write` **(new)** | relay | the rule, not the input |
| which resources | `context` → `_meta` | the MCP | nothing |

The third row's qualifier is stated rather than rounded up: relay applies the mode itself and the decision is visible in the audit log and in `ListTools`, but the *classification* of a tool as read-only is the MCP's own `readOnlyHint`. Still stronger than the resource layer — a false hint is a lie told in a published tool list an operator can read and diff, whereas an ignored `_meta` leaves no trace.

**`allowed_tools` is the layer the access mode cannot substitute for**: `contacts_*`, `calendars_*` and `web_fetch` are all legitimately read-only, so a `read` profile would keep every one of them.

## Relay learns five keywords, not field names

`scope`, `source`, `applies_to`, `enumerable`, `depends_on`. The hardcoded `schemaHasField(…, "allowed_dirs")` is gone: `ValidateProjectGrants` now asks the general question — *would this grant leave the MCP with no usable tools?* — which still refuses fsMCP to a profile and still permits macMCP, by a derived rule instead of a string.

`source: "project_path"` vs `"operator"` is what marries the local and remote models: a directory scope and a mailbox scope are the same mechanism, differing only in who supplies the value. It also **improves the local side** — a local project granted macMCP could previously write an attachment anywhere on the host; now it writes inside its own project directory.

Three keywords from the issue's proposal were dropped with reasons (`absent`, `wildcard`, `ui`), as was the proposed attestation echo: declaring the field *is* the assertion that you enforce it, so an echo adds nothing relay does not already hold.

## Operator surfaces

The permission set is settable for the first time — `context` has only ever been *derived*. Every value is validated against the declared schema on save and an invalid one is refused rather than stored.

`context/enumerate` gives the editor a **picker over real values** rather than a text box where `mail_accounts: ["Bpb"]` saves cleanly and silently confines a client to nothing. Four outcomes stay distinct because collapsing any two produces a form that lies: `-32601` degrades to text entry permanently, `-32602` is a relay bug and is surfaced, the `-32000` range / unknown codes / transport failures are retryable and keep text entry available, and an empty list is a real answer. **An empty list is never rendered for a call that failed**, and a stored value no longer offered stays visible and selected, marked unrecognised.

A remote-kind record is an **access profile** in every operator-facing surface — it has no directory, skills, shell, models or sessions, and calling it a project invites the reader to expect all of those. `kind: "remote"` on disk is unchanged; no Go identifier moved.

## Verified end to end, not just unit-tested

Two profiles built **through the Settings UI**, two enrolments, run against the live testMail fixture. **30/30 assertions pass.** Ground truth is relay's audit log and the Maildir, never a client's self-report.

```
47 tools →  5  read profile (exactly the read-only ones — it never sees mail_send)
         → 11  write profile
         →  0  the unmigrated control, with nobody editing it
```

Each layer denies with its own reason:
```
denied  capture_screenshot  not in the allowed tools for MCP 'macmcp'
denied  mail_send           not annotated read-only and this grant is read-only
```
and the intent record carries the authority:
```json
{"phase":"intent","tool":"mail_get_email","access":"read",
 "scope":{"mail_accounts":["Bob"],"mail_mailboxes":["INBOX"]}}
{"phase":"completion","outcome":"tool_error","scope_violation":true}
```
`scope_violation` rides on `tool_error` — no new outcome — and `scope` carries only declared restrict fields, never the whole context map, so `_meta` does not become where credentials get archived.

The generated `SKILL.md` carries the scope note on all five tools and **zero** scope words in the frontmatter, so the 500-byte lazy-load routing budget is intact.

## Testing

`go build`, `go vet`, `go test ./...` and `go test -race ./... -count=1` all clean. ~112 new test cases.

Note on issue #14: the `./mcp/` flake was measured rather than assumed — reproduced on a scratch worktree at the branch point (1/10 runs) and on this tree (4/10), same stack, in code this PR does not touch. Timing noise, but it fires more often than "known flake" suggests.

## Review notes — behaviour changes

- **The live `Hermes Mail` profile becomes read-only and loses 36 tools**, with nobody editing it. It never should have held them. This is the change most likely to surprise anything depending on it.
- **Local projects granted a scope-declaring MCP need a scope too.** The presence requirement is not remote-only, so the existing wildcard `Relay` project loses the mail tools until someone sets one. A *mode* has a defensible default in each direction; a *scope* has none.
- `permission_policy` and `chat_templates` are now refused on a profile, joining the fields ADR-009 already refuses. An inert control is worse than none.
- A `write` mail profile is still an exfiltration channel — `mail_accounts` scopes the identity a message is sent *as*, never who it is sent *to*. Named in the ADR rather than papered over; the fixture hides it by refusing non-fixture recipients, which is a property of the fixture and not a control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsKAJ7Kcc35NkBmcJwiAiW